### PR TITLE
Fix: Date Range formatting when dates are in the same minute

### DIFF
--- a/lib/date/DateRange.ts
+++ b/lib/date/DateRange.ts
@@ -65,7 +65,7 @@ export class FixedDateRange {
     const end = dayjs(this.endDate)
 
     const startDateFormat = formatFromBasis(now(), start)
-    if (start.isSame(end)) return startDateFormat
+    if (start.isSame(end, "minute")) return startDateFormat
 
     const endDateFormat = start.isSame(end, "day")
       ? formatTime(end)

--- a/lib/date/DateRange.ts
+++ b/lib/date/DateRange.ts
@@ -65,6 +65,8 @@ export class FixedDateRange {
     const end = dayjs(this.endDate)
 
     const startDateFormat = formatFromBasis(now(), start)
+    if (start.isSame(end)) return startDateFormat
+
     const endDateFormat = start.isSame(end, "day")
       ? formatTime(end)
       : formatFromBasis(start, end)

--- a/tests/date/FixedDateRangeFormatting.test.ts
+++ b/tests/date/FixedDateRangeFormatting.test.ts
@@ -2,7 +2,7 @@ import { dateRange, FixedDateRange } from "@lib/date"
 
 describe("FixedDateRangeFormatting tests", () => {
   beforeEach(() => {
-    jest.useFakeTimers("modern").setSystemTime(new Date("2023-02-26T12:00:00"))
+    jest.useFakeTimers().setSystemTime(new Date("2023-02-26T12:00:00"))
   })
   afterEach(() => jest.useRealTimers())
 
@@ -213,6 +213,66 @@ describe("FixedDateRangeFormatting tests", () => {
         new Date("2023-03-05T10:00:00")
       ),
       "Today 8am - Mar 5, 10am"
+    )
+  })
+
+  test("start and end date are the exact same, today", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2023-02-26T08:00:00"),
+        new Date("2023-02-26T08:00:00")
+      ),
+      "Today 8am"
+    )
+  })
+
+  test("start and end date are the exact same, yesterday", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2023-02-25T08:00:00"),
+        new Date("2023-02-25T08:00:00")
+      ),
+      "Yesterday 8am"
+    )
+  })
+
+  test("start and end date are the exact same, tomorrow", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2023-02-27T08:00:00"),
+        new Date("2023-02-27T08:00:00")
+      ),
+      "Tomorrow 8am"
+    )
+  })
+
+  test("start and end date are the exact same, 2 days from now", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2023-02-28T08:00:00"),
+        new Date("2023-02-28T08:00:00")
+      ),
+      "Tue 8am"
+    )
+  })
+
+  test("start and end date are the exact same, 1 month from now", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2023-03-26T08:00:00"),
+        new Date("2023-03-26T08:00:00")
+      ),
+      "Mar 26, 8am"
+    )
+  })
+
+  test("start and end date are the exact same, 1 year from now", () => {
+    expectFormattedDateRange(
+      dateRange(
+        new Date("2024-02-26T08:00:00"),
+        new Date("2024-02-26T08:00:00")
+      ),
+      "Feb 26 2024, 8am"
     )
   })
 })

--- a/tests/date/FixedDateRangeFormatting.test.ts
+++ b/tests/date/FixedDateRangeFormatting.test.ts
@@ -216,37 +216,37 @@ describe("FixedDateRangeFormatting tests", () => {
     )
   })
 
-  test("start and end date are the exact same, today", () => {
+  test("start and end date are in same minute, today", () => {
     expectFormattedDateRange(
       dateRange(
-        new Date("2023-02-26T08:00:00"),
-        new Date("2023-02-26T08:00:00")
+        new Date("2023-02-26T08:00:32"),
+        new Date("2023-02-26T08:00:48")
       ),
       "Today 8am"
     )
   })
 
-  test("start and end date are the exact same, yesterday", () => {
+  test("start and end date are in same minute, yesterday", () => {
     expectFormattedDateRange(
       dateRange(
-        new Date("2023-02-25T08:00:00"),
-        new Date("2023-02-25T08:00:00")
+        new Date("2023-02-25T08:00:06"),
+        new Date("2023-02-25T08:00:42")
       ),
       "Yesterday 8am"
     )
   })
 
-  test("start and end date are the exact same, tomorrow", () => {
+  test("start and end date are in same minute, tomorrow", () => {
     expectFormattedDateRange(
       dateRange(
-        new Date("2023-02-27T08:00:00"),
-        new Date("2023-02-27T08:00:00")
+        new Date("2023-02-27T08:00:11"),
+        new Date("2023-02-27T08:00:22")
       ),
       "Tomorrow 8am"
     )
   })
 
-  test("start and end date are the exact same, 2 days from now", () => {
+  test("start and end date are in same minute, 2 days from now", () => {
     expectFormattedDateRange(
       dateRange(
         new Date("2023-02-28T08:00:00"),
@@ -256,21 +256,21 @@ describe("FixedDateRangeFormatting tests", () => {
     )
   })
 
-  test("start and end date are the exact same, 1 month from now", () => {
+  test("start and end date are in same minute, 1 month from now", () => {
     expectFormattedDateRange(
       dateRange(
-        new Date("2023-03-26T08:00:00"),
-        new Date("2023-03-26T08:00:00")
+        new Date("2023-03-26T08:00:55"),
+        new Date("2023-03-26T08:00:58")
       ),
       "Mar 26, 8am"
     )
   })
 
-  test("start and end date are the exact same, 1 year from now", () => {
+  test("start and end date arein same minute, 1 year from now", () => {
     expectFormattedDateRange(
       dateRange(
-        new Date("2024-02-26T08:00:00"),
-        new Date("2024-02-26T08:00:00")
+        new Date("2024-02-26T08:00:30"),
+        new Date("2024-02-26T08:00:50")
       ),
       "Feb 26 2024, 8am"
     )


### PR DESCRIPTION
Currently when 2 dates are the same (eg. `startDate = today = today at 5pm, endDate = today at 5pm`) calling `formatted` on `FixedDateRange` will return this for the above example: `Today 5pm - 5pm`.

This obviously is very redundant, so this PR simply makes that become `Today 5pm`.