### PR TITLE
Remove Autocorrect from Password Text Fields

### DIFF
--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -146,6 +146,9 @@ export const ShadedPasswordTextField = ({
           }
         />
       }
+      autoCorrect={false}
+      autoCapitalize="none"
+      autoComplete="password"
       {...props}
     />
   )


### PR DESCRIPTION
Something was weird when I was trying to test entering passwords, turns out it was the beloved autocorrect. Yeah, lets not give the users that pleasure either.