### PR TITLE
useUserLocation hook

### DIFF
--- a/lib/dependencies/DependencyValues.ts
+++ b/lib/dependencies/DependencyValues.ts
@@ -72,7 +72,10 @@ export class DependencyValues {
     const cachedValue = this.cachedValues.get(key.identifier)
     if (cachedValue) return cachedValue as T
 
-    if (process.env.JEST_WORKER_ID !== "undefined") {
+    if (
+      process.env.JEST_WORKER_ID !== "undefined" &&
+      process.env.JEST_WORKER_ID !== undefined
+    ) {
       throw new Error(`
       Attempted to access the default value of a dependency key in a test context.
 

--- a/tests/helpers/Promise.ts
+++ b/tests/helpers/Promise.ts
@@ -2,3 +2,16 @@
  * Creates a promise that never resolves.
  */
 export const neverPromise = <T>() => new Promise<T>(() => {})
+
+/**
+ * Returns a promise along with functions to resolve and reject it.
+ */
+export const promiseComponents = <T>() => {
+  let resolver: (value: T) => void = () => {}
+  let rejecter: (value: unknown) => void = () => {}
+  const promise = new Promise<T>((resolve, reject) => {
+    resolver = resolve
+    rejecter = reject
+  })
+  return { resolver, rejecter, promise }
+}

--- a/tests/location/helpers.ts
+++ b/tests/location/helpers.ts
@@ -12,3 +12,7 @@ export const baseTestPlacemark = {
 export const unknownLocationPlacemark = {
   name: "North Pacific Ocean"
 } as const
+
+export const unimplementedUserLocation = () => ({
+  track: jest.fn()
+})

--- a/tests/location/useUserLocation.test.tsx
+++ b/tests/location/useUserLocation.test.tsx
@@ -1,0 +1,64 @@
+import { SetDependencyValue } from "@lib/dependencies"
+import {
+  TrackedLocation,
+  UserLocation,
+  userLocationDependencyKey,
+  useUserLocation
+} from "@lib/location"
+import { act, renderHook } from "@testing-library/react-native"
+import { neverPromise, promiseComponents } from "../helpers/Promise"
+import { unimplementedUserLocation } from "./helpers"
+
+const testTrackedLocation: TrackedLocation = {
+  coordinate: {
+    latitude: 69.69696969,
+    longitude: -69.696969
+  },
+  trackingDate: new Date()
+}
+
+describe("useUserLocation tests", () => {
+  beforeEach(() => (userLocation = unimplementedUserLocation()))
+
+  it("is tracks the user's location", () => {
+    let sendLocationUpdate: (location: TrackedLocation) => void
+    userLocation.track.mockImplementation((callback) => {
+      sendLocationUpdate = callback
+      return neverPromise()
+    })
+    const { result } = renderUserLocation()
+    expect(result.current).toBeUndefined()
+
+    act(() => sendLocationUpdate(testTrackedLocation))
+    expect(result.current).toMatchObject(testTrackedLocation)
+  })
+
+  it("unsubs when unmounted", async () => {
+    const unsubAction = jest.fn()
+    const { resolver, promise } = promiseComponents<undefined>()
+    userLocation.track.mockImplementation(() => {
+      resolver(undefined)
+      return Promise.resolve(unsubAction)
+    })
+
+    const { unmount } = renderUserLocation()
+    await promise
+
+    unmount()
+    expect(unsubAction).toHaveBeenCalled()
+  })
+})
+
+let userLocation = unimplementedUserLocation()
+
+const renderUserLocation = () => {
+  const wrapper = ({ children }: any) => (
+    <SetDependencyValue
+      forKey={userLocationDependencyKey}
+      value={userLocation as unknown as UserLocation}
+    >
+      {children}
+    </SetDependencyValue>
+  )
+  return renderHook(useUserLocation, { wrapper })
+}


### PR DESCRIPTION
This PR just includes a simple way to track the current user's location with a hook. Note that the location can be undefined if the the user has denied permissions, has bad network, etc.