### PR TITLE
Fix test infrastructure + React Query

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -41,6 +41,7 @@ import { enableSentry } from "@lib/Sentry"
 import { Auth } from "aws-amplify"
 import { Native as SentryNative } from "sentry-expo"
 import awsconfig from "./src/aws-exports"
+import { mockExpoLocationObject } from "@lib/location"
 
 Geo.configure(awsconfig)
 Auth.configure(awsconfig)
@@ -103,15 +104,15 @@ const App = () => {
   )
 }
 
-export default SentryNative.wrap(
-  withAuthenticator(App, false, [
-    <Greetings />,
-    <SignIn />,
-    <SignUp />,
-    <ConfirmSignIn />,
-    <ConfirmSignUp />,
-    <VerifyContact />,
-    <ForgotPassword />,
-    <RequireNewPassword />
-  ])
-)
+export default SentryNative.wrap(App)
+//   withAuthenticator(App, false, [
+//     <Greetings />,
+//     <SignIn />,
+//     <SignUp />,
+//     <ConfirmSignIn />,
+//     <ConfirmSignUp />,
+//     <VerifyContact />,
+//     <ForgotPassword />,
+//     <RequireNewPassword />
+//   ])
+// )

--- a/App.tsx
+++ b/App.tsx
@@ -41,7 +41,6 @@ import { enableSentry } from "@lib/Sentry"
 import { Auth } from "aws-amplify"
 import { Native as SentryNative } from "sentry-expo"
 import awsconfig from "./src/aws-exports"
-import { mockExpoLocationObject } from "@lib/location"
 
 Geo.configure(awsconfig)
 Auth.configure(awsconfig)
@@ -104,15 +103,15 @@ const App = () => {
   )
 }
 
-export default SentryNative.wrap(App)
-//   withAuthenticator(App, false, [
-//     <Greetings />,
-//     <SignIn />,
-//     <SignUp />,
-//     <ConfirmSignIn />,
-//     <ConfirmSignUp />,
-//     <VerifyContact />,
-//     <ForgotPassword />,
-//     <RequireNewPassword />
-//   ])
-// )
+export default SentryNative.wrap(
+  withAuthenticator(App, false, [
+    <Greetings />,
+    <SignIn />,
+    <SignUp />,
+    <ConfirmSignIn />,
+    <ConfirmSignUp />,
+    <VerifyContact />,
+    <ForgotPassword />,
+    <RequireNewPassword />
+  ])
+)

--- a/auth/ChangePassword.test.tsx
+++ b/auth/ChangePassword.test.tsx
@@ -2,18 +2,33 @@ import { Password } from "@auth/Password"
 import { useChangePasswordForm } from "@auth/ChangePasswordForm"
 import { act, renderHook, waitFor } from "@testing-library/react-native"
 import { captureAlerts } from "../tests/helpers/Alerts"
