### PR TITLE
Add accessibility label to Password text field

### DIFF
--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -73,8 +73,11 @@ export const PasswordTextField = ({
     rightAddon={
       <TouchableIonicon
         icon={{ name: isShowingPasswordContents ? "eye" : "lock-closed" }}
-        onPress={() =>
+        onPress={() => {
           onShowPasswordContentsChanged(!isShowingPasswordContents)
+        }}
+        accessibilityLabel={
+          isShowingPasswordContents ? "Hide password" : "Show password"
         }
       />
     }


### PR DESCRIPTION
It seems like I forgor this the first time, but the lock icon now has an accessibility label.