### PR TITLE
Eslint Rules for Type naming conventions and React Hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,22 @@
     "array-bracket-spacing": "error",
     "object-curly-spacing": "error",
     "comma-spacing": "error",
-    "indent": ["error", 2]
+    "indent": ["error", 2],
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": [
+          "function",
+          "objectLiteralProperty",
+          "objectLiteralMethod"
+        ],
+        "format": ["PascalCase", "camelCase"]
+      },
+      { "selector": "typeLike", "format": ["PascalCase"] },
+      { "selector": "typeParameter", "format": ["PascalCase"] },
+
+      { "selector": "interface", "format": ["PascalCase"] }
+    ]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,13 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "react-native", "@typescript-eslint", "jest"],
+  "plugins": [
+    "react",
+    "react-hooks",
+    "react-native",
+    "@typescript-eslint",
+    "jest"
+  ],
   "settings": {
     "react": {
       "version": "detect"
@@ -24,6 +30,8 @@
     "no-unused-vars": "warn",
     "eqeqeq": "warn",
     "react/jsx-key": "warn",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "spaced-comment": "warn",
     "space-in-parens": "error",
     "computed-property-spacing": "error",

--- a/App.tsx
+++ b/App.tsx
@@ -4,8 +4,6 @@ import { Amplify, Auth, Cache, graphqlOperation, Storage } from "aws-amplify"
 import { withAuthenticator } from "aws-amplify-react-native"
 import awsconfig from "./src/aws-exports"
 
-import { AmplifyGraphQLClient } from "@lib/GraphQLClient"
-
 // graphql
 import { updateUser } from "@graphql/mutations.js"
 import { User } from "src/models"
@@ -304,7 +302,6 @@ const App = () => {
         </Tab.Navigator>
       </NavigationContainer>
     )
-
   } else if (isDeveloper) {
     return (
       <NavigationContainer linking={linkingConfig}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-native": "^4.0.0",
         "husky": "^8.0.3",
         "jest": "^26.6.3",
@@ -20775,6 +20776,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react-native": {
@@ -51955,6 +51968,13 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react-native": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-native": "^4.0.0",
     "husky": "^8.0.3",
     "jest": "^26.6.3",

--- a/screens/UserPostReplyScreen.tsx
+++ b/screens/UserPostReplyScreen.tsx
@@ -17,12 +17,12 @@ import { useDependencyValue } from "../lib/dependencies"
 import { userPostsDependencyKey } from "../lib/posts/UserPosts"
 
 export type UserPostReplyScreenProps = {
-  postId: string;
-  replyId: string;
-  onDismiss: () => void;
-  userPostView?: (post: UserPost, onDeleted?: () => void) => ReactNode;
-  fullRepliesView?: (post: UserPost) => ReactNode;
-};
+  postId: string
+  replyId: string
+  onDismiss: () => void
+  userPostView?: (post: UserPost, onDeleted?: () => void) => ReactNode
+  fullRepliesView?: (post: UserPost) => ReactNode
+}
 
 const renderUserPost = (post: UserPost, onDeleted?: () => void) => (
   <UserPostView post={post} onDeleted={() => onDeleted?.()} />
@@ -65,75 +65,75 @@ const UserPostReplyScreen = ({
 
   return isLoading
     ? (
-    <ActivityIndicator accessibilityLabel="Loading..." />
-      )
+      <ActivityIndicator accessibilityLabel="Loading..." />
+    )
     : (
-    <View>
-      {post
-        ? (
-        <ScrollView style={{ height: "100%" }}>
-          {userPostView(post, onDismiss)}
-          {reply
-            ? (
-                userPostView(reply)
-              )
-            : (
-            <Text
-              style={{
-                fontWeight: "bold",
-                color: "black",
-                backgroundColor: "white",
-                padding: 8,
-                marginBottom: 16
-              }}
-            >
+      <View>
+        {post
+          ? (
+            <ScrollView style={{ height: "100%" }}>
+              {userPostView(post, onDismiss)}
+              {reply
+                ? (
+                  userPostView(reply)
+                )
+                : (
+                  <Text
+                    style={{
+                      fontWeight: "bold",
+                      color: "black",
+                      backgroundColor: "white",
+                      padding: 8,
+                      marginBottom: 16
+                    }}
+                  >
               Reply not found.
-            </Text>
-              )}
-          <TouchableOpacity
-            onPress={() => modalRef.current?.showModal()}
-            style={{
-              display: "flex",
-              padding: 8,
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "space-between",
-              backgroundColor: "#148df7"
-            }}
-          >
-            <View>
-              <Text style={{ fontWeight: "bold", color: "white" }}>
+                  </Text>
+                )}
+              <TouchableOpacity
+                onPress={() => modalRef.current?.showModal()}
+                style={{
+                  display: "flex",
+                  padding: 8,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  backgroundColor: "#148df7"
+                }}
+              >
+                <View>
+                  <Text style={{ fontWeight: "bold", color: "white" }}>
                 View All Replies
-              </Text>
-              <Text style={{ opacity: 0.75, color: "white" }}>
+                  </Text>
+                  <Text style={{ opacity: 0.75, color: "white" }}>
                 This is a single reply from the post.
-              </Text>
-            </View>
-            <MaterialIcons name="arrow-right" size={32} color="white" />
-          </TouchableOpacity>
-          <Modal ref={modalRef}>{fullRepliesView(post)}</Modal>
-        </ScrollView>
+                  </Text>
+                </View>
+                <MaterialIcons name="arrow-right" size={32} color="white" />
+              </TouchableOpacity>
+              <Modal ref={modalRef}>{fullRepliesView(post)}</Modal>
+            </ScrollView>
           )
-        : (
-        <ErrorPrompt
-          errorText="Post not found."
-          actionText="Close"
-          actionIcon="highlight-off"
-          actionButtonBackgroundColor="#e3492d"
-          onActionButtonTapped={onDismiss}
-        />
+          : (
+            <ErrorPrompt
+              errorText="Post not found."
+              actionText="Close"
+              actionIcon="highlight-off"
+              actionButtonBackgroundColor="#e3492d"
+              onActionButtonTapped={onDismiss}
+            />
           )}
-    </View>
-      )
+      </View>
+    )
 }
 
 type ErrorPromptProps = {
-  errorText: string;
-  actionText: string;
-  actionIcon: ComponentProps<typeof MaterialIcons>["name"];
-  actionButtonBackgroundColor: string;
-  onActionButtonTapped: () => void;
-};
+  errorText: string
+  actionText: string
+  actionIcon: ComponentProps<typeof MaterialIcons>["name"]
+  actionButtonBackgroundColor: string
+  onActionButtonTapped: () => void
+}
 
 const ErrorPrompt = ({
   errorText,


### PR DESCRIPTION
This PR simply ensures that all types or interfaces are in PascalCase. Or basically:

```ts
interface mapMarker = {} // 🔴 Not PascalCase
interface MapMarker = {} // 🟢 PascalCase
```

Additionally, I also added the infamous react hooks exhaustive dependencies rule, which means this code now gets a linter warning:

```ts
const [state, setState] = useState("hello")

// 🟡 This will give a linter warning becuase state is not declared in the dependency array
useEffect(() => {
    if (state === "hello") setState("world")
}, [])
```

The above rule is in some ways considered controversial, but I (and seemingly pretty much all react influencers worth their salt) think it's a good rule to ensure we are using `useEffect` for it's intended purpose (which is synchronization with  outside world dependencies). Having this rule prevents many subtle bugs that can take days to track down (yes I've been through it), so it's honestly just better to deal with it upfront even if it's annoying rather than in 10 months.