### PR TITLE
Cleanup: Get Map component under a test harness

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -1,4 +1,3 @@
-import { degreesToRadians } from "@lib/Math"
 import { Location } from "lib/location/Location"
 import React, {
   forwardRef,
@@ -37,9 +36,11 @@ export type MapRefMethods = {
 }
 
 export type MapProps<T extends MapMarker> = {
-  // Map style specifically for style on map
-  mapStyle?: StyleProp<ViewStyle>
+  style?: StyleProp<ViewStyle>
 
+  /**
+   * The initial region to center the map on.
+   */
   initialRegion: {
     latitude: number
     longitude: number
@@ -47,52 +48,52 @@ export type MapProps<T extends MapMarker> = {
     longitudeDelta: number
   }
 
+  /**
+   * A list of map markers to render.
+   */
   markers: T[]
 
+  /**
+   * Enables scrolling if true (default: true)
+   */
   canScroll?: boolean
+
+  /**
+   * Enables zooming if true (default: true)
+   */
   canZoom?: boolean
+
+  /**
+   * Enables rotating if true (default: true)
+   */
   canRotate?: boolean
 
+  /**
+   * Renders a singular map marker that was passed in through `markers`.
+   */
   renderMarker: (marker: T) => React.ReactNode
 
+  /**
+   * Renders a circle for a singular map marker that was passed in through `markers`.
+   */
   renderCircle?: (marker: T) => React.ReactNode
 
+  /**
+   * Handles the selection of a marker.
+   *
+   * @param marker a singular map marker that was passed in through `markers`.
+   */
   onMarkerSelected?: (marker: T) => void
 
+  /**
+   * Forwards the coordinates of where a user long pressed on the map.
+   */
   onLongPress?: (coordinates: Location) => void
 }
 
-// When clicking on the marker, zoom towards where it is.
-// Using stackOverflow formula
-// stackoverflow.com/questions/5206018/fit-mapview-to-circle-bounds
-function circleCoordinateGeneration (lat: number, long: number, radius: number) {
-  const earthRadius = 6378.1 // km
-  const circleLatitude0 = lat + degreesToRadians(-radius / earthRadius)
-  const circleLatitude1 = lat + degreesToRadians(radius / earthRadius)
-  const circleLongitude0 =
-    long + degreesToRadians(-radius / earthRadius) / degreesToRadians(lat)
-  const circleLongitude1 =
-    long + degreesToRadians(radius / earthRadius) / degreesToRadians(lat)
-  const bottomCoord = {
-    latitude: circleLatitude0,
-    longitude: long
-  }
-  const leftCoord = {
-    latitude: lat,
-    longitude: circleLongitude0
-  }
-  const rightCoord = {
-    latitude: circleLatitude1,
-    longitude: long
-  }
-  const topCoord = {
-    latitude: lat,
-    longitude: circleLongitude1
-  }
-  return [bottomCoord, leftCoord, rightCoord, topCoord]
-}
-
-// Map view component itself
+/**
+ * A view for rendering a google map.
+ */
 export const Map = forwardRef(function ReffedMap<T extends MapMarker> (
   {
     initialRegion,
@@ -100,7 +101,7 @@ export const Map = forwardRef(function ReffedMap<T extends MapMarker> (
     renderMarker,
     renderCircle,
     onMarkerSelected,
-    mapStyle,
+    style,
     canScroll = true,
     canRotate = true,
     canZoom = true,
@@ -120,7 +121,7 @@ export const Map = forwardRef(function ReffedMap<T extends MapMarker> (
   }))
 
   return (
-    <View style={mapStyle}>
+    <View style={style}>
       <MapView
         ref={mapRef}
         style={fillStyle.map}

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -121,55 +121,47 @@ export const Map = forwardRef(function ReffedMap<T extends MapMarker> (
   }))
 
   return (
-    <View style={style}>
-      <MapView
-        ref={mapRef}
-        style={fillStyle.map}
-        provider={PROVIDER_GOOGLE}
-        initialRegion={initialRegion}
-        rotateEnabled={canRotate}
-        scrollEnabled={canScroll}
-        loadingEnabled={true}
-        toolbarEnabled={false}
-        onLongPress={(e) => onLongPress?.(e.nativeEvent.coordinate)}
-        followsUserLocation={true}
-        showsUserLocation={true}
-        zoomEnabled={canZoom}
-        customMapStyle={[
-          {
-            featureType: "poi",
-            stylers: [{ visibility: "off" }]
-          },
-          {
-            featureType: "transit",
-            stylers: [{ visibility: "off" }]
-          }
-        ]}
-      >
-        {markers.map((marker) => (
-          <>
-            <Marker
-              key={marker.key}
-              coordinate={{
-                latitude: marker.location.latitude,
-                longitude: marker.location.longitude
-              }}
-              onPress={() => onMarkerSelected?.(marker)}
-            >
-              {renderMarker(marker)}
-            </Marker>
-            {renderCircle && renderCircle(marker)}
-          </>
-        ))}
-      </MapView>
-    </View>
+    <MapView
+      ref={mapRef}
+      style={style}
+      provider={PROVIDER_GOOGLE}
+      initialRegion={initialRegion}
+      rotateEnabled={canRotate}
+      scrollEnabled={canScroll}
+      loadingEnabled={true}
+      toolbarEnabled={false}
+      onLongPress={(e) => onLongPress?.(e.nativeEvent.coordinate)}
+      followsUserLocation={true}
+      showsUserLocation={true}
+      zoomEnabled={canZoom}
+      customMapStyle={[
+        {
+          featureType: "poi",
+          stylers: [{ visibility: "off" }]
+        },
+        {
+          featureType: "transit",
+          stylers: [{ visibility: "off" }]
+        }
+      ]}
+    >
+      {markers.map((marker) => (
+        <>
+          <Marker
+            key={marker.key}
+            coordinate={{
+              latitude: marker.location.latitude,
+              longitude: marker.location.longitude
+            }}
+            onPress={() => onMarkerSelected?.(marker)}
+          >
+            {renderMarker(marker)}
+          </Marker>
+          {renderCircle && renderCircle(marker)}
+        </>
+      ))}
+    </MapView>
   )
-})
-
-const fillStyle = StyleSheet.create({
-  map: {
-    ...StyleSheet.absoluteFillObject
-  }
 })
 
 export default Map

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -32,6 +32,8 @@ interface Props<T extends MapMarker> {
   renderCircle?: (marker: T) => React.ReactNode
 
   onMarkerSelected?: (marker: T) => void
+
+  onLongPress?: (coordinates: Location) => void
 }
 
 // When clicking on the marker, zoom towards where it is.
@@ -74,7 +76,8 @@ export function Map<T extends MapMarker> ({
   mapStyle,
   canScroll = true,
   canRotate = true,
-  canZoom = true
+  canZoom = true,
+  onLongPress
 }: Props<T>) {
   // Map references
   const mapRef = React.useRef<MapView | null>(null)
@@ -100,14 +103,6 @@ export function Map<T extends MapMarker> ({
     })
   }
 
-  // Function to give the location of a long press, ideally for a pin place.
-  function onPinPlace (lat: number, lng: number): Location {
-    return {
-      latitude: lat,
-      longitude: lng
-    }
-  }
-
   return (
     <View style={mapStyle}>
       <MapView
@@ -119,12 +114,7 @@ export function Map<T extends MapMarker> ({
         scrollEnabled={canScroll}
         loadingEnabled={true}
         toolbarEnabled={false}
-        onLongPress={(e) => {
-          onPinPlace(
-            e.nativeEvent.coordinate.latitude,
-            e.nativeEvent.coordinate.longitude
-          )
-        }}
+        onLongPress={(e) => onLongPress?.(e.nativeEvent.coordinate)}
         followsUserLocation={true}
         showsUserLocation={true}
         zoomEnabled={canZoom}

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -7,11 +7,10 @@ import MapView, { Marker, PROVIDER_GOOGLE } from "react-native-maps"
 // Type for the map markers, in order to separate their logic out
 export interface MapMarker {
   key: string
-  title: string
   location: Location
 }
 
-interface Props<T> {
+interface Props<T extends MapMarker> {
   // Map style specifically for style on map
   mapStyle?: StyleProp<ViewStyle>
 
@@ -22,25 +21,17 @@ interface Props<T> {
     longitudeDelta: number
   }
 
-  initialRadius: {
-    radius: number
-  }
+  markers: T[]
 
-  markers: MapMarker[]
+  canScroll?: boolean
+  canZoom?: boolean
+  canRotate?: boolean
 
-  currentSelectedMarker: String | undefined
+  renderMarker: (marker: T) => React.ReactNode
 
-  movementSettings: {
-    canScroll: boolean
-    canZoom: boolean
-    canRotate: boolean
-  }
+  renderCircle?: (marker: T) => React.ReactNode
 
-  renderMarker: (marker: MapMarker) => React.ReactNode
-
-  renderCircle?: (marker: MapMarker) => React.ReactNode
-
-  onMarkerSelected?: (marker: MapMarker) => void
+  onMarkerSelected?: (marker: T) => void
 }
 
 // When clicking on the marker, zoom towards where it is.
@@ -74,16 +65,16 @@ function circleCoordinateGeneration (lat: number, long: number, radius: number) 
 }
 
 // Map view component itself
-export function MapComponent<T extends MapMarker> ({
+export function Map<T extends MapMarker> ({
   initialRegion,
   markers,
-  currentSelectedMarker,
   renderMarker,
   renderCircle,
   onMarkerSelected,
-  initialRadius,
   mapStyle,
-  movementSettings
+  canScroll = true,
+  canRotate = true,
+  canZoom = true
 }: Props<T>) {
   // Map references
   const mapRef = React.useRef<MapView | null>(null)
@@ -95,7 +86,6 @@ export function MapComponent<T extends MapMarker> ({
         <>
           <Marker
             key={marker.key}
-            title={marker.title}
             coordinate={{
               latitude: marker.location.latitude,
               longitude: marker.location.longitude
@@ -125,8 +115,8 @@ export function MapComponent<T extends MapMarker> ({
         provider={PROVIDER_GOOGLE}
         initialRegion={initialRegion}
         ref={mapRef}
-        rotateEnabled={movementSettings.canRotate}
-        scrollEnabled={movementSettings.canScroll}
+        rotateEnabled={canRotate}
+        scrollEnabled={canScroll}
         loadingEnabled={true}
         toolbarEnabled={false}
         onLongPress={(e) => {
@@ -137,7 +127,7 @@ export function MapComponent<T extends MapMarker> ({
         }}
         followsUserLocation={true}
         showsUserLocation={true}
-        zoomEnabled={movementSettings.canZoom}
+        zoomEnabled={canZoom}
         customMapStyle={[
           {
             featureType: "poi",
@@ -161,4 +151,4 @@ const fillStyle = StyleSheet.create({
   }
 })
 
-export default MapComponent
+export default Map

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -67,7 +67,7 @@ function circleCoordinateGeneration (lat: number, long: number, radius: number) 
 }
 
 // Map view component itself
-export function Map<T extends MapMarker> ({
+export const Map = <T extends MapMarker>({
   initialRegion,
   markers,
   renderMarker,
@@ -78,38 +78,12 @@ export function Map<T extends MapMarker> ({
   canRotate = true,
   canZoom = true,
   onLongPress
-}: Props<T>) {
-  // Map references
-  const mapRef = React.useRef<MapView | null>(null)
-
-  // Return the markers/circles so that they appear on the map
-  const mapMarkerCreations = () => {
-    return markers.map((marker) => {
-      return (
-        <>
-          <Marker
-            key={marker.key}
-            coordinate={{
-              latitude: marker.location.latitude,
-              longitude: marker.location.longitude
-            }}
-            onPress={() => onMarkerSelected?.(marker)}
-          >
-            {renderMarker(marker)}
-          </Marker>
-          {renderCircle && renderCircle(marker)}
-        </>
-      )
-    })
-  }
-
-  return (
+}: Props<T>) => (
     <View style={mapStyle}>
       <MapView
         style={fillStyle.map}
         provider={PROVIDER_GOOGLE}
         initialRegion={initialRegion}
-        ref={mapRef}
         rotateEnabled={canRotate}
         scrollEnabled={canScroll}
         loadingEnabled={true}
@@ -129,11 +103,24 @@ export function Map<T extends MapMarker> ({
           }
         ]}
       >
-        {mapMarkerCreations()}
+        {markers.map((marker) => (
+          <>
+            <Marker
+              key={marker.key}
+              coordinate={{
+                latitude: marker.location.latitude,
+                longitude: marker.location.longitude
+              }}
+              onPress={() => onMarkerSelected?.(marker)}
+            >
+              {renderMarker(marker)}
+            </Marker>
+            {renderCircle && renderCircle(marker)}
+          </>
+        ))}
       </MapView>
     </View>
   )
-}
 
 const fillStyle = StyleSheet.create({
   map: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
   preset: "jest-expo",
   setupFiles: [
     "<rootDir>/jest/setupNav.js",
-    "<rootDir>/jest/setupBottomSheetMock.jsx"
+    "<rootDir>/jest/setupBottomSheetMock.jsx",
+    "<rootDir>/jest/setupMapMock.jsx"
   ],
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"

--- a/jest/setupMapMock.jsx
+++ b/jest/setupMapMock.jsx
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+// @ts-nocheck
+/* eslint-disable react/prop-types */
+/* eslint-disable react/react-in-jsx-scope */
+jest.mock("react-native-maps", () => {
+  const { View } = require("react-native")
+  const MockMapView = (props) => {
+    return <View>{props.children}</View>
+  }
+  const MockMarker = (props) => {
+    return <View>{props.children}</View>
+  }
+  return {
+    __esModule: true,
+    default: MockMapView,
+    Marker: MockMarker
+  }
+})

--- a/screens/ActivitiesScreen.tsx
+++ b/screens/ActivitiesScreen.tsx
@@ -1,5 +1,5 @@
 import EventsList from "@components/EventsList"
-import MapComponent from "@components/MapComponent"
+import Map from "@components/Map"
 import { mapCompStyle, state } from "@components/MapTestData"
 import { Auth } from "aws-amplify"
 import React, { useState } from "react"
@@ -31,10 +31,9 @@ const ActivitiesScreen = () => {
 
   return (
     <>
-      <MapComponent
+      <Map
         mapStyle={mapCompStyle.container}
         initialRegion={state.initialRegion}
-        initialRadius={{ radius: circleRadius }}
         renderMarker={(item) => <Text> Lesgoo </Text>}
         renderCircle={(item) => (
           <Circle
@@ -48,9 +47,7 @@ const ActivitiesScreen = () => {
             strokeWidth={1}
           />
         )}
-        currentSelectedMarker={selectedMarker}
         markers={state.markers}
-        movementSettings={state.movementSettings}
       />
       <EventsList />
     </>

--- a/screens/ActivitiesScreen.tsx
+++ b/screens/ActivitiesScreen.tsx
@@ -32,7 +32,7 @@ const ActivitiesScreen = () => {
   return (
     <>
       <Map
-        style={mapCompStyle.container}
+        style={{ width: "100%", height: "100%" }}
         initialRegion={state.initialRegion}
         renderMarker={(item) => <Text> Lesgoo </Text>}
         renderCircle={(item) => (

--- a/screens/ActivitiesScreen.tsx
+++ b/screens/ActivitiesScreen.tsx
@@ -32,7 +32,7 @@ const ActivitiesScreen = () => {
   return (
     <>
       <Map
-        mapStyle={mapCompStyle.container}
+        style={mapCompStyle.container}
         initialRegion={state.initialRegion}
         renderMarker={(item) => <Text> Lesgoo </Text>}
         renderCircle={(item) => (

--- a/tests/components/Map.test.tsx
+++ b/tests/components/Map.test.tsx
@@ -36,7 +36,7 @@ const renderMap = (markers: TestMapMarker[]) => {
         latitudeDelta: 0.2,
         longitudeDelta: 0.2
       }}
-      renderMarker={(marker) => <View testID={marker.name} />}
+      renderMarker={(marker: TestMapMarker) => <View testID={marker.name} />}
       onMarkerSelected={selectionEvent}
     />
   )

--- a/tests/components/Map.test.tsx
+++ b/tests/components/Map.test.tsx
@@ -1,0 +1,43 @@
+import Map, { MapMarker } from "@components/Map"
+import { fireEvent, render, screen } from "@testing-library/react-native"
+import React from "react"
+import { View } from "react-native"
+
+const testMapMarker = {
+  key: "test",
+  location: { latitude: 41.1234, longitude: -121.1234 },
+  name: "Test Marker"
+}
+
+describe("Map tests", () => {
+  it("forwards marker selection events", () => {
+    renderMap([testMapMarker])
+    selectMarker(testMapMarker.name)
+    expect(selectionEvent).toHaveBeenCalledWith(testMapMarker)
+  })
+})
+
+const selectionEvent = jest.fn()
+
+const selectMarker = (markerName: string) => {
+  fireEvent.press(screen.getByTestId(markerName))
+}
+
+interface TestMapMarker extends MapMarker {
+  name: string
+}
+
+const renderMap = (markers: TestMapMarker[]) => {
+  return render(
+    <Map
+      markers={markers}
+      initialRegion={{
+        ...testMapMarker.location,
+        latitudeDelta: 0.2,
+        longitudeDelta: 0.2
+      }}
+      renderMarker={(marker) => <View testID={marker.name} />}
+      onMarkerSelected={selectionEvent}
+    />
+  )
+}


### PR DESCRIPTION
This PR cleans up the map component interface, whilst also just renaming it to `Map`. It naturally also includes a jest mock so that the map component is usable for testing. I've also removed some unused functions atm since we probably won't need them for the near future.