-import { TestQueryClientProvider } from "../tests/helpers/ReactQuery"
+import {
+  TestQueryClientProvider,
+  createTestQueryClient
+} from "../tests/helpers/ReactQuery"
+import { neverPromise } from "../tests/helpers/Promise"
 
 describe("ChangePassword tests", () => {
   beforeEach(() => jest.resetAllMocks())
 
   describe("UseChangePassword tests", () => {
+    const queryClient = createTestQueryClient()
+    beforeEach(() => queryClient.clear())
+
+    afterAll(() => {
+      queryClient.resetQueries()
+      queryClient.clear()
+    })
+
     const changePassword = jest.fn()
     const onSuccess = jest.fn()
+
     const { tapAlertButton, alertPresentationSpy } = captureAlerts()
+
     const retry = async () => {
       await tapAlertButton("Try Again")
     }
+
     const renderChangePassword = () => {
       return renderHook(
         () =>
@@ -23,7 +38,9 @@ describe("ChangePassword tests", () => {
           }),
         {
           wrapper: ({ children }) => (
-            <TestQueryClientProvider>{children}</TestQueryClientProvider>
+            <TestQueryClientProvider client={queryClient}>
+              {children}
+            </TestQueryClientProvider>
           )
         }
       )
@@ -70,16 +87,35 @@ describe("ChangePassword tests", () => {
       })
     })
 
+    it("should have a submitting status while in process in submitting", async () => {
+      changePassword.mockImplementation(neverPromise)
+      const { result } = renderChangePassword()
+
+      act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
+      act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
+      act(() => {
+        result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
+      })
+
+      expect(result.current.submission.status).toEqual("valid")
+
+      act(() => result.current.submission.submit?.())
+
+      await waitFor(() => {
+        expect(result.current.submission.status).toEqual("submitting")
+      })
+    })
+
     it("should have a successful submission flow", async () => {
       changePassword.mockImplementation(
-        async (uncheckedOldPass: string, newPass: Password) => {
+        (uncheckedOldPass: string, newPass: Password) => {
           if (
             uncheckedOldPass === "ReturnToAll32@" &&
             newPass.rawValue === "OblivionAwaits43#"
           ) {
-            return "valid"
+            return Promise.resolve("valid")
           }
-          return "invalid"
+          return Promise.resolve("invalid")
         }
       )
 
@@ -87,19 +123,15 @@ describe("ChangePassword tests", () => {
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
-      act(() =>
+      act(() => {
         result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
-      )
+      })
 
       expect(result.current.submission.status).toEqual("valid")
 
       act(() => result.current.submission.submit?.())
-      await waitFor(() => {
-        expect(result.current.submission.status).toEqual("submitting")
-      })
-      await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalled()
-      })
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
 
     it("should have a failed submission flow", async () => {
@@ -116,15 +148,13 @@ describe("ChangePassword tests", () => {
       expect(result.current.submission.status).toEqual("valid")
 
       act(() => result.current.submission.submit?.())
-      await waitFor(() => {
-        expect(result.current.submission.status).toEqual("submitting")
-      })
+
       await waitFor(() => {
         expect(result.current.submission.status).toEqual("invalid")
-        expect(result.current.submission.error).toEqual(
-          "incorrect-current-password"
-        )
       })
+      expect(result.current.submission.error).toEqual(
+        "incorrect-current-password"
+      )
     })
 
     it("should be able to retry when it gets an error", async () => {
@@ -143,16 +173,14 @@ describe("ChangePassword tests", () => {
       expect(result.current.submission.status).toEqual("valid")
 
       act(() => result.current.submission.submit?.())
-      await waitFor(() => {
-        expect(result.current.submission.status).toEqual("submitting")
-      })
+
       await waitFor(() => {
         expect(alertPresentationSpy).toHaveBeenCalled()
       })
+
       await act(async () => await retry())
-      await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalled()
-      })
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
 
     it("should not produce error messages when no input is initially given", () => {

--- a/auth/ChangePasswordForm.tsx
+++ b/auth/ChangePasswordForm.tsx
@@ -14,7 +14,7 @@ import {
   ViewStyle
 } from "react-native"
 import { TouchableOpacity } from "react-native-gesture-handler"
-import { useMutation } from "react-query"
+import { useMutation } from "@tanstack/react-query"
 
 export type ChangePasswordResult = "valid" | "invalid" | "incorrect-password"
 
@@ -65,7 +65,6 @@ export const useChangePasswordForm = ({
         return await onSubmitted(fields.currentPassword, passwordResult)
       }
     },
-
     {
       onSuccess,
       onError: () => {

--- a/components/TiFQueryClientProvider.tsx
+++ b/components/TiFQueryClientProvider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react"
-import { QueryClient, QueryClientProvider } from "react-query"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 const tiFQueryClient = new QueryClient()
 

--- a/hooks/Geocoding.tsx
+++ b/hooks/Geocoding.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, createContext, useContext } from "react"
 import { LocationCoordinate2D, TiFLocation } from "../lib/location"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { QueryHookOptions } from "@lib/ReactQuery"
 
 /**

--- a/hooks/UserLocation.tsx
+++ b/hooks/UserLocation.tsx
@@ -5,7 +5,7 @@ import {
   LocationOptions,
   PermissionResponse
 } from "expo-location"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 
 /**
  * A query hook to load the user's current location from expo.

--- a/hooks/useApiQuery.ts
+++ b/hooks/useApiQuery.ts
@@ -1,6 +1,6 @@
 import { ApiSchema } from "@api-client/api-schema"
 import { apiClient } from "@api-client/index"
-import { UseQueryOptions, UseQueryResult, useQuery } from "react-query"
+import { UseQueryOptions, UseQueryResult, useQuery } from "@tanstack/react-query"
 
 type ApiPath = keyof typeof ApiSchema
 type ApiMethod<P extends ApiPath> = keyof (typeof ApiSchema)[P]

--- a/lib/ReactQuery.ts
+++ b/lib/ReactQuery.ts
@@ -1,4 +1,4 @@
-import { UseQueryOptions } from "react-query"
+import { UseQueryOptions } from "@tanstack/react-query"
 
 // TODO: - React query module
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@react-navigation/stack": "^5.9.1",
         "@sentry/react-native": "4.15.2",
         "@sinonjs/commons": "3.0.0",
+        "@tanstack/react-query": "^4.33.0",
         "@turf/boolean-clockwise": "6.5.0",
         "@turf/invariant": "6.5.0",
         "amazon-cognito-identity-js": "^6.2.0",
@@ -101,7 +102,6 @@
         "react-native-svg": "13.4.0",
         "react-native-web": "~0.18.11",
         "react-navigation": "^4.4.4",
-        "react-query": "^3.39.3",
         "regenerator-runtime": "^0.13.11",
         "sentry-expo": "^6.2.0",
         "tlds": "^1.221.1",
@@ -113,7 +113,7 @@
         "@aws-amplify/cli": "^10.8.1",
         "@babel/core": "^7.20.0",
         "@faker-js/faker": "^7.6.0",
-        "@testing-library/react-native": "^10.1.1",
+        "@testing-library/react-native": "12.2",
         "@types/jest": "^29.4.0",
         "@types/linkify-it": "^3.0.2",
         "@types/ngeohash": "^0.6.4",
@@ -140,7 +140,7 @@
         "jest-expo": "^48.0.0",
         "lint-staged": "^13.1.1",
         "prettier": "^2.8.8",
-        "react-test-renderer": "^18.0.0",
+        "react-test-renderer": "18.2",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -15410,9 +15410,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -17688,18 +17688,59 @@
         "node": ">=10"
       }
     },
-    "node_modules/@testing-library/react-native": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
-      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
-      "dev": true,
+    "node_modules/@tanstack/query-core": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
       "dependencies": {
-        "pretty-format": "^27.0.0"
+        "@tanstack/query-core": "4.33.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": ">=16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.2.2.tgz",
+      "integrity": "sha512-aLr7YQ6pyn8PbLmdbtADG2aKcmarTLI7VhgWNVzJLxQHOtsDxLpJGKMSw10j406BE/GyGHbB0Gln3Of8/2TjnA==",
+      "dev": true,
+      "dependencies": {
+        "pretty-format": "^29.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=28.0.0",
+        "react": ">=16.8.0",
         "react-native": ">=0.59",
-        "react-test-renderer": ">=16.0.0"
+        "react-test-renderer": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -19713,21 +19754,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
-      }
-    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -21263,11 +21289,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff-sequences": {
       "version": "29.4.3",
@@ -26725,26 +26746,6 @@
         "jest": "bin/jest.js"
       }
     },
-    "node_modules/jest-expo/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
-    },
-    "node_modules/jest-expo/node_modules/react-test-renderer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "react-shallow-renderer": "^16.15.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
     "node_modules/jest-get-type": {
       "version": "29.4.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
@@ -28272,11 +28273,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -29646,15 +29642,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -30931,11 +30918,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -31190,14 +31172,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -31713,11 +31687,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -32426,17 +32395,17 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -32452,9 +32421,9 @@
       }
     },
     "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "node_modules/process-nextick-args": {
@@ -33434,31 +33403,6 @@
         "react-native-safe-area-view": "^0.14.9"
       }
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -33480,17 +33424,17 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
-      "integrity": "sha512-SyZTP/FSkwfiKOZuTZiISzsrC8A80KNlQ8PyyoGoOq+VzMAab6Em1POK/CiX3+XyXG6oiJa1C53zYDbdrJu9fw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
       "dependencies": {
-        "react-is": "^18.0.0",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.21.0"
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
@@ -33498,15 +33442,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
-      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "node_modules/read-env": {
       "version": "1.3.0",
@@ -33665,11 +33600,6 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
-    },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "node_modules/remove-trailing-slash": {
       "version": "0.1.1",
@@ -35811,15 +35741,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -49149,9 +49070,9 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "requires": {
         "@sinclair/typebox": "^0.27.8"
       }
@@ -50846,13 +50767,27 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tanstack/query-core": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
+      "requires": {
+        "@tanstack/query-core": "4.33.0",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@testing-library/react-native": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
-      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-12.2.2.tgz",
+      "integrity": "sha512-aLr7YQ6pyn8PbLmdbtADG2aKcmarTLI7VhgWNVzJLxQHOtsDxLpJGKMSw10j406BE/GyGHbB0Gln3Of8/2TjnA==",
       "dev": true,
       "requires": {
-        "pretty-format": "^27.0.0"
+        "pretty-format": "^29.0.0"
       }
     },
     "@tootallnate/once": {
@@ -52472,21 +52407,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -53680,11 +53600,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff-sequences": {
       "version": "29.4.3",
@@ -57715,25 +57630,6 @@
         "json5": "^2.1.0",
         "lodash": "^4.17.19",
         "react-test-renderer": "18.2.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
-        "react-test-renderer": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
-          "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
-          "dev": true,
-          "requires": {
-            "react-is": "^18.2.0",
-            "react-shallow-renderer": "^16.15.0",
-            "scheduler": "^0.23.0"
-          }
-        }
       }
     },
     "jest-get-type": {
@@ -58851,11 +58747,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -59860,15 +59751,6 @@
       "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
       }
     },
     "md5": {
@@ -60932,11 +60814,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -61139,14 +61016,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "requires": {
-        "big-integer": "^1.6.16"
       }
     },
     "nanoid": {
@@ -61531,11 +61400,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
-    },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "on-finished": {
       "version": "2.4.1",
@@ -62044,14 +61908,14 @@
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
     },
     "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -62061,9 +61925,9 @@
           "dev": true
         },
         "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
       }
@@ -62808,16 +62672,6 @@
         }
       }
     },
-    "react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      }
-    },
     "react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -62833,14 +62687,14 @@
       }
     },
     "react-test-renderer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
-      "integrity": "sha512-SyZTP/FSkwfiKOZuTZiISzsrC8A80KNlQ8PyyoGoOq+VzMAab6Em1POK/CiX3+XyXG6oiJa1C53zYDbdrJu9fw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
       "requires": {
-        "react-is": "^18.0.0",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.21.0"
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
       },
       "dependencies": {
         "react-is": {
@@ -62848,15 +62702,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
-        },
-        "scheduler": {
-          "version": "0.21.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
-          "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0"
-          }
         }
       }
     },
@@ -62990,11 +62835,6 @@
           "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
         }
       }
-    },
-    "remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "remove-trailing-slash": {
       "version": "0.1.1",
@@ -64628,15 +64468,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,6 @@
   "engines": {
     "npm": ">=8.3.0"
   },
-  "overrides": {
-    "@react-native-picker/picker": {
-      "react": "18"
-    },
-    "@testing-library/react-native": {
-      "react": "18",
-      "react-test-renderer": "18.0.0"
-    }
-  },
   "dependencies": {
     "@alessiocancian/react-native-actionsheet": "^3.2.0",
     "@aws-amplify/api": "^4.0.63",
@@ -52,6 +43,7 @@
     "@react-navigation/stack": "^5.9.1",
     "@sentry/react-native": "4.15.2",
     "@sinonjs/commons": "3.0.0",
+    "@tanstack/react-query": "^4.33.0",
     "@turf/boolean-clockwise": "6.5.0",
     "@turf/invariant": "6.5.0",
     "amazon-cognito-identity-js": "^6.2.0",
@@ -121,7 +113,6 @@
     "react-native-svg": "13.4.0",
     "react-native-web": "~0.18.11",
     "react-navigation": "^4.4.4",
-    "react-query": "^3.39.3",
     "regenerator-runtime": "^0.13.11",
     "sentry-expo": "^6.2.0",
     "tlds": "^1.221.1",
@@ -133,7 +124,7 @@
     "@aws-amplify/cli": "^10.8.1",
     "@babel/core": "^7.20.0",
     "@faker-js/faker": "^7.6.0",
-    "@testing-library/react-native": "^10.1.1",
+    "@testing-library/react-native": "12.2",
     "@types/jest": "^29.4.0",
     "@types/linkify-it": "^3.0.2",
     "@types/ngeohash": "^0.6.4",
@@ -160,7 +151,7 @@
     "jest-expo": "^48.0.0",
     "lint-staged": "^13.1.1",
     "prettier": "^2.8.8",
-    "react-test-renderer": "^18.0.0",
+    "react-test-renderer": "18.2",
     "typescript": "^4.9.5"
   },
   "private": true

--- a/screens/EventAttendeesList/AttendeesListScreen.tsx
+++ b/screens/EventAttendeesList/AttendeesListScreen.tsx
@@ -4,7 +4,7 @@ import { delayData } from "@lib/DelayData"
 import { AttendeeEntry } from "@screens/EventAttendeesList/attendeeEntry"
 import React from "react"
 import { FlatList, StyleProp, StyleSheet, View, ViewStyle } from "react-native"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { AttendeeListMocks } from "./AttendeesMocks"
 
 export const AttendeesListScreen = () => {

--- a/screens/EventFormScreen.tsx
+++ b/screens/EventFormScreen.tsx
@@ -1,6 +1,5 @@
 import { EventFormBottomSheet } from "@components/eventForm/BottomSheet"
 import { SaveEventRequest } from "@lib/events"
-import { createStackNavigator } from "@react-navigation/stack"
 import React from "react"
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native"
 import { Divider } from "react-native-elements"
@@ -14,8 +13,6 @@ import {
   EventFormToolbar,
   EventFormValues
 } from "../components/eventForm"
-
-const Stack = createStackNavigator()
 
 export type EventFormScreenProps = {
   initialValues: EventFormValues
@@ -35,27 +32,13 @@ const EventFormScreen = ({
     onSubmit={onSubmit}
     onDismiss={onDismiss}
   >
-    <Stack.Navigator>
-      <Stack.Screen
-        name="Event"
-        component={TextFields}
-        options={{
-          title: "",
-          headerRight: () => (
-            <View style={styles.padding}>
-              <EventFormSubmitButton label={submissionLabel} />
-            </View>
-          ),
-          headerLeft: () => (
-            <View style={styles.padding}>
-              <EventFormDismissButton />
-            </View>
-          ),
-          headerStyle: styles.header,
-          cardStyle: styles.card
-        }}
-      />
-    </Stack.Navigator>
+    <View style={styles.padding}>
+      <EventFormSubmitButton label={submissionLabel} />
+    </View>
+    <View style={styles.padding}>
+      <EventFormDismissButton />
+    </View>
+    <TextFields />
     <Footer />
     <EventFormBottomSheet />
   </EventForm>

--- a/screens/ExploreEvents/models.ts
+++ b/screens/ExploreEvents/models.ts
@@ -52,7 +52,7 @@ export const initialCenterToRegion = (center: ExploreEventsInitialCenter) => {
  * Data representation of events explored in a given area.
  */
 export type ExploreEventsData =
-  | { status: "loading"; events?: CurrentUserEvent[]; retry?: () => void }
+  | { status: "loading"; events?: CurrentUserEvent[] }
   | { status: "error"; events?: CurrentUserEvent[]; retry: () => void }
-  | { status: "no-results"; events: []; retry?: () => void }
-  | { status: "success"; events: CurrentUserEvent[]; retry?: undefined }
+  | { status: "no-results"; events: [] }
+  | { status: "success"; events: CurrentUserEvent[] }

--- a/screens/LocationSearch/Picker.tsx
+++ b/screens/LocationSearch/Picker.tsx
@@ -21,7 +21,7 @@ import {
 } from "./SearchResultView"
 import { LocationAccuracy, LocationObject } from "expo-location"
 import { useLocationsSearchQueryObject } from "./state"
-import { UseQueryResult, useQuery } from "react-query"
+import { UseQueryResult, useQuery } from "@tanstack/react-query"
 import { LocationSearchResultsData } from "./models"
 import { LocationSearchIconView } from "./Icon"
 import { AppStyles } from "@lib/AppColorStyle"
@@ -64,7 +64,7 @@ const queryResultToDataResult = ({
     return { status: "no-results", data: [] }
   } else if (status === "success") {
     return { status, data }
-  } else if (status === "loading" || status === "idle") {
+  } else if (status === "loading") {
     return { status: "loading", data: undefined }
   }
   return { status: "error", data: undefined }

--- a/tests/Haptics.test.tsx
+++ b/tests/Haptics.test.tsx
@@ -13,6 +13,16 @@ describe("Haptics tests", () => {
   describe("useHaptics tests", () => {
     beforeEach(async () => await AsyncStorage.clear())
 
+    it("should mute and unmute its state", () => {
+      const { result } = renderUseHaptics(new TestHaptics())
+
+      act(() => result.current.mute())
+      expect(result.current.isMuted).toEqual(true)
+
+      act(() => result.current.unmute())
+      expect(result.current.isMuted).toEqual(false)
+    })
+
     it("should persist mute state in AsyncStorage", async () => {
       const { result } = renderUseHaptics(new TestHaptics())
 
@@ -70,10 +80,10 @@ describe("Haptics tests", () => {
       testHaptics.unmute()
       await AsyncStorage.setItem(IS_HAPTICS_MUTED_KEY, "true")
 
-      renderUseHaptics(testHaptics)
+      const { result } = renderUseHaptics(testHaptics)
 
-      await waitFor(() => expect(testHaptics.isMuted).toEqual(false))
-      expect(testHaptics.isMuted).toEqual(true)
+      await waitFor(() => expect(testHaptics.isMuted).toEqual(true))
+      expect(result.current.isMuted).toEqual(true)
     })
 
     it("should unmute when rendered if persisted value indicates unmute", async () => {
@@ -81,9 +91,10 @@ describe("Haptics tests", () => {
       testHaptics.mute()
       await AsyncStorage.setItem(IS_HAPTICS_MUTED_KEY, "false")
 
-      renderUseHaptics(testHaptics)
+      const { result } = renderUseHaptics(testHaptics)
 
       await waitFor(() => expect(testHaptics.isMuted).toEqual(false))
+      expect(result.current.isMuted).toEqual(false)
     })
 
     const renderUseHaptics = (haptics: Haptics) => {

--- a/tests/Reporting.test.tsx
+++ b/tests/Reporting.test.tsx
@@ -1,5 +1,6 @@
 import { ReportFormView } from "@screens/Reporting"
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -62,7 +63,7 @@ describe("Reporting tests", () => {
 
         // NB: Wait for the submission to finish before checking this. This prevents a bug
         // where the user can somehow tap another selection when doing a navigation animation.
-        await waitForSubmission
+        await act(async () => await waitForSubmission)
         expect(canSubmitAnyReportReason()).toEqual(false)
       })
 
@@ -78,7 +79,7 @@ describe("Reporting tests", () => {
 
         // NB: Make it so that the user explicitly has to dismiss the error alert before re-allowing
         // submissions. This ensures that they cannot somehow submit 2 reasons at once.
-        await waitForSubmission
+        await act(async () => await waitForSubmission)
         expect(canSubmitAnyReportReason()).toEqual(false)
 
         await dismissErrorAlert()

--- a/tests/events/EventForm/EventFormScreen.test.tsx
+++ b/tests/events/EventForm/EventFormScreen.test.tsx
@@ -3,7 +3,6 @@ import { GeocodingFunctionsProvider } from "@hooks/Geocoding"
 import { HapticsProvider } from "@lib/Haptics"
 import { dateRange } from "@lib/date"
 import { EventColors } from "@lib/events"
-import { NavigationContainer } from "@react-navigation/native"
 import EventFormScreen from "@screens/EventFormScreen"
 import {
   fireEvent,
@@ -11,13 +10,12 @@ import {
   screen,
   waitFor
 } from "@testing-library/react-native"
-import { QueryClient } from "react-query"
+import { QueryClient } from "@tanstack/react-query"
 import { captureAlerts } from "../../helpers/Alerts"
 import { TestHaptics } from "../../helpers/Haptics"
 import { neverPromise } from "../../helpers/Promise"
 import {
   TestQueryClientProvider,
-  cleanupTestQueryClient,
   createTestQueryClient
 } from "../../helpers/ReactQuery"
 import {
@@ -36,7 +34,10 @@ const testLocation = { latitude: 45.0, longitude: -121.0 }
 const queryClient = createTestQueryClient()
 
 describe("EventFormScreen tests", () => {
-  beforeEach(() => jest.resetAllMocks())
+  beforeEach(() => {
+    jest.resetAllMocks()
+    queryClient.clear()
+  })
 
   it("should be able to edit and submit a form with a preselected location", async () => {
     renderEventFormScreen(queryClient, {
@@ -158,8 +159,6 @@ describe("EventFormScreen tests", () => {
     submit()
     await waitFor(() => expect(canSubmit()).toEqual(true))
   }) */
-
-  afterAll(() => cleanupTestQueryClient(queryClient))
 })
 
 const editedTitle = "Test title"
@@ -176,23 +175,18 @@ const renderEventFormScreen = (
   values: EventFormValues
 ) => {
   render(
-    <NavigationContainer>
-      <TestQueryClientProvider client={queryClient}>
-        <HapticsProvider
-          isSupportedOnDevice={false}
-          haptics={new TestHaptics()}
-        >
-          <GeocodingFunctionsProvider reverseGeocode={neverPromise}>
-            <EventFormScreen
-              submissionLabel={testSubmissionLabel}
-              initialValues={values}
-              onSubmit={submitAction}
-              onDismiss={dismissAction}
-            />
-          </GeocodingFunctionsProvider>
-        </HapticsProvider>
-      </TestQueryClientProvider>
-    </NavigationContainer>
+    <TestQueryClientProvider client={queryClient}>
+      <HapticsProvider isSupportedOnDevice={false} haptics={new TestHaptics()}>
+        <GeocodingFunctionsProvider reverseGeocode={neverPromise}>
+          <EventFormScreen
+            submissionLabel={testSubmissionLabel}
+            initialValues={values}
+            onSubmit={submitAction}
+            onDismiss={dismissAction}
+          />
+        </GeocodingFunctionsProvider>
+      </HapticsProvider>
+    </TestQueryClientProvider>
   )
 }
 

--- a/tests/events/EventForm/LocationBanner.test.tsx
+++ b/tests/events/EventForm/LocationBanner.test.tsx
@@ -3,7 +3,6 @@ import {
   EventFormLocationBanner,
   EventFormLocationInfo
 } from "@components/eventForm"
-import { SetDependencyValue } from "@lib/dependencies"
 import { render, screen, waitFor } from "@testing-library/react-native"
 import "../../helpers/Matchers"
 import { TestQueryClientProvider } from "../../helpers/ReactQuery"

--- a/tests/helpers/Alerts.ts
+++ b/tests/helpers/Alerts.ts
@@ -1,4 +1,5 @@
 /* global jest */
+import { act } from "@testing-library/react-native"
 import { Alert, AlertButton } from "react-native"
 
 /**
@@ -39,7 +40,7 @@ export const captureAlerts = () => {
       }
 
       if (targetButton.onPress) {
-        await targetButton.onPress()
+        await act(async () => await targetButton.onPress())
       }
 
       dismissedCalls = [...dismissedCalls, mostRecentCall]

--- a/tests/helpers/ReactQuery.tsx
+++ b/tests/helpers/ReactQuery.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, useEffect, useMemo } from "react"
-import { QueryClient, QueryClientProvider } from "react-query"
+import React, { ReactNode, useMemo } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 /**
  * Creates a `QueryClient` suitable for testing.
@@ -36,18 +36,19 @@ export const createTestQueryClient = () => {
         retry: false,
         retryDelay: 0,
         // NB: This prevents CI from hanging endlessly.
-        cacheTime: 0
+        cacheTime: Infinity
+      },
+      mutations: {
+        cacheTime: Infinity,
+        retry: false
       }
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: process.env.NODE_ENV === "test" ? () => {} : console.error
     }
   })
-}
-
-/**
- * Use this inside of an `afterAll` to make sure CI doesn't break.
- */
-export const cleanupTestQueryClient = (client: QueryClient) => {
-  client.resetQueries()
-  client.clear()
 }
 
 /**
@@ -69,10 +70,6 @@ export const TestQueryClientProvider = ({
     if (client) return client
     return createTestQueryClient()
   }, [client])
-
-  useEffect(() => {
-    cleanupTestQueryClient(queryClient)
-  }, [queryClient])
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/tests/helpers/Timers.ts
+++ b/tests/helpers/Timers.ts
@@ -2,8 +2,6 @@
  * Fakes jest timers for the duration of each test.
  */
 export const fakeTimers = () => {
-  beforeEach(() => {
-    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] })
-  })
+  beforeEach(() => jest.useFakeTimers())
   afterEach(() => jest.useRealTimers())
 }

--- a/tests/location/LocationSearch.test.tsx
+++ b/tests/location/LocationSearch.test.tsx
@@ -113,7 +113,7 @@ describe("LocationSearch tests", () => {
         await waitForCurrentLocationOptionToLoad()
 
         expect(
-          await locationWithName(searchResult.location.placemark.name!)
+          await waitForLocationWithName(searchResult.location.placemark.name!)
         ).toBeDisplayed()
         expect(searchForLocations).toHaveBeenCalledWith(
           LocationsSearchQuery.empty,
@@ -137,7 +137,9 @@ describe("LocationSearch tests", () => {
         queryUserCoordinates.mockRejectedValueOnce(new Error())
         renderPicker()
 
-        await selectLocationWithName(searchResult.location.placemark.name!)
+        await waitToSelectLocationWithName(
+          searchResult.location.placemark.name!
+        )
         expect(selectedLocation).toMatchObject(searchResult.location)
         expect(savedLocation).toMatchObject(searchResult.location)
       })
@@ -158,7 +160,10 @@ describe("LocationSearch tests", () => {
 
       it("should debounce when search text changes", async () => {
         queryUserCoordinates.mockRejectedValueOnce(new Error())
-        searchForLocations.mockImplementation(neverPromise)
+        const result = mockLocationSearchResult()
+        searchForLocations
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([result])
         renderPicker()
 
         let searchText = "Hello World!"
@@ -186,6 +191,9 @@ describe("LocationSearch tests", () => {
           new LocationsSearchQuery(searchText),
           undefined
         )
+        expect(
+          await waitForLocationWithName(result.location.placemark.name!)
+        ).toBeDisplayed()
       })
 
       it("should indicate that no results were found when no options available with non-empty search", async () => {
@@ -261,11 +269,11 @@ describe("LocationSearch tests", () => {
         return await screen.findByText("Use current location")
       }
 
-      const selectLocationWithName = async (name: string) => {
-        return fireEvent.press(await locationWithName(name))
+      const waitToSelectLocationWithName = async (name: string) => {
+        return fireEvent.press(await waitForLocationWithName(name))
       }
 
-      const locationWithName = async (name: string) => {
+      const waitForLocationWithName = async (name: string) => {
         return await screen.findByText(name)
       }
 

--- a/tests/location/LocationSearch.test.tsx
+++ b/tests/location/LocationSearch.test.tsx
@@ -101,10 +101,12 @@ describe("LocationSearch tests", () => {
 
       test("loading results at the user's location", async () => {
         const userLocation = mockExpoLocationObject()
-        queryUserCoordinates.mockResolvedValue(userLocation)
+        queryUserCoordinates.mockResolvedValueOnce(userLocation)
 
         const searchResult = mockLocationSearchResult()
-        searchForLocations.mockResolvedValue([searchResult])
+        searchForLocations
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([searchResult])
 
         renderPicker()
 
@@ -121,7 +123,7 @@ describe("LocationSearch tests", () => {
 
       it("can select the user's coordinates when user coordinates available", async () => {
         const userLocation = mockExpoLocationObject()
-        queryUserCoordinates.mockResolvedValue(userLocation)
+        queryUserCoordinates.mockResolvedValueOnce(userLocation)
         searchForLocations.mockImplementation(neverPromise)
         renderPicker()
 
@@ -131,7 +133,8 @@ describe("LocationSearch tests", () => {
 
       test("when option is selected, it is also saved somewhere", async () => {
         const searchResult = mockLocationSearchResult()
-        searchForLocations.mockResolvedValue([searchResult])
+        searchForLocations.mockResolvedValueOnce([searchResult])
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
         renderPicker()
 
         await selectLocationWithName(searchResult.location.placemark.name!)
@@ -140,18 +143,21 @@ describe("LocationSearch tests", () => {
       })
 
       it("should indicate an error when loading options fails", async () => {
-        searchForLocations.mockRejectedValue(new Error())
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
+        searchForLocations.mockRejectedValueOnce(new Error())
         renderPicker()
         await waitFor(() => expect(errorIndicator()).toBeDisplayed())
       })
 
       it("should indicate that there are no recents when no options available with empty search", async () => {
-        searchForLocations.mockResolvedValue([])
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
+        searchForLocations.mockResolvedValueOnce([])
         renderPicker()
         await waitFor(() => expect(noRecentsIndicator()).toBeDisplayed())
       })
 
       it("should debounce when search text changes", async () => {
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
         searchForLocations.mockImplementation(neverPromise)
         renderPicker()
 
@@ -183,7 +189,10 @@ describe("LocationSearch tests", () => {
       })
 
       it("should indicate that no results were found when no options available with non-empty search", async () => {
-        searchForLocations.mockResolvedValue([])
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
+        searchForLocations
+          .mockResolvedValueOnce([mockLocationSearchResult()])
+          .mockResolvedValueOnce([])
         renderPicker()
 
         const searchText = "Chuck E. Cheese"
@@ -194,6 +203,7 @@ describe("LocationSearch tests", () => {
       })
 
       it("displays a loading indicator when searched results have not yet loaded", async () => {
+        queryUserCoordinates.mockRejectedValueOnce(new Error())
         searchForLocations.mockImplementation(neverPromise)
         renderPicker()
         await waitFor(() => expect(loadingIndicator()).toBeDisplayed())


### PR DESCRIPTION
Recently it was discovered that our version of react native testing library was a little outdated, but the main problem that triggered this PR was that `waitFor` was acting weird. In particular, it required code to be written like this:
```ts
// 🔴 ???
await waitFor(() => {})

// ✅ This passes because of the prior waitFor
expect(result.current.status).toEqual("success")
expect(result.current.status).toEqual({...})
```
And code like this:
```ts
await waitFor(() => expect(result.status).toEqual("success"))
```
Would fail when it really shouldn't.

Well the good news is that this happened to be a bug with the old version of rntl, so it was updated here. However, this broke a few tests, particularly in the explore and change password features, since they were making assertions based on the old flawed style of `waitFor`. Therefore, I went and fixed them, but also improved some of the assertions. Additionally, I also went ahead and updated react query to the latest version as I had accidentally thought that it was an accomplice in fixing some of the aftermath of updating rntl, but the reality was a problem with `TestQueryClientProvider` which now no longer performs automatic query client cleanup if you need to use a custom query client for a feature's test (I think this is only the explore feature atm).

Additionally, there were some act warnings with the report screem tests, so I fixed those too. And I also fixed the "internal react errors" which were caused by `NavigationContainer` in the event form tests. Since the event form is getting a redesign in the near future, I removed all unnecessary react-navigation code from `EventFormScreen` which negatively affects the look, but this is void for obvious reasons.

In other words, there shouldn't be anymore flaky test infrastructure at this point.