### PR TITLE
Current User Coordinates Expo Query

### DIFF
--- a/hooks/UserLocation.ts
+++ b/hooks/UserLocation.ts
@@ -3,8 +3,9 @@ import {
   UserLocationTrackingAccurracy,
   expoTrackUserLocation,
   TrackUserLocation,
-  QueryUserCoordinates
-} from "@lib/location/UserLocation"
+  QueryUserCoordinates,
+  expoQueryUserCoordinates
+} from "@lib/location"
 import { createDependencyKey, useDependencyValue } from "@lib/dependencies"
 import { useEffect, useState } from "react"
 import { useQuery } from "react-query"
@@ -23,8 +24,9 @@ export namespace UserLocationDependencyKeys {
   /**
    * A dependency key to load the user's current coordinates a single time.
    */
-  // TODO: - Live Value
-  export const currentCoordinates = createDependencyKey<QueryUserCoordinates>()
+  export const currentCoordinates = createDependencyKey<QueryUserCoordinates>(
+    () => expoQueryUserCoordinates
+  )
 }
 
 /**

--- a/lib/location/UserLocation.ts
+++ b/lib/location/UserLocation.ts
@@ -5,7 +5,8 @@ import {
   LocationCallback,
   LocationSubscription,
   LocationAccuracy,
-  LocationObject
+  LocationObject,
+  getCurrentPositionAsync
 } from "expo-location"
 
 /**
@@ -28,6 +29,20 @@ export type UserLocationTrackingAccurracy =
 export type QueryUserCoordinates = (
   accurracy: UserLocationTrackingAccurracy
 ) => Promise<TrackedLocationCoordinates>
+
+/**
+ * Queries the current user's coordinates using expo.
+ */
+export const expoQueryUserCoordinates = async (
+  accurracy: UserLocationTrackingAccurracy,
+  getCurrentPosition: (
+    options: LocationOptions
+  ) => Promise<LocationObject> = getCurrentPositionAsync
+) => {
+  return expoLocationToTrackedLocation(
+    await getCurrentPosition({ accuracy: accurracyToExpoAccurracy(accurracy) })
+  )
+}
 
 /**
  * An update published to a (@link TrackUserLocation} callback.
@@ -89,5 +104,5 @@ const expoLocationToTrackedLocation = (location: LocationObject) => ({
     latitude: location.coords.latitude,
     longitude: location.coords.longitude
   },
-  trackingDate: new Date(location.timestamp / 1000)
+  trackingDate: new Date(location.timestamp)
 })

--- a/tests/location/UserLocation.test.ts
+++ b/tests/location/UserLocation.test.ts
@@ -1,7 +1,9 @@
-import { LocationAccuracy } from "expo-location"
+import { LocationAccuracy, LocationOptions } from "expo-location"
 import {
+  expoQueryUserCoordinates,
   expoTrackUserLocation,
   LocationCoordinatesMocks,
+  mockLocationCoordinate2D,
   UserLocationTrackingAccurracy
 } from "@lib/location"
 import { waitFor } from "@testing-library/react-native"
@@ -9,10 +11,42 @@ import { waitFor } from "@testing-library/react-native"
 const testAccuracy = "precise"
 
 describe("UserLocation tests", () => {
+  describe("ExpoQueryUserCoordinates tests", () => {
+    it("translates a response from expo properly", async () => {
+      const coordinates = mockLocationCoordinate2D()
+      const getCurrentPosition = jest
+        .fn()
+        .mockImplementation((options: LocationOptions) => {
+          if (options.accuracy === LocationAccuracy.Highest) {
+            return Promise.resolve({
+              coords: coordinates,
+              timestamp: 1000
+            })
+          }
+          return Promise.reject(new Error())
+        })
+
+      const response = await expoQueryUserCoordinates(
+        "precise",
+        getCurrentPosition
+      )
+      expect(response).toMatchObject({
+        coordinates,
+        trackingDate: new Date(1000)
+      })
+    })
+  })
+
   describe("ExpoUserLocationTracking tests", () => {
     test("translates accurracy to proper expo accurracy when making tracking request", () => {
-      expectMakesExpoRequestWithAccurracy("approximate-low", LocationAccuracy.Low)
-      expectMakesExpoRequestWithAccurracy("approximate-medium", LocationAccuracy.Balanced)
+      expectMakesExpoRequestWithAccurracy(
+        "approximate-low",
+        LocationAccuracy.Low
+      )
+      expectMakesExpoRequestWithAccurracy(
+        "approximate-medium",
+        LocationAccuracy.Balanced
+      )
       expectMakesExpoRequestWithAccurracy("precise", LocationAccuracy.Highest)
     })
 
@@ -43,7 +77,7 @@ describe("UserLocation tests", () => {
         status: "success",
         location: {
           coordinates: LocationCoordinatesMocks.Paris,
-          trackingDate: new Date(1)
+          trackingDate: new Date(1000)
         }
       })
     })


### PR DESCRIPTION
This PR adds a wrapper around getting the user's current coordinates similar to the way we did it with tracking.