### PR TITLE
Fix babel storybook issue

### DIFF
--- a/.storybook/.ondevice/Storybook.tsx
+++ b/.storybook/.ondevice/Storybook.tsx
@@ -1,5 +1,7 @@
-import { getStorybookUI } from "@storybook/react-native";
-import "./storybook.requires";
+import { getStorybookUI } from "@storybook/react-native"
+import "./storybook.requires"
 
-const StorybookUIRoot = getStorybookUI({});
-export default StorybookUIRoot;
+const StorybookUIRoot = getStorybookUI({
+  shouldDisableKeyboardAvoidingView: true
+})
+export default StorybookUIRoot

--- a/.storybook/.ondevice/storybook.requires.js
+++ b/.storybook/.ondevice/storybook.requires.js
@@ -52,6 +52,7 @@ const getStories = () => {
     "./components/Button/Button.stories.tsx": require("../components/Button/Button.stories.tsx"),
     "./components/DateTimePicker/DateTimePicker.stories.tsx": require("../components/DateTimePicker/DateTimePicker.stories.tsx"),
     "./components/EventFormToolbar/EventFormToolbar.stories.tsx": require("../components/EventFormToolbar/EventFormToolbar.stories.tsx"),
+    "./components/EventForm/EventForm.stories.tsx": require("../components/EventForm/EventForm.stories.tsx"),
     "./components/HexColorPicker/HexColorPicker.stories.tsx": require("../components/HexColorPicker/HexColorPicker.stories.tsx"),
     "./components/IconButton/IconButton.stories.tsx": require("../components/IconButton/IconButton.stories.tsx"),
     "./components/LocationSearchResultRow/LocationSearchResultRow.stories.tsx": require("../components/LocationSearchResultRow/LocationSearchResultRow.stories.tsx"),

--- a/.storybook/babel.config.js
+++ b/.storybook/babel.config.js
@@ -1,6 +1,1 @@
-module.exports = function (api) {
-  api.cache(true)
-  return {
-    presets: ["babel-preset-expo"]
-  }
-}
+module.exports = require("../babel.config");

--- a/.storybook/components/EventForm/EventForm.stories.tsx
+++ b/.storybook/components/EventForm/EventForm.stories.tsx
@@ -1,0 +1,26 @@
+import { EventForm } from "@components/eventForm"
+import { NavigationContainer } from "@react-navigation/native"
+import { createStackNavigator } from "@react-navigation/stack"
+import { EventFormTestScreen } from "@screens/testScreens/EventFormTestScreen"
+import { ComponentMeta, ComponentStory } from "@storybook/react-native"
+import React from "react"
+
+const Stack = createStackNavigator()
+
+const EventFormMeta: ComponentMeta<typeof EventForm> = {
+  title: "EventForm",
+  component: EventFormTestScreen,
+  decorators: [
+    (Story) => (
+      <NavigationContainer>
+        <Story />
+      </NavigationContainer>
+    )
+  ]
+}
+
+export default EventFormMeta
+
+type EventFormStory = ComponentStory<typeof EventForm>
+
+export const EmptyForm: EventFormStory = (args) => <EventFormTestScreen />

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,9 @@
+// @ts-nocheck
+/* eslint-disable comma-dangle */
+/* eslint-disable semi */
+const path = require("path");
+const rootPath = __dirname;
+
 module.exports = function (api) {
   api.cache(true);
   return {
@@ -10,13 +16,13 @@ module.exports = function (api) {
         "module-resolver",
         {
           alias: {
-            "@screens": "./screens",
-            "@components": "./components",
-            "@stacks": "./stacks",
-            "@hooks": "./hooks",
-            "@assets": "./assets",
-            "@graphql": "./src/graphql",
-            "@lib": "./lib",
+            "@screens": path.join(rootPath, "screens"),
+            "@components": path.join(rootPath, "components"),
+            "@stacks": path.join(rootPath, "stacks"),
+            "@hooks": path.join(rootPath, "hooks"),
+            "@assets": path.join(rootPath, "assets"),
+            "@graphql": path.join(rootPath, "src/graphql"),
+            "@lib": path.join(rootPath, "lib"),
           },
           extensions: [".js", ".jsx", ".ts", ".tsx"],
         },


### PR DESCRIPTION
Imports in storybook should work as expected now by using the same babel config as the root project.

Remaining issues:
* VS still doesn't recognize the @path shortcuts in storybook, but they should build properly in expo
* Storybook adds a margin on top of the stacknavigator for some reason. Adding "headerStatusBarHeight" to 0 fixes it but it would need to go in the stack navigator directly, which I didn't include here.