### PR TITLE
Cleanup: Represent Null values on Placemark as undefined

### DIFF
--- a/components/eventForm/LocationBanner.tsx
+++ b/components/eventForm/LocationBanner.tsx
@@ -2,13 +2,14 @@ import { useReverseGeocodeQuery } from "../../hooks/Geocoding"
 import { placemarkToFormattedAddress } from "../../lib/location"
 import React from "react"
 import { StyleSheet, View } from "react-native"
-import {
-  useEventFormContext
-} from "./EventForm"
+import { useEventFormContext } from "./EventForm"
 import { FormLabel, SkeletonFormLabel } from "../formComponents/FormLabels"
 import { MaterialIcons } from "@expo/vector-icons"
 import { FontScaleFactors, useFontScale } from "../../lib/FontScale"
-import { EventFormLocationInfo, EventFormPlacemarkInfo } from "./EventFormValues"
+import {
+  EventFormLocationInfo,
+  EventFormPlacemarkInfo
+} from "./EventFormValues"
 
 /**
  * Displays the selected location (if one) in the event form.
@@ -71,9 +72,7 @@ const GeocodedLocationInfoBanner = (locationInfo: EventFormLocationInfo) => {
   if (!placemark) return <SkeletonFormLabel icon="location-pin" />
 
   const address = placemarkToFormattedAddress(placemark)
-  return (
-    <PlacemarkInfoBanner name={placemark.name ?? undefined} address={address} />
-  )
+  return <PlacemarkInfoBanner name={placemark.name} address={address} />
 }
 
 const PlacemarkInfoBanner = ({ name, address }: EventFormPlacemarkInfo) => (

--- a/lib/NullsToUndefined.ts
+++ b/lib/NullsToUndefined.ts
@@ -1,0 +1,37 @@
+/**
+ * A type which ensures that all `null` values become `undefined`.
+ *
+ * See: https://stackoverflow.com/questions/50374869/generic-way-to-convert-all-instances-of-null-to-undefined-in-typescript
+ */
+export type NullsAsUndefined<T> = T extends null
+  ? undefined
+  : T extends Date
+  ? T
+  : {
+      [K in keyof T]: T[K] extends (infer U)[]
+        ? NullsAsUndefined<U>[]
+        : NullsAsUndefined<T[K]>
+    }
+
+/**
+ * Converts null values of an object to undefined.
+ *
+ * @param value the object
+ */
+export const nullsToUndefined = <T>(value: T) => {
+  if (value === null) return undefined as NullsAsUndefined<T>
+  if (typeof value !== "object") return value as NullsAsUndefined<T>
+
+  // NB: For the bottom 2 cases we must extract out a local variable instead
+  // of returning directly to make the compiler happy.
+
+  if (value instanceof Array) {
+    const array = value.map(nullsToUndefined) as NullsAsUndefined<T>
+    return array
+  }
+
+  const object = Object.fromEntries(
+    Object.entries(value).map(([key, val]) => [key, nullsToUndefined(val)])
+  ) as NullsAsUndefined<T>
+  return object
+}

--- a/lib/location/Geocoding.ts
+++ b/lib/location/Geocoding.ts
@@ -2,6 +2,7 @@ import { Placemark } from "./Placemark"
 import ExpoLocation from "expo-location"
 import { createDependencyKey } from "../dependencies"
 import { Location } from "./Location"
+import { nullsToUndefined } from "@lib/NullsToUndefined"
 
 /**
  * An interface for geocoding operations.
@@ -32,10 +33,11 @@ export class ExpoGeocoding implements Geocoding {
   }
 
   async reverseGeocode (location: Location) {
-    const results = await ExpoLocation.reverseGeocodeAsync({
-      ...location
-    })
-    return results as Placemark[]
+    return nullsToUndefined(
+      await ExpoLocation.reverseGeocodeAsync({
+        ...location
+      })
+    ) as Placemark[]
   }
 }
 

--- a/lib/location/Placemark.ts
+++ b/lib/location/Placemark.ts
@@ -3,16 +3,18 @@ import addressFormatter from "@fragaria/address-formatter"
 /**
  * A type representing the components of an address.
  */
-export type Placemark = {
-  readonly name: string | null
-  readonly country: string | null
-  readonly postalCode: string | null
-  readonly street: string | null
-  readonly streetNumber: string | null
-  readonly region: string | null
-  readonly isoCountryCode: string | null
-  readonly city: string | null
-}
+export type Placemark = Partial<
+  Readonly<{
+    name: string
+    country: string
+    postalCode: string
+    street: string
+    streetNumber: string
+    region: string
+    isoCountryCode: string
+    city: string
+  }>
+>
 
 /**
  * Formats a `Placemark` instance into a readable address if able.
@@ -21,22 +23,18 @@ export type Placemark = {
  */
 export const placemarkToFormattedAddress = (placemark: Placemark) => {
   // TODO: - At some point this should probably support internationalized styles.
-  const streetNumber = placemark.street
-    ? placemark.streetNumber ?? undefined
-    : undefined
+  const streetNumber = placemark.street ? placemark.streetNumber : undefined
 
-  const postalCode = placemark.region
-    ? placemark.postalCode ?? undefined
-    : undefined
+  const postalCode = placemark.region ? placemark.postalCode : undefined
   const formattedAddress = addressFormatter
     .format(
       {
-        street: placemark.street ?? undefined,
+        street: placemark.street,
         streetNumber,
-        city: placemark.city ?? undefined,
-        region: placemark.region ?? undefined,
+        city: placemark.city,
+        region: placemark.region,
         postcode: postalCode,
-        state: placemark.region ?? undefined
+        state: placemark.region
       },
       { abbreviate: true, countryCode: US_COUNTRY_CODE }
     )

--- a/tests/NullsToUndefined.test.ts
+++ b/tests/NullsToUndefined.test.ts
@@ -1,0 +1,57 @@
+import { nullsToUndefined } from "@lib/NullsToUndefined"
+
+describe("NullsToUndefined tests", () => {
+  test("null converts to undefined", () => {
+    expect(nullsToUndefined(null)).toBeUndefined()
+  })
+
+  test("shallowly converts null values in object to undefined", () => {
+    expect(nullsToUndefined({ a: 1, b: null })).toMatchObject({
+      a: 1,
+      b: undefined
+    })
+  })
+
+  test("deeply converts null values in object to undefined", () => {
+    expect(
+      nullsToUndefined({ a: 1, b: { c: null, d: { e: null, f: "Hello" } } })
+    ).toMatchObject({
+      a: 1,
+      b: { c: undefined, d: { e: undefined, f: "Hello" } }
+    })
+  })
+
+  test("shallowly converts array nulls to undefined", () => {
+    expect(nullsToUndefined([1, null])).toEqual([1, undefined])
+  })
+
+  test("deeply converts array nulls to undefined", () => {
+    expect(nullsToUndefined([1, [2, null]])).toEqual([1, [2, undefined]])
+  })
+
+  test("converts object nulls to undefined in array", () => {
+    expect(nullsToUndefined([1, { a: null, b: 2 }])).toEqual([
+      1,
+      { a: undefined, b: 2 }
+    ])
+  })
+
+  test("converts array nulls to undefined in object", () => {
+    expect(nullsToUndefined({ a: 1, b: [2, null] })).toMatchObject({
+      a: 1,
+      b: [2, undefined]
+    })
+  })
+
+  it("does not modify input object", () => {
+    const obj = { a: null, b: 1 }
+    nullsToUndefined(obj)
+    expect(obj).toMatchObject({ a: null, b: 1 })
+  })
+
+  it("does not modify input array", () => {
+    const obj = [null, 2]
+    nullsToUndefined(obj)
+    expect(obj).toMatchObject([null, 2])
+  })
+})

--- a/tests/location/PlacemarkFormatting.test.ts
+++ b/tests/location/PlacemarkFormatting.test.ts
@@ -10,13 +10,13 @@ describe("Placemark Formatting tests", () => {
 
   it("omits street number when missing street name", () => {
     expect(
-      placemarkToFormattedAddress({ ...baseTestPlacemark, street: null })
+      placemarkToFormattedAddress({ ...baseTestPlacemark, street: undefined })
     ).toEqual("Cupertino, CA 95104")
   })
 
   it("omits postal code when missing state", () => {
     expect(
-      placemarkToFormattedAddress({ ...baseTestPlacemark, region: null })
+      placemarkToFormattedAddress({ ...baseTestPlacemark, region: undefined })
     ).toEqual("1234 Cupertino Rd, Cupertino")
   })
 

--- a/tests/location/helpers.ts
+++ b/tests/location/helpers.ts
@@ -10,12 +10,5 @@ export const baseTestPlacemark = {
 } as const
 
 export const unknownLocationPlacemark = {
-  name: "North Pacific Ocean",
-  country: null,
-  postalCode: null,
-  street: null,
-  streetNumber: null,
-  region: null,
-  isoCountryCode: null,
-  city: null
+  name: "North Pacific Ocean"
 } as const


### PR DESCRIPTION
Since js has both `null` and `undefined`, and react tends to prefer `undefined` for optional prop values, I decided to covert the `Placemark` type to hold a bunch of possible undefined values instead of a bunch of `string | null` types. This removed the ridiculous `placemark.someField ?? undefined` dance that was performed several times.

Additionally, I also added a generic utility to convert null values on any object to undefined, which should make life easier when working with react props. It's called `nullsToUndefined`, and it will mostly be useful in turning 3rd party library types that use null into ones that use undefined.