### PR TITLE
Fix CI

### DIFF
--- a/lib/dependencies/DependencyValues.ts
+++ b/lib/dependencies/DependencyValues.ts
@@ -56,6 +56,7 @@ import { DependencyKey } from "./DependencyKey"
  * ```
  */
 export class DependencyValues {
+  static isInTestContext = process.env.JEST_WORKER_ID !== undefined
   private cachedValues = new Map<string, any>()
 
   /**
@@ -72,10 +73,7 @@ export class DependencyValues {
     const cachedValue = this.cachedValues.get(key.identifier)
     if (cachedValue) return cachedValue as T
 
-    if (
-      process.env.JEST_WORKER_ID !== "undefined" &&
-      process.env.JEST_WORKER_ID !== undefined
-    ) {
+    if (DependencyValues.isInTestContext) {
       throw new Error(`
       Attempted to access the default value of a dependency key in a test context.
 

--- a/tests/dependencies/helpers.ts
+++ b/tests/dependencies/helpers.ts
@@ -1,11 +1,9 @@
+import { DependencyValues } from "@lib/dependencies"
+
 /**
  * Only for use in dependencies tests which need to test default value behavior.
  */
 export const _negateDependencyKeyDefaultValueTestContext = () => {
-  let jestId: string | undefined
-  beforeAll(() => {
-    jestId = process.env.JEST_WORKER_ID
-    process.env.JEST_WORKER_ID = undefined
-  })
-  afterAll(() => (process.env.JEST_WORKER_ID = jestId))
+  beforeAll(() => (DependencyValues.isInTestContext = false))
+  afterAll(() => (DependencyValues.isInTestContext = true))
 }


### PR DESCRIPTION
This PR fixes test failures related to the dependencies system by introducing a static `isInTestContext` variable. The issues from earlier came from nulling out the jest worker id when running tests.