### PR TITLE
Update: Make a test fail when it uses the default value from a dependency key

### DIFF
--- a/lib/dependencies/DependencyHooks.tsx
+++ b/lib/dependencies/DependencyHooks.tsx
@@ -123,7 +123,7 @@ export const useDependencyValue = <T, >(key: DependencyKey<T>) => {
  * }
  * ```
  *
- * @param keys the `DependencyKey`s to use to retrieve their values in the dependencies system.
+ * @param keys the {@link DependencyKey}'s to use to retrieve their values in the dependencies system.
  * @returns a tuple type of all the dependencies returned.
  */
 export const useDependencyValues = <
@@ -147,7 +147,7 @@ export type SetDependencyValueProps<T> = {
 /**
  * Sets the dependency value for a particular key in a child context. This is most useful
  * when you need to update the value just for a single dependency, if you need to update
- * the values for multiple dependencies, use `UpdateDependencyValues` instead.
+ * the values for multiple dependencies, use {@link UpdateDependencyValues} instead.
  *
  * Using this will override the default/pre-existing value of the specified key.
  *
@@ -188,7 +188,7 @@ export type UpdateDependencyValuesProps = {
  * Updates an instance of `DependencyValues` specifically for the child context to use.
  *
  * Use this component when you need to set the values of 2 or more dependencies. If you
- * only need to set the value of 1 dependency, use `SetDependencyValue`.
+ * only need to set the value of 1 dependency, use {@link SetDependencyValue}.
  *
  * Using this will override any of the values for the given dependency keys.
  *

--- a/lib/dependencies/DependencyKey.ts
+++ b/lib/dependencies/DependencyKey.ts
@@ -1,11 +1,11 @@
-import { ImmutableDependencyValues } from "./DependencyValues"
+import { ReadonlyDependencyValues } from "./DependencyValues"
 import { uuid } from "@lib/uuid"
 
 /**
  * A key to that associates itself with a particular type, and is used to retrieve and
  * modify its associated type in the dependencies system.
  *
- * This object should not be created directly, but rather with the `createDependencyKey`
+ * This object should not be created directly, but rather with the {@link createDependencyKey}
  * function like such.
  *
  * ```ts
