### PR TITLE
React Query config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -68,6 +68,7 @@ import { ExpoUserNotifications } from "@lib/UserNotifications"
 import ActivitiesScreen from "@screens/ActivitiesScreen"
 import { SetDependencyValue } from "./lib/dependencies"
 import { userIdDependencyKey } from "./lib/MiscDependencyKeys"
+import { AppQueryClientProvider } from "@components/AppQueryClientProvider"
 
 if (
   Platform.OS === "android" &&
@@ -304,7 +305,6 @@ const App = () => {
         </Tab.Navigator>
       </NavigationContainer>
     )
-
   } else if (isDeveloper) {
     return (
       <NavigationContainer linking={linkingConfig}>
@@ -366,7 +366,13 @@ const App = () => {
   }
 }
 
-export default withAuthenticator(App, false, [
+const LiveApp = () => (
+  <AppQueryClientProvider>
+    <App />
+  </AppQueryClientProvider>
+)
+
+export default withAuthenticator(LiveApp, false, [
   <Greetings />,
   <SignIn />,
   <SignUp />,

--- a/components/AppQueryClientProvider.tsx
+++ b/components/AppQueryClientProvider.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from "react"
+import { QueryClient, QueryClientProvider } from "react-query"
+
+const appQueryClient = new QueryClient()
+
+export type AppQueryClientProviderProps = {
+  children: ReactNode
+}
+
+/**
+ * Default `QueryClientProvider` for the app.
+ */
+export const AppQueryClientProvider = ({
+  children
+}: AppQueryClientProviderProps) => (
+  <QueryClientProvider client={appQueryClient}>{children}</QueryClientProvider>
+)

--- a/tests/helpers/ReactQuery.tsx
+++ b/tests/helpers/ReactQuery.tsx
@@ -1,0 +1,79 @@
+import React, { ReactNode, useMemo } from "react"
+import { QueryClient, QueryClientProvider } from "react-query"
+
+/**
+ * Creates a `QueryClient` suitable for testing.
+ *
+ * The test query client disables all retrying behavior to ensure that,
+ * query functions don't get called more than once in tests.
+ *
+ * However, you may decide that you need to test something related to the
+ * retry behavior, you can do this by manually enabling retries like so:
+ *
+ * ```ts
+ * const queryClient = createTestQueryClient()
+ * queryClient.setDefaultOptions({ ...queryClient.getDefaultOptions(), retry: true })
+ * ```
+ *
+ * You will then need to pass your custom test query client to `TestQueryClientProvider`
+ * as such:
+ *
+ * ```tsx
+ * <TestQueryClientProvider client={queryClient}>
+ *  {...}
+ * </TestQueryClientProvider>
+ * ```
+ *
+ * In the case of needing to test retries like the one above, the retry delay is also
+ * set to 0 to ensure fast tests. It is highly recommended to not change that value.
+ */
+export const createTestQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // NB: Turn retries off so that we don't get unexepcted calls to queries in tests.
+        // See: https://react-query-v3.tanstack.com/guides/testing#turn-off-retries
+        retry: false,
+        retryDelay: 0
+      }
+    }
+  })
+}
+
+/**
+ * Props for `TestQueryClientProvider`.
+ */
+export type TestQueryClientProviderProps = {
+  children: ReactNode
+
+  /**
+   * Use this if you need to pass in a custom query client.
+   * (Eg. if you need to test some retry behavior)
+   *
+   * Any custom query client will automatically be reset when
+   * `TestQueryClientProvider` mounts.
+   */
+  client?: QueryClient
+}
+
+/**
+ * Use this when testing components that use react query.
+ */
+export const TestQueryClientProvider = ({
+  children,
+  client
+}: TestQueryClientProviderProps) => {
+  // NB: Ensure each test has a fresh query client so that tests don't depend
+  // on each other.
+  // See: https://react-query-v3.tanstack.com/guides/testing#our-first-test
+  const queryClient = useMemo(() => {
+    if (client) {
+      client.resetQueries()
+      return client
+    }
+    return createTestQueryClient()
+  }, [client])
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}


### PR DESCRIPTION
Since the event form stuff finally brings on react query, I figured that I would just break out those tools into a separate PR since it's pretty disconnected to the event form entirely.

It basically includes a `TestQueryClientProvider` and an `AppQueryClientProvider`, the former is for tests which you could probably guess and the latter is for wrapping the actual app.

The test provider basically disables retries and sets all retry delay to 0 so that when we need to test error cases for fetching it doesn't ping the fetch function a crap ton of times.

The app provider just creates a default `QueryClient`, but I expect that we would configure it differently once we need to in the future.