### PR TITLE
OpenSans Text Components

### DIFF
--- a/components/Text.tsx
+++ b/components/Text.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { StyleSheet, Text, TextProps } from "react-native"
+
+/**
+ * A text component that represents the standard title of
+ * some UI element.
+ */
+export const Title = (props: TextProps) => (
+  <Text {...props} style={[props.style, styles.title]} />
+)
+
+/**
+ * A text component for standard text that the user sees.
+ */
+export const BodyText = (props: TextProps) => (
+  <Text {...props} style={[props.style, styles.body]} />
+)
+
+/**
+ * A text component for smaller and more subtle details.
+ */
+export const Subtitle = (props: TextProps) => (
+  <Text {...props} style={[props.style, styles.subtitle]} />
+)
+
+/**
+ * A text component with the same font size as {@link BodyText}
+ * that allows for more emphasis on a particular UI element
+ * group.
+ */
+export const Headline = (props: TextProps) => (
+  <Text {...props} style={[props.style, styles.headline]} />
+)
+
+const styles = StyleSheet.create({
+  title: {
+    fontFamily: "OpenSansBold",
+    fontSize: 24
+  },
+  body: {
+    fontFamily: "OpenSans",
+    fontSize: 16
+  },
+  subtitle: {
+    fontFamily: "OpenSans",
+    fontSize: 12,
+    opacity: 0.35
+  },
+  headline: {
+    fontFamily: "OpenSansBold",
+    fontSize: 16
+  }
+})

--- a/components/Text.tsx
+++ b/components/Text.tsx
@@ -19,8 +19,8 @@ export const BodyText = (props: TextProps) => (
 /**
  * A text component for smaller and more subtle details.
  */
-export const Subtitle = (props: TextProps) => (
-  <Text {...props} style={[props.style, styles.subtitle]} />
+export const Caption = (props: TextProps) => (
+  <Text {...props} style={[props.style, styles.caption]} />
 )
 
 /**
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     fontFamily: "OpenSans",
     fontSize: 16
   },
-  subtitle: {
+  caption: {
     fontFamily: "OpenSans",
     fontSize: 12,
     opacity: 0.35


### PR DESCRIPTION
#92 Added the open sans font and a hook to load the font. This PR now adds some preset text components since more design details have been fleshed out. Each text component takes in the standard `TextProps` so they can be used like the normal react native text component. Here's an image for reference:
![IMG_2872](https://user-images.githubusercontent.com/75196016/231698089-74869a03-4aec-43b9-970e-97d8d5b82af7.jpeg)