@@ -95,9 +95,9 @@ import { uuid } from "@lib/uuid"
  */
 export class DependencyKey<T> {
   readonly identifier: string
-  readonly createDefaultValue?: (values: ImmutableDependencyValues) => T
+  readonly createDefaultValue?: (values: ReadonlyDependencyValues) => T
 
-  constructor (createDefaultValue?: (values: ImmutableDependencyValues) => T) {
+  constructor (createDefaultValue?: (values: ReadonlyDependencyValues) => T) {
     this.identifier = uuid()
     this.createDefaultValue = createDefaultValue
   }
@@ -127,16 +127,16 @@ export class DependencyKey<T> {
  * @param defaultValue a default value, or a function to create a default value for this key
  */
 export const createDependencyKey = <T>(
-  defaultValue?: ((values: ImmutableDependencyValues) => T) | T
+  defaultValue?: ((values: ReadonlyDependencyValues) => T) | T
 ) => {
   if (!defaultValue) return new DependencyKey<T>()
   return new DependencyKey<T>(makeDefaultValueCreation(defaultValue))
 }
 
 const makeDefaultValueCreation = <T>(
-  defaultValue: ((values: ImmutableDependencyValues) => T) | T
+  defaultValue: ((values: ReadonlyDependencyValues) => T) | T
 ) => {
-  return (values: ImmutableDependencyValues) => {
+  return (values: ReadonlyDependencyValues) => {
     if (defaultValue instanceof Function) {
       return defaultValue(values)
     }

--- a/tests/dependencies/DependencyHooks.test.tsx
+++ b/tests/dependencies/DependencyHooks.test.tsx
@@ -9,121 +9,128 @@ import {
 } from "../../lib/dependencies"
 import "../helpers/Matchers"
 import { render, screen } from "@testing-library/react-native"
+import { _negateDependencyKeyDefaultValueTestContext } from "./helpers"
 
 const testString1 = "Hello World"
 const testString2 = "Goodbye World"
 
 describe("DependencyHooks tests", () => {
-  test("SetDependencyValue creates a new DependencyValues instance for the child context", () => {
-    const key = createDependencyKey(testString1)
+  _negateDependencyKeyDefaultValueTestContext()
 
-    const ChildComponent = () => {
-      const dependency = useDependencyValue(key)
-      return <View testID={makeChildId(dependency)} />
-    }
+  describe("SetDependencyValue tests", () => {
+    it("creates a new DependencyValues instance for the child context", () => {
+      const key = createDependencyKey(testString1)
 
-    const ParentComponent = () => {
-      const dependency = useDependencyValue(key)
-      return (
-        <SetDependencyValue forKey={key} value={testString2}>
-          <ChildComponent />
-          <View testID={makeParentId(dependency)} />
+      const ChildComponent = () => {
+        const dependency = useDependencyValue(key)
+        return <View testID={makeChildId(dependency)} />
+      }
+
+      const ParentComponent = () => {
+        const dependency = useDependencyValue(key)
+        return (
+          <SetDependencyValue forKey={key} value={testString2}>
+            <ChildComponent />
+            <View testID={makeParentId(dependency)} />
+          </SetDependencyValue>
+        )
+      }
+
+      render(<ParentComponent />)
+
+      expect(parentId(testString1)).toBeDisplayed()
+      expect(childId(testString2)).toBeDisplayed()
+    })
+
+    it("preserves current values in child context", () => {
+      const key1 = createDependencyKey<string>()
+      const key2 = createDependencyKey<string>()
+
+      const ChildComponent = () => {
+        const [d1, d2] = useDependencyValues<[string, string]>([key1, key2])
+        return (
+          <>
+            <View testID={makeChildId(d1)} />
+            <View testID={makeChildId(d2)} />
+          </>
+        )
+      }
+
+      const ParentComponent = () => (
+        <SetDependencyValue forKey={key1} value={testString1}>
+          <SetDependencyValue forKey={key2} value={testString2}>
+            <ChildComponent />
+          </SetDependencyValue>
         </SetDependencyValue>
       )
-    }
 
-    render(<ParentComponent />)
+      render(<ParentComponent />)
 
-    expect(parentId(testString1)).toBeDisplayed()
-    expect(childId(testString2)).toBeDisplayed()
+      expect(childId(testString1)).toBeDisplayed()
+      expect(childId(testString2)).toBeDisplayed()
+    })
   })
 
-  test("SetDependencyValue preserves current values in child context", () => {
-    const key1 = createDependencyKey<string>()
-    const key2 = createDependencyKey<string>()
+  describe("UpdateDependencyValues tests", () => {
+    it("creates a new DependencyValues instance for the child context", () => {
+      const key = createDependencyKey(testString1)
 
-    const ChildComponent = () => {
-      const [d1, d2] = useDependencyValues<[string, string]>([key1, key2])
-      return (
-        <>
-          <View testID={makeChildId(d1)} />
-          <View testID={makeChildId(d2)} />
-        </>
-      )
-    }
+      const ChildComponent = () => {
+        const dependency = useDependencyValue(key)
+        return <View testID={makeChildId(dependency)} />
+      }
 
-    const ParentComponent = () => (
-      <SetDependencyValue forKey={key1} value={testString1}>
-        <SetDependencyValue forKey={key2} value={testString2}>
-          <ChildComponent />
-        </SetDependencyValue>
-      </SetDependencyValue>
-    )
+      const ParentComponent = () => {
+        const dependency = useDependencyValue(key)
+        return (
+          <UpdateDependencyValues
+            update={(values) => {
+              values.set(key, testString2)
+            }}
+          >
+            <ChildComponent />
+            <View testID={makeParentId(dependency)} />
+          </UpdateDependencyValues>
+        )
+      }
 
-    render(<ParentComponent />)
+      render(<ParentComponent />)
 
-    expect(childId(testString1)).toBeDisplayed()
-    expect(childId(testString2)).toBeDisplayed()
-  })
+      expect(parentId(testString1)).toBeDisplayed()
+      expect(childId(testString2)).toBeDisplayed()
+    })
 
-  test("UpdateDependencyValues creates a new DependencyValues instance for the child context", () => {
-    const key = createDependencyKey(testString1)
+    it("preserves current values in child context", () => {
+      const key1 = createDependencyKey<string>()
+      const key2 = createDependencyKey<string>()
 
-    const ChildComponent = () => {
-      const dependency = useDependencyValue(key)
-      return <View testID={makeChildId(dependency)} />
-    }
+      const ChildComponent = () => {
+        const [d1, d2] = useDependencyValues<[string, string]>([key1, key2])
+        return (
+          <>
+            <View testID={makeChildId(d1)} />
+            <View testID={makeChildId(d2)} />
+          </>
+        )
+      }
 
-    const ParentComponent = () => {
-      const dependency = useDependencyValue(key)
-      return (
+      const ParentComponent = () => (
         <UpdateDependencyValues
-          update={(values) => {
-            values.set(key, testString2)
-          }}
+          update={(values) => values.set(key1, testString1)}
         >
-          <ChildComponent />
-          <View testID={makeParentId(dependency)} />
+          <UpdateDependencyValues
+            update={(values) => values.set(key2, testString2)}
+          >
+            <ChildComponent />
+          </UpdateDependencyValues>
         </UpdateDependencyValues>
       )
-    }
 
-    render(<ParentComponent />)
+      render(<ParentComponent />)
 
-    expect(parentId(testString1)).toBeDisplayed()
-    expect(childId(testString2)).toBeDisplayed()
-  })
-
-  test("UpdateDependencyValues preserves current values in child context", () => {
-    const key1 = createDependencyKey<string>()
-    const key2 = createDependencyKey<string>()
-
-    const ChildComponent = () => {
-      const [d1, d2] = useDependencyValues<[string, string]>([key1, key2])
-      return (
-        <>
-          <View testID={makeChildId(d1)} />
-          <View testID={makeChildId(d2)} />
-        </>
-      )
-    }
-
-    const ParentComponent = () => (
-      <UpdateDependencyValues
-        update={(values) => values.set(key1, testString1)}
-      >
-        <UpdateDependencyValues
-          update={(values) => values.set(key2, testString2)}
-        >
-          <ChildComponent />
-        </UpdateDependencyValues>
-      </UpdateDependencyValues>
-    )
-
-    render(<ParentComponent />)
-
-    expect(childId(testString1)).toBeDisplayed()
-    expect(childId(testString2)).toBeDisplayed()
+      expect(childId(testString1)).toBeDisplayed()
+      expect(childId(testString2)).toBeDisplayed()
+    })
   })
 })
 

--- a/tests/dependencies/DependencyValues.test.ts
+++ b/tests/dependencies/DependencyValues.test.ts
@@ -1,6 +1,9 @@
 import { createDependencyKey, DependencyValues } from "../../lib/dependencies"
+import { _negateDependencyKeyDefaultValueTestContext } from "./helpers"
 
 describe("DependencyValues tests", () => {
+  _negateDependencyKeyDefaultValueTestContext()
+
   it("creates a dependency key's default value on first access", () => {
     const key = createDependencyKey(1)
 

--- a/tests/dependencies/helpers.ts
+++ b/tests/dependencies/helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Only for use in dependencies tests which need to test default value behavior.
+ */
+export const _negateDependencyKeyDefaultValueTestContext = () => {
+  let jestId: string | undefined
+  beforeAll(() => {
+    jestId = process.env.JEST_WORKER_ID
+    process.env.JEST_WORKER_ID = undefined
+  })
+  afterAll(() => (process.env.JEST_WORKER_ID = jestId))
+}


### PR DESCRIPTION
This PR requires that `SetDependencyValue` or `UpdateDependencyValue` is used for all dependency keys in a given test context. If a dependency key attempts to use its default value inside a test, the `DependencyValues` class will throw an error (which is highly likely to cause a test failure).

There are 2 reasons for why this is a good idea:
1. It prevents tests from accidentally making AWS calls, tracking analytics, or doing other costly operations.
2. It ensures that when you write tests, you don't miss covering important side effects. By explicitly requiring that you give a preset value for a dependency key, you will naturally think about how the component under test uses the dependency.