### PR TITLE
Button Components Shown in Design

### DIFF
--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -1,38 +1,51 @@
+import { Headline } from "@components/Text"
+import { ButtonStyles } from "@lib/ButtonStyle"
 import React from "react"
-import {StyleSheet, TouchableOpacity, TouchableOpacityProps } from "react-native"
+import {
+  StyleSheet,
+  TouchableOpacity,
+  TouchableOpacityProps
+} from "react-native"
 
-const hexAlpha = "26" // 15% Opacity
-
-export namespace CustomButtonStyles {
-  export const darkColor = "#26282A"
+interface ButtonProps {
+  title: string
+  buttonProps: TouchableOpacityProps
 }
 
-export const CustomButton = (props: TouchableOpacityProps) => {
+export const PrimaryButton = ({ title, buttonProps }: ButtonProps) => {
   return (
     <TouchableOpacity
-      {...props}
-      style={[props.style, styles.container, {backgroundColor: CustomButtonStyles.darkColor}]}>
-      {props.children}
+      {...buttonProps}
+      style={[
+        buttonProps.style,
+        styles.container,
+        { backgroundColor: ButtonStyles.darkColor }
+      ]}
+    >
+      <Headline style={{ color: "white" }}>{title}</Headline>
+      {buttonProps.children}
     </TouchableOpacity>
   )
 }
 
-export const CustomOutlinedButton = (props: TouchableOpacityProps) => {
+export const OutlinedButton = ({ title, buttonProps }: ButtonProps) => {
   return (
     <TouchableOpacity
-      {...props}
+      {...buttonProps}
       style={[
-        props.style,
+        buttonProps.style,
         styles.container,
         styles.lightStyle,
-        {borderColor: CustomButtonStyles.darkColor + hexAlpha}
-      ]}>
-      {props.children}
+        { borderColor: ButtonStyles.darkColor + ButtonStyles.opacity }
+      ]}
+    >
+      <Headline style={{ color: ButtonStyles.darkColor }}>{title}</Headline>
+      {buttonProps.children}
     </TouchableOpacity>
   )
 }
 
-const styles = StyleSheet.create ({
+const styles = StyleSheet.create({
   container: {
     height: 48,
     alignSelf: "center",

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -1,51 +1,47 @@
 import React from "react"
-import { ButtonProps, Pressable, StyleSheet } from "react-native"
-import { Headline } from "@components/Text"
+import {StyleSheet, TouchableOpacity, TouchableOpacityProps } from "react-native"
 
-const darkColor = "#26282A"
 const hexAlpha = "26" // 15% Opacity
 
-export const DarkButton = (props: ButtonProps) => {
+export namespace CustomButtonStyles {
+  export const darkColor = "#26282A"
+}
+
+export const CustomButton = (props: TouchableOpacityProps) => {
   return (
-    <Pressable
-      onPress={props.onPress}
-      style={[styles.container, {backgroundColor: darkColor}]}>
-      <Headline style={styles.darkStyleText}>{props.title}</Headline>
-    </Pressable>
+    <TouchableOpacity
+      {...props}
+      style={[props.style, styles.container, {backgroundColor: CustomButtonStyles.darkColor}]}>
+      {props.children}
+    </TouchableOpacity>
   )
 }
 
-export const LightButton = (props: ButtonProps) => {
+export const CustomOutlinedButton = (props: TouchableOpacityProps) => {
   return (
-    <Pressable
-      onPress={props.onPress}
+    <TouchableOpacity
+      {...props}
       style={[
+        props.style,
         styles.container,
         styles.lightStyle,
-        {borderColor: darkColor + hexAlpha}
+        {borderColor: CustomButtonStyles.darkColor + hexAlpha}
       ]}>
-      <Headline style={styles.lightStyleText}>{props.title}</Headline>
-    </Pressable>
+      {props.children}
+    </TouchableOpacity>
   )
 }
 
 const styles = StyleSheet.create ({
   container: {
     height: 48,
-    width: "90%",
     alignSelf: "center",
     alignItems: "center",
     justifyContent: "center",
     borderRadius: 12
   },
-  darkStyleText: {
-    color: "white"
-  },
   lightStyle: {
     backgroundColor: "white",
     borderWidth: 1
-  },
-  lightStyleText: {
-    color: "black"
   }
 })

--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { ButtonProps, Pressable, StyleSheet } from "react-native"
+import { Headline } from "@components/Text"
+
+const darkColor = "#26282A"
+const hexAlpha = "26" // 15% Opacity
+
+export const DarkButton = (props: ButtonProps) => {
+  return (
+    <Pressable
+      onPress={props.onPress}
+      style={[styles.container, {backgroundColor: darkColor}]}>
+      <Headline style={styles.darkStyleText}>{props.title}</Headline>
+    </Pressable>
+  )
+}
+
+export const LightButton = (props: ButtonProps) => {
+  return (
+    <Pressable
+      onPress={props.onPress}
+      style={[
+        styles.container,
+        styles.lightStyle,
+        {borderColor: darkColor + hexAlpha}
+      ]}>
+      <Headline style={styles.lightStyleText}>{props.title}</Headline>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create ({
+  container: {
+    height: 48,
+    width: "90%",
+    alignSelf: "center",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12
+  },
+  darkStyleText: {
+    color: "white"
+  },
+  lightStyle: {
+    backgroundColor: "white",
+    borderWidth: 1
+  },
+  lightStyleText: {
+    color: "black"
+  }
+})

--- a/lib/ButtonStyle.ts
+++ b/lib/ButtonStyle.ts
@@ -1,0 +1,4 @@
+export namespace ButtonStyles {
+  export const darkColor = "#26282A"
+  export const opacity = "26" // 15% Opacity
+}


### PR DESCRIPTION
This PR includes the button components shown in the designs and includes a dark variant and light variant. The title and onPress function are passed in through props so the components are reusable.
![darkButton_1](https://user-images.githubusercontent.com/60305446/232966476-e9bcf718-dfbc-429f-b7f4-0d798bcf028c.jpg)
![lightButton_1](https://user-images.githubusercontent.com/60305446/232966478-ac2b2434-7845-40ab-aa93-a434e321b2b1.jpg)
