### PR TITLE
Update Event Type

### DIFF
--- a/.storybook/components/HexColorPicker/HexColorPicker.stories.tsx
+++ b/.storybook/components/HexColorPicker/HexColorPicker.stories.tsx
@@ -4,7 +4,7 @@ import { EventColors } from "../../../lib/events/EventColors"
 import HexColorPicker, {
   HexColorPickerProps
 } from "../../../components/formComponents/HexColorPicker"
-import { eventColorOptions } from "../../../components/eventForm"
+import { eventColorPickerOptions } from "../../../components/eventForm"
 
 const Picker = (props: HexColorPickerProps) => {
   const [color, setColor] = useState(EventColors.Red)
@@ -15,7 +15,7 @@ const HexColorPickerMeta: ComponentMeta<typeof HexColorPicker> = {
   title: "HexColorPicker",
   component: Picker,
   args: {
-    options: eventColorOptions,
+    options: eventColorPickerOptions,
     style: {
       display: "flex",
       justifyContent: "center",

--- a/components/EventItem.tsx
+++ b/components/EventItem.tsx
@@ -16,7 +16,7 @@ const EventItem = ({ event }: Props) => {
   const numAttendees = 1
   const distance = 0.5
   const shadowColor = "#bdbdbd"
-  const lightEventColor = tinycolor(event.colorHex).lighten(10).toString()
+  const lightEventColor = tinycolor(event.color).lighten(10).toString()
 
   const onPressMore = () => {
     return null
@@ -51,16 +51,16 @@ const EventItem = ({ event }: Props) => {
           <Text style={styles.titleText}>{event.title}</Text>
 
           <View style={[styles.location, styles.flexRow]}>
-            <Icon name="location-on" color={event.colorHex} />
+            <Icon name="location-on" color={event.color} />
             <Text style={styles.infoText}>
               {placemarkToFormattedAddress(event.address)}
             </Text>
           </View>
 
           <View style={styles.flexRow}>
-            <Icon name="event-available" color={event.colorHex} />
+            <Icon name="event-available" color={event.color} />
             <Text style={styles.infoText} accessibilityLabel="day">
-              {event.duration.formatted()}
+              {event.dateRange.formatted()}
             </Text>
           </View>
 
@@ -72,7 +72,7 @@ const EventItem = ({ event }: Props) => {
         {/* People Attending, Distance */}
         <View style={styles.distanceContainer}>
           <View style={[styles.flexRow, { alignItems: "center" }]}>
-            <Icon name="people-alt" color={event.colorHex} />
+            <Icon name="people-alt" color={event.color} />
             <Text
               style={[styles.attendingText, styles.attendingNumber]}
             >{`${numAttendees}`}</Text>
@@ -84,7 +84,7 @@ const EventItem = ({ event }: Props) => {
               style={[
                 styles.distance,
                 {
-                  backgroundColor: event.colorHex,
+                  backgroundColor: event.color,
                   borderColor: lightEventColor
                 }
               ]}

--- a/components/eventForm/ColorPicker.tsx
+++ b/components/eventForm/ColorPicker.tsx
@@ -1,7 +1,9 @@
-import HexColorPicker from "../formComponents/HexColorPicker"
+import HexColorPicker, {
+  HexColorPickerOption
+} from "../formComponents/HexColorPicker"
 import React from "react"
 import { useEventFormField } from "./EventForm"
-import { eventColorOptions } from "./EventFormValues"
+import { EventColors } from "@lib/events/EventColors"
 
 /**
  * A color picker for an event form.
@@ -11,8 +13,15 @@ export const EventFormColorPicker = () => {
   return (
     <HexColorPicker
       color={color}
-      options={eventColorOptions}
+      options={eventColorPickerOptions}
       onChange={(value) => setColor(value)}
     />
   )
 }
+
+export const eventColorPickerOptions = Object.entries(EventColors).map(
+  ([name, color]) => ({
+    accessibilityLabel: name,
+    color
+  })
+) as HexColorPickerOption<EventColors>[]

--- a/components/eventForm/EventFormValues.ts
+++ b/components/eventForm/EventFormValues.ts
@@ -1,5 +1,4 @@
-import { HexColorPickerOption } from "../formComponents/HexColorPicker"
-import { EventColor, EventColors } from "../../lib/events/EventColors"
+import { EventColors } from "../../lib/events/EventColors"
 import { FixedDateRange } from "../../lib/Date"
 import { EditEventInput } from "../../lib/events"
 import { Location } from "../../lib/location"
@@ -22,7 +21,7 @@ export type EventFormValues = {
   readonly description: string
   readonly locationInfo?: EventFormLocationInfo
   readonly dateRange: FixedDateRange
-  readonly color: EventColor
+  readonly color: EventColors
   readonly shouldHideAfterStartDate: boolean
   readonly radiusMeters: number
 }
@@ -42,13 +41,3 @@ export const eventEditInputFromFormValues = (values: EventFormValues) => {
     radiusMeters: values.radiusMeters
   } as EditEventInput
 }
-
-export const eventColorOptions = [
-  { color: EventColors.Red, accessibilityLabel: "Red" },
-  { color: EventColors.Orange, accessibilityLabel: "Orange" },
-  { color: EventColors.Pink, accessibilityLabel: "Pink" },
-  { color: EventColors.Yellow, accessibilityLabel: "Yellow" },
-  { color: EventColors.Green, accessibilityLabel: "Green" },
-  { color: EventColors.Purple, accessibilityLabel: "Purple" },
-  { color: EventColors.Blue, accessibilityLabel: "Blue" }
-] as HexColorPickerOption<EventColor>[]

--- a/lib/events/Event.ts
+++ b/lib/events/Event.ts
@@ -1,5 +1,6 @@
 import { dateRange, FixedDateRange } from "@lib/date"
 import { Location, Placemark } from "@lib/location"
+import { EventColors } from "./EventColors"
 
 /**
  * A type representing an event hosted by a user, which is meant for
@@ -13,8 +14,8 @@ export type Event = {
   readonly repliesCount: number
   readonly description?: string
   readonly writtenByYou: boolean
-  readonly duration: FixedDateRange
-  readonly colorHex: string
+  readonly dateRange: FixedDateRange
+  readonly color: EventColors
   readonly coordinates: Location
   readonly address: Placemark
 }
@@ -43,8 +44,8 @@ export namespace TestEventItems {
       title: "Pickup Basketball",
       repliesCount: 2,
       writtenByYou: true,
-      duration: dateRange(start, end),
-      colorHex: "magenta",
+      dateRange: dateRange(start, end),
+      color: EventColors.Red,
       coordinates: { latitude: 36.991585, longitude: -122.058277 },
       address
     }

--- a/lib/events/EventColors.ts
+++ b/lib/events/EventColors.ts
@@ -1,29 +1,12 @@
 /**
- * Colors that can be used for customizing events.
- */
-export namespace EventColors {
-  export const Red = "#EF6351"
-  export const Purple = "#CB9CF2"
-  export const Blue = "#88BDEA"
-  export const Green = "#72B01D"
-  export const Pink = "#F7B2BD"
-  export const Orange = "#F4845F"
-  export const Yellow = "#F6BD60"
-
-  /**
-   * All supported event colors.
-   */
-  export const all = [Red, Orange, Yellow, Pink, Purple, Blue, Green]
-}
-
-/**
  * A type for the color value for an event.
  */
-export type EventColor =
-  | typeof EventColors.Red
-  | typeof EventColors.Green
-  | typeof EventColors.Blue
-  | typeof EventColors.Pink
-  | typeof EventColors.Purple
-  | typeof EventColors.Yellow
-  | typeof EventColors.Orange
+export enum EventColors {
+  Red = "#EF6351",
+  Purple = "#CB9CF2",
+  Blue = "#88BDEA",
+  Green = "#72B01D",
+  Pink = "#F7B2BD",
+  Orange = "#F4845F",
+  Yellow = "#F6BD60"
+}

--- a/lib/events/Events.ts
+++ b/lib/events/Events.ts
@@ -1,7 +1,7 @@
 import { FixedDateRange } from "@lib/Date"
 import { createDependencyKey } from "@lib/dependencies"
 import { Location, Placemark } from "@lib/location"
-import { EventColor } from "./EventColors"
+import { EventColors } from "./EventColors"
 
 /**
  * A data type which is used to update event information.
@@ -10,7 +10,7 @@ export type EditEventInput = {
   readonly title: string
   readonly description?: string
   readonly location: Location
-  readonly color: EventColor
+  readonly color: EventColors
   readonly dateRange: FixedDateRange
   readonly shouldHideAfterStartDate: boolean
   readonly radiusMeters: number


### PR DESCRIPTION
This PR simply converts the `EventColors` namespace into an enum such that you can now use `Object.values`, `Object.keys`, `Object.entries`, etc. to do transforms on the colors like @seanim0920 suggested. I also updated the `Event` type to use this new enum rather than a string.