### PR TITLE
Generic Verification Code Form

### DIFF
--- a/.storybook/.ondevice/Storybook.tsx
+++ b/.storybook/.ondevice/Storybook.tsx
@@ -31,6 +31,9 @@ import LocationSearchMeta, {
 import SignUpMeta, {
   Basic as SignUpBasic
 } from "../components/SignUp/SignUp.stories"
+import VerifcationCodeMeta, {
+  Basic as VerifcationCodeBasic
+} from "../components/VerificationCode/VerifyCode.stories"
 
 // Create an array of stories
 const stories = [
@@ -78,6 +81,11 @@ const stories = [
     name: SignUpMeta.title,
     component: SignUpBasic,
     args: SignUpMeta.args
+  },
+  {
+    name: VerifcationCodeMeta.title,
+    component: VerifcationCodeBasic,
+    args: VerifcationCodeMeta.args
   }
   // Add more stories here...
 ]

--- a/.storybook/.ondevice/storybook.requires.js
+++ b/.storybook/.ondevice/storybook.requires.js
@@ -58,6 +58,7 @@ const getStories = () => {
     "./components/SettingsScreen/SettingsScreen.stories.tsx": require("../components/SettingsScreen/SettingsScreen.stories.tsx"),
     "./components/SignUp/SignUp.stories.tsx": require("../components/SignUp/SignUp.stories.tsx"),
     "./components/TextField/TextField.stories.tsx": require("../components/TextField/TextField.stories.tsx"),
+    "./components/VerificationCode/VerifyCode.stories.tsx": require("../components/VerificationCode/VerifyCode.stories.tsx"),
   };
 };
 

--- a/.storybook/components/SignUp/SignUp.stories.tsx
+++ b/.storybook/components/SignUp/SignUp.stories.tsx
@@ -10,7 +10,6 @@ import { ComponentMeta, ComponentStory } from "@storybook/react-native"
 import {
   CreateAccountUserHandleFormView,
   CreateAccountCredentialsFormView,
-  CreateAccountVerifyCodeView,
   CreateAccountEndingView
 } from "@auth/sign-up"
 import { SafeAreaProvider } from "react-native-safe-area-context"
@@ -41,11 +40,6 @@ export const Basic: SignUpStory = () => (
           name="changeHandle"
           options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
           component={HandleScreen}
-        />
-        <Stack.Screen
-          name="verifyCode"
-          options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
-          component={CreateAccountVerifyCodeView}
         />
         <Stack.Screen
           name="welcome"
@@ -79,10 +73,6 @@ const TestScreen = () => {
       <Button
         title="Change Handle Form"
         onPress={() => navigation.navigate("changeHandle")}
-      />
-      <Button
-        title="Verify Code Form"
-        onPress={() => navigation.navigate("verifyCode")}
       />
       <Button title="Welcome" onPress={() => navigation.navigate("welcome")} />
     </View>

--- a/.storybook/components/VerificationCode/VerifyCode.stories.tsx
+++ b/.storybook/components/VerificationCode/VerifyCode.stories.tsx
@@ -1,16 +1,23 @@
 import {
   BASE_HEADER_SCREEN_OPTIONS,
-  ChevronBackButton,
-  XMarkBackButton
+  ChevronBackButton
 } from "@components/Navigation"
 import { NavigationContainer, useNavigation } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
-import { AuthVerificationCodeView } from "@auth"
+import {
+  AuthVerificationCodeFormView,
+  EmailAddress,
+  USPhoneNumber,
+  useAuthVerificationCodeForm
+} from "@auth/index"
+import { RootSiblingParent } from "react-native-root-siblings"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { Button, View } from "react-native"
 import React, { useState } from "react"
+import { delayData } from "@lib/DelayData"
+import { TiFQueryClientProvider } from "@components/TiFQueryClientProvider"
 
 const VerifyCodeMeta: ComponentMeta<typeof SettingsScreen> = {
   title: "Verifcation Code"
@@ -23,31 +30,60 @@ type VerifyCodeStory = ComponentStory<typeof SettingsScreen>
 const Stack = createStackNavigator()
 
 export const Basic: VerifyCodeStory = () => (
-  <SafeAreaProvider>
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
-        <Stack.Screen name="test" component={TestScreen} />
-        <Stack.Screen
-          name="email"
-          options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
-          component={EmailScreen}
-        />
-        <Stack.Screen
-          name="phoneNumber"
-          options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
-          component={PhoneNumberScreen}
-        />
-      </Stack.Navigator>
-    </NavigationContainer>
-  </SafeAreaProvider>
+  <RootSiblingParent>
+    <TiFQueryClientProvider>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
+            <Stack.Screen name="test" component={TestScreen} />
+            <Stack.Screen
+              name="email"
+              options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
+              component={EmailScreen}
+            />
+            <Stack.Screen
+              name="phoneNumber"
+              options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
+              component={PhoneNumberScreen}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </TiFQueryClientProvider>
+  </RootSiblingParent>
 )
 
 const EmailScreen = () => {
-  return <AuthVerificationCodeView />
+  const email = EmailAddress.parse("peacock69@gmail.com")!
+  const form = useAuthVerificationCodeForm({
+    checkCode: async () => await delayData(true, 1500),
+    resendCode: async () => await delayData(undefined, 1000),
+    onSuccess: () => console.log("success")
+  })
+  console.log("Code resend status", form.resendCodeStatus)
+  return (
+    <AuthVerificationCodeFormView
+      {...form}
+      codeReceiverName={email.formattedForPrivacy}
+    />
+  )
 }
 
 const PhoneNumberScreen = () => {
-  return <AuthVerificationCodeView />
+  const phoneNumber = USPhoneNumber.parse("1234567890")!
+  const form = useAuthVerificationCodeForm({
+    checkCode: async () => await delayData(false, 1500),
+    resendCode: async () => {
+      throw new Error("Lol")
+    },
+    onSuccess: () => console.log("success")
+  })
+  return (
+    <AuthVerificationCodeFormView
+      {...form}
+      codeReceiverName={phoneNumber.formattedForPrivacy}
+    />
+  )
 }
 
 const TestScreen = () => {

--- a/.storybook/components/VerificationCode/VerifyCode.stories.tsx
+++ b/.storybook/components/VerificationCode/VerifyCode.stories.tsx
@@ -1,0 +1,67 @@
+import {
+  BASE_HEADER_SCREEN_OPTIONS,
+  ChevronBackButton,
+  XMarkBackButton
+} from "@components/Navigation"
+import { NavigationContainer, useNavigation } from "@react-navigation/native"
+import { createStackNavigator } from "@react-navigation/stack"
+import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
+import { ComponentMeta, ComponentStory } from "@storybook/react-native"
+import { AuthVerificationCodeView } from "@auth"
+import { SafeAreaProvider } from "react-native-safe-area-context"
+import { Button, View } from "react-native"
+import React, { useState } from "react"
+
+const VerifyCodeMeta: ComponentMeta<typeof SettingsScreen> = {
+  title: "Verifcation Code"
+}
+
+export default VerifyCodeMeta
+
+type VerifyCodeStory = ComponentStory<typeof SettingsScreen>
+
+const Stack = createStackNavigator()
+
+export const Basic: VerifyCodeStory = () => (
+  <SafeAreaProvider>
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
+        <Stack.Screen name="test" component={TestScreen} />
+        <Stack.Screen
+          name="email"
+          options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
+          component={EmailScreen}
+        />
+        <Stack.Screen
+          name="phoneNumber"
+          options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
+          component={PhoneNumberScreen}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  </SafeAreaProvider>
+)
+
+const EmailScreen = () => {
+  return <AuthVerificationCodeView />
+}
+
+const PhoneNumberScreen = () => {
+  return <AuthVerificationCodeView />
+}
+
+const TestScreen = () => {
+  const navigation = useNavigation()
+  return (
+    <View>
+      <Button
+        title="Email Variant"
+        onPress={() => navigation.navigate("email")}
+      />
+      <Button
+        title="Phone Number variant"
+        onPress={() => navigation.navigate("phoneNumber")}
+      />
+    </View>
+  )
+}

--- a/.storybook/components/VerificationCode/VerifyCode.stories.tsx
+++ b/.storybook/components/VerificationCode/VerifyCode.stories.tsx
@@ -56,7 +56,7 @@ export const Basic: VerifyCodeStory = () => (
 const EmailScreen = () => {
   const email = EmailAddress.parse("peacock69@gmail.com")!
   const form = useAuthVerificationCodeForm({
-    checkCode: async () => await delayData(true, 1500),
+    checkCode: async () => await delayData(false, 7000),
     resendCode: async () => await delayData(undefined, 1000),
     onSuccess: () => console.log("success")
   })

--- a/auth/AuthSection.tsx
+++ b/auth/AuthSection.tsx
@@ -20,6 +20,8 @@ export type AuthSectionProps = {
   children: ReactNode
   footer?: JSX.Element
   callToActionTitle: string
+  isCallToActionDisabled?: boolean
+  onCallToActionTapped?: () => void
   style?: StyleProp<ViewStyle>
 }
 
@@ -35,6 +37,8 @@ export const AuthSectionView = ({
   children,
   footer,
   callToActionTitle,
+  isCallToActionDisabled,
+  onCallToActionTapped,
   style
 }: AuthSectionProps) => {
   const [footerHeight, setFooterHeight] = useState(0)
@@ -73,7 +77,12 @@ export const AuthSectionView = ({
           {footer}
           <PrimaryButton
             title={callToActionTitle}
-            style={styles.callToActionButton}
+            style={[
+              styles.callToActionButton,
+              { opacity: isCallToActionDisabled ? 0.5 : 1 }
+            ]}
+            disabled={isCallToActionDisabled}
+            onPressIn={onCallToActionTapped}
           />
         </View>
       </KeyboardAvoidingView>

--- a/auth/AuthSection.tsx
+++ b/auth/AuthSection.tsx
@@ -14,6 +14,46 @@ import {
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
+/**
+ * A base type that all Auth Forms should union with.
+ */
+export type BaseAuthFormSubmission =
+  | { status: "submittable"; submit: () => void }
+  | { status: "submitting" }
+
+export type AuthFormProps<Submission extends { status: string }> = {
+  title: string
+  description: string
+  children: ReactNode
+  footer?: JSX.Element
+  submissionTitle: string
+  submission: Submission | BaseAuthFormSubmission
+  style?: StyleProp<ViewStyle>
+}
+
+/**
+ * A base view for creating an auth screen that acts as a form.
+ *
+ * It automatically includes a title, description, a call to action at the bottom with an optional
+ * footer above it, and handles weird scrolling behaviors.
+ */
+export const AuthFormView = <Submission extends { status: string }>({
+  submission,
+  submissionTitle,
+  ...props
+}: AuthFormProps<Submission>) => (
+    <AuthSectionView
+      callToActionTitle={submissionTitle}
+      isCallToActionDisabled={submission.status !== "submittable"}
+      onCallToActionTapped={() => {
+        if (submission.status === "submittable") {
+          ;(submission as { submit: () => void }).submit()
+        }
+      }}
+      {...props}
+    />
+  )
+
 export type AuthSectionProps = {
   title: string
   description: string

--- a/auth/AuthTextFields.tsx
+++ b/auth/AuthTextFields.tsx
@@ -9,7 +9,7 @@ import { CircularIonicon, IoniconName } from "@components/common/Icons"
 import { StyleProp, ViewStyle } from "react-native"
 import { useFontScale } from "@hooks/Fonts"
 
-export type AuthFilledTextFieldProps = {
+export type AuthShadedTextFieldProps = {
   iconName: IoniconName
   iconBackgroundColor: string
   style?: StyleProp<ViewStyle>
@@ -23,7 +23,7 @@ export const AuthShadedTextField = ({
   iconBackgroundColor,
   style,
   ...props
-}: AuthFilledTextFieldProps) => {
+}: AuthShadedTextFieldProps) => {
   const textFieldHeight = 32 * useFontScale()
   return (
     <ShadedTextField
@@ -40,7 +40,7 @@ export const AuthShadedTextField = ({
   )
 }
 
-export type AuthFilledPasswordTextFieldProps = {
+export type AuthShadedPasswordTextFieldProps = {
   iconName: IoniconName
   iconBackgroundColor: string
   style?: StyleProp<ViewStyle>
@@ -54,7 +54,7 @@ export const AuthShadedPasswordTextField = ({
   iconBackgroundColor,
   style,
   ...props
-}: AuthFilledPasswordTextFieldProps) => {
+}: AuthShadedPasswordTextFieldProps) => {
   const textFieldHeight = 32 * useFontScale()
   return (
     <ShadedPasswordTextField

--- a/auth/Email.test.ts
+++ b/auth/Email.test.ts
@@ -1,0 +1,10 @@
+import { EmailAddress } from "./Email"
+
+describe("Email tests", () => {
+  describe("EmailAddress tests", () => {
+    test("formattedForPrivacy", () => {
+      const email = EmailAddress.parse("peacock69@gmail.com")!
+      expect(email.formattedForPrivacy).toEqual("p***9@gmail.com")
+    })
+  })
+})

--- a/auth/Email.ts
+++ b/auth/Email.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+
+const RawStringEmailAddressSchema = z.string().email()
+
+/**
+ * A data type representing a valid email address.
+ */
+export class EmailAddress {
+  private readonly rawValue: string
+
+  private constructor (rawValue: string) {
+    this.rawValue = rawValue
+  }
+
+  /**
+   * Formats this email address in a privacy centric way.
+   *
+   * (eg. peacock69@gmail.com -> p***9@gmail.com)
+   */
+  get formattedForPrivacy () {
+    const privacySuffix = this.rawValue.substring(
+      this.rawValue.indexOf("@") - 1
+    )
+    return `${this.rawValue[0]}***${privacySuffix}`
+  }
+
+  toString () {
+    return this.rawValue
+  }
+
+  /**
+   * Attempts to parse a raw string as an {@link EmailAddress} and returns undefined
+   * if it is unable to parse the email.
+   */
+  static parse (rawValue: string) {
+    const parseResult = RawStringEmailAddressSchema.safeParse(rawValue)
+    return parseResult.success ? new EmailAddress(parseResult.data) : undefined
+  }
+}

--- a/auth/PhoneNumber.test.ts
+++ b/auth/PhoneNumber.test.ts
@@ -1,0 +1,28 @@
+import { USPhoneNumber } from "./PhoneNumber"
+
+describe("PhoneNumber tests", () => {
+  describe("USPhoneNumber tests", () => {
+    it("fails to parse an input with letters", () => {
+      expect(USPhoneNumber.parse("123456789a")).toBeUndefined()
+    })
+
+    it("fails to parse an input with less than 10 digits", () => {
+      expect(USPhoneNumber.parse("1234567")).toBeUndefined()
+    })
+
+    it("fails to parse an input with more than 10 digits", () => {
+      expect(USPhoneNumber.parse("123456789012345")).toBeUndefined()
+    })
+
+    it("should only allow parse phone numbers with exactly 10 digits", () => {
+      expect(USPhoneNumber.parse("1234567890")?.toString()).toEqual(
+        "1234567890"
+      )
+    })
+
+    test("privacy formatted", () => {
+      const phoneNumber = USPhoneNumber.parse("9258881234")!
+      expect(phoneNumber.formattedForPrivacy).toEqual("+1 (***) ***-1234")
+    })
+  })
+})

--- a/auth/PhoneNumber.test.ts
+++ b/auth/PhoneNumber.test.ts
@@ -22,7 +22,7 @@ describe("PhoneNumber tests", () => {
 
     test("privacy formatted", () => {
       const phoneNumber = USPhoneNumber.parse("9258881234")!
-      expect(phoneNumber.formattedForPrivacy).toEqual("+1 (***) ***-1234")
+      expect(phoneNumber.formattedForPrivacy).toEqual("(***) ***-1234")
     })
   })
 })

--- a/auth/PhoneNumber.ts
+++ b/auth/PhoneNumber.ts
@@ -17,7 +17,7 @@ export class USPhoneNumber {
    * centric screens (eg. verification code, settings).
    */
   get formattedForPrivacy () {
-    return `+1 (***) ***-${this.rawValue.substring(6)}`
+    return `(***) ***-${this.rawValue.substring(6)}`
   }
 
   toString () {

--- a/auth/PhoneNumber.ts
+++ b/auth/PhoneNumber.ts
@@ -1,0 +1,38 @@
+/**
+ * A data class representing a US Phone Number.
+ *
+ * In this case, the phone number is a precise 10 digit string.
+ */
+export class USPhoneNumber {
+  private readonly rawValue: string
+
+  private constructor (rawValue: string) {
+    this.rawValue = rawValue
+  }
+
+  private static REGEX = /^\d{10}$/
+
+  /**
+   * Formats this phone number in a way such that it can be used on privacy
+   * centric screens (eg. verification code, settings).
+   */
+  get formattedForPrivacy (): string {
+    return `+1 (***) ***-${this.rawValue.substring(6)}`
+  }
+
+  toString () {
+    return this.rawValue
+  }
+
+  /**
+   * Attempts to parse an {@link USPhoneNumber} from a raw string and returns undefined
+   * if it fails to parse the string.
+   *
+   * A valid phone number string is precisely an exact 10 character, numerical string.
+   */
+  static parse (rawValue: string): USPhoneNumber | undefined {
+    return USPhoneNumber.REGEX.test(rawValue)
+      ? new USPhoneNumber(rawValue)
+      : undefined
+  }
+}

--- a/auth/PhoneNumber.ts
+++ b/auth/PhoneNumber.ts
@@ -16,7 +16,7 @@ export class USPhoneNumber {
    * Formats this phone number in a way such that it can be used on privacy
    * centric screens (eg. verification code, settings).
    */
-  get formattedForPrivacy (): string {
+  get formattedForPrivacy () {
     return `+1 (***) ***-${this.rawValue.substring(6)}`
   }
 
@@ -30,7 +30,7 @@ export class USPhoneNumber {
    *
    * A valid phone number string is precisely an exact 10 character, numerical string.
    */
-  static parse (rawValue: string): USPhoneNumber | undefined {
+  static parse (rawValue: string) {
     return USPhoneNumber.REGEX.test(rawValue)
       ? new USPhoneNumber(rawValue)
       : undefined

--- a/auth/VerifyCode.test.tsx
+++ b/auth/VerifyCode.test.tsx
@@ -16,7 +16,7 @@ describe("VerifyCode tests", () => {
 
       expect(result.current.submission).toMatchObject({
         status: "invalid",
-        reason: "too-short"
+        reason: "code-too-short"
       })
     })
 
@@ -27,7 +27,7 @@ describe("VerifyCode tests", () => {
 
       expect(result.current.submission).toMatchObject({
         status: "invalid",
-        reason: "too-long"
+        reason: "code-too-long"
       })
     })
 

--- a/auth/VerifyCode.tsx
+++ b/auth/VerifyCode.tsx
@@ -5,16 +5,16 @@ import { AppStyles } from "@lib/AppColorStyle"
 import React from "react"
 import { StyleProp, ViewStyle, StyleSheet } from "react-native"
 
-export type CreateAccountVerifyCodeProps = {
+export type AuthVerificationCodeProps = {
   style?: StyleProp<ViewStyle>
 }
 
 /**
- * A view for the user to verify their account with a 2FA code during sign up.
+ * A view for the user to verify their account with a 2FA code during auth flows.
  */
-export const CreateAccountVerifyCodeView = ({
+export const AuthVerificationCodeView = ({
   style
-}: CreateAccountVerifyCodeProps) => (
+}: AuthVerificationCodeProps) => (
   <AuthSectionView
     title="Verify your Account"
     description="We have sent a verification code to *****-61. Please enter it in the field below."

--- a/auth/VerifyCode.tsx
+++ b/auth/VerifyCode.tsx
@@ -64,7 +64,10 @@ export const useAuthVerificationCodeForm = ({
       checkCodeMutation.reset()
       setCode(code)
     },
-    resendCodeStatus: resendCodeMutation.status,
+    resendCodeStatus:
+      resendCodeMutation.isError || resendCodeMutation.isSuccess
+        ? resendCodeMutation.status
+        : undefined,
     onCodeResent: resendCodeMutation.mutate,
     get submission (): AuthVerificationCodeFormSubmission {
       if (hasSubmittedInvalidCode) {

--- a/auth/index.ts
+++ b/auth/index.ts
@@ -1,2 +1,3 @@
 export * from "./ChangePasswordForm"
 export * from "./Password"
+export * from "./VerifyCode"

--- a/auth/index.ts
+++ b/auth/index.ts
@@ -1,3 +1,5 @@
 export * from "./ChangePasswordForm"
 export * from "./Password"
 export * from "./VerifyCode"
+export * from "./Email"
+export * from "./PhoneNumber"

--- a/auth/sign-up/index.ts
+++ b/auth/sign-up/index.ts
@@ -1,4 +1,3 @@
 export * from "./CredentialsForm"
-export * from "./VerifyCode"
 export * from "./Welcome"
 export * from "./ChangeUserHandle"

--- a/components/common/Toasts.tsx
+++ b/components/common/Toasts.tsx
@@ -1,16 +1,16 @@
-import Toast from "react-native-root-toast"
+import React from "react"
+import Toast, { ToastContainer } from "react-native-root-toast"
 import { AppStyles } from "../../lib/AppColorStyle"
-import { Platform, StyleSheet, View } from "react-native"
+import { StyleSheet, View, useWindowDimensions } from "react-native"
 import { Ionicon } from "./Icons"
 import { BodyText } from "@components/Text"
-import { UserFriendStatus } from "@lib/users/User"
 
-const BOTTOM_TAB_HEIGHT = 80
+const TOAST_OFFSET = 100
 
 export const showToast = (message: string) => {
   Toast.show(message, {
     duration: Toast.durations.SHORT,
-    position: Toast.positions.BOTTOM - BOTTOM_TAB_HEIGHT,
+    position: Toast.positions.BOTTOM - TOAST_OFFSET,
     shadow: false,
     animation: true,
     hideOnPress: true,
@@ -23,60 +23,48 @@ export const showToast = (message: string) => {
   })
 }
 
-interface ToastProps {
-  requestSent: boolean
-  setRequestSent: React.Dispatch<React.SetStateAction<boolean>>
+export type TextToastProps = {
   isVisible: boolean
   text: string
+  duration?: number
 }
 
-export const ToastWithIcon = ({
-  requestSent,
-  setRequestSent,
+/**
+ * A toast view that shows simple text.
+ */
+export const TextToastView = ({
   isVisible,
-  text
-}: ToastProps) => {
-  return (
-    <>
-      {!requestSent && (
-        <Toast
-          visible={isVisible}
-          opacity={1}
-          position={Toast.positions.BOTTOM - BOTTOM_TAB_HEIGHT}
-          shadow={false}
-          animation={true}
-          hideOnPress={true}
-          containerStyle={styles.toastStyle}
-          onHide={() => setRequestSent(true)}
-        >
-          <View style={styles.containerStyle}>
-            <View style={styles.iconStyle}>
-              <Ionicon color="white" name="close" />
-            </View>
-            <BodyText style={styles.textStyle}>{text}</BodyText>
-          </View>
-        </Toast>
-      )}
-    </>
-  )
-}
+  text,
+  duration = 3000
+}: TextToastProps) => (
+  <ToastContainer
+    visible={isVisible}
+    opacity={1}
+    position={Toast.positions.BOTTOM - TOAST_OFFSET}
+    shadow={false}
+    animation={true}
+    hideOnPress={true}
+    containerStyle={[
+      styles.toastStyle,
+      { width: useWindowDimensions().width - 32 }
+    ]}
+    duration={duration}
+  >
+    <View style={styles.containerStyle}>
+      <Ionicon color="white" name="close" />
+      <BodyText style={styles.text}>{text}</BodyText>
+    </View>
+  </ToastContainer>
+)
 
 const styles = StyleSheet.create({
   toastStyle: {
     borderRadius: 12,
-    flex: 1,
-    width: "90%",
-    backgroundColor: AppStyles.darkColor,
-    alignItems: "flex-start"
+    backgroundColor: AppStyles.darkColor
   },
-  textStyle: {
+  text: {
     color: "white",
-    textAlignVertical: "center",
-    paddingTop: Platform.OS === "ios" ? 4 : 0
-  },
-  iconStyle: {
-    marginRight: 16,
-    paddingTop: Platform.OS === "ios" ? 4 : 0
+    marginHorizontal: 8
   },
   containerStyle: {
     flexDirection: "row",

--- a/components/profileImageComponents/ProfileImageAndNameWithFriend.tsx
+++ b/components/profileImageComponents/ProfileImageAndNameWithFriend.tsx
@@ -4,7 +4,7 @@ import ProfileImage from "./ProfileImage"
 import React, { useState } from "react"
 import { Ionicon } from "@components/common/Icons"
 import { AppStyles } from "@lib/AppColorStyle"
-import { ToastWithIcon } from "@components/common/Toasts"
+import { TextToastView } from "@components/common/Toasts"
 import { UserToProfileRelationStatus } from "@lib/users"
 
 interface ImageAndNameProps {
@@ -81,7 +81,7 @@ const ProfileImageAndNameWithFriend = ({
               >
                 {renderFriendStatus(friendStatus)}
               </Headline>
-              <ToastWithIcon
+              <TextToastView
                 requestSent={requestSent}
                 setRequestSent={setRequestSent}
                 isVisible={friendStatus === "friend-request-pending"}

--- a/lib/String.ts
+++ b/lib/String.ts
@@ -15,8 +15,4 @@ export namespace StringUtils {
   export const isWhitespaceCharacter = (str: string, index: number) => {
     return /\s/.test(str[index])
   }
-
-  // export const findIndexBeforeSubstring = (str: string, substr: string) => {
-
-  // }
 }

--- a/lib/String.ts
+++ b/lib/String.ts
@@ -15,4 +15,8 @@ export namespace StringUtils {
   export const isWhitespaceCharacter = (str: string, index: number) => {
     return /\s/.test(str[index])
   }
+
+  // export const findIndexBeforeSubstring = (str: string, substr: string) => {
+
+  // }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "react-native-popup-menu": "^0.15.13",
         "react-native-reanimated": "~2.14.4",
         "react-native-reanimated-carousel": "^3.0.0",
-        "react-native-root-toast": "^3.4.1",
+        "react-native-root-toast": "^3.5.1",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0",
         "react-native-select-dropdown": "^3.2.1",
@@ -33115,9 +33115,9 @@
       "integrity": "sha512-sdmLElNs5PDWqmZmj4/aNH4anyxreaPm61c4ZkRiR8SO/GzLg6KjAbb0e17RmMdnBdD0AIQbS38h/l55YKN4ZA=="
     },
     "node_modules/react-native-root-toast": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-root-toast/-/react-native-root-toast-3.4.1.tgz",
-      "integrity": "sha512-rZFoaVZWZiPCcwP9n5a+1KtVM22JNp6pkodluCoRIb5oE2ip8mhpdvlZUIWoM5nxfmL4TBThWDp7se6j4X7lPA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-root-toast/-/react-native-root-toast-3.5.1.tgz",
+      "integrity": "sha512-zqsuec7Ugx2/9hR9BHqcmb3WWC/WBouqn2RYIpeTG+OpVvVfvr2UhWK4kLPJLk5/icZWl3xJrqiktPpbRpEA2A==",
       "dependencies": {
         "deprecated-react-native-prop-types": "^2.3.0",
         "prop-types": "^15.5.10",
@@ -62539,9 +62539,9 @@
       "integrity": "sha512-sdmLElNs5PDWqmZmj4/aNH4anyxreaPm61c4ZkRiR8SO/GzLg6KjAbb0e17RmMdnBdD0AIQbS38h/l55YKN4ZA=="
     },
     "react-native-root-toast": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-root-toast/-/react-native-root-toast-3.4.1.tgz",
-      "integrity": "sha512-rZFoaVZWZiPCcwP9n5a+1KtVM22JNp6pkodluCoRIb5oE2ip8mhpdvlZUIWoM5nxfmL4TBThWDp7se6j4X7lPA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-root-toast/-/react-native-root-toast-3.5.1.tgz",
+      "integrity": "sha512-zqsuec7Ugx2/9hR9BHqcmb3WWC/WBouqn2RYIpeTG+OpVvVfvr2UhWK4kLPJLk5/icZWl3xJrqiktPpbRpEA2A==",
       "requires": {
         "deprecated-react-native-prop-types": "^2.3.0",
         "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-popup-menu": "^0.15.13",
     "react-native-reanimated": "~2.14.4",
     "react-native-reanimated-carousel": "^3.0.0",
-    "react-native-root-toast": "^3.4.1",
+    "react-native-root-toast": "^3.5.1",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-select-dropdown": "^3.2.1",

--- a/screens/ProfileScreen/ProfileView.tsx
+++ b/screens/ProfileScreen/ProfileView.tsx
@@ -6,7 +6,7 @@ import {
   PrimaryButton
 } from "@components/common/Buttons"
 import ExpandableText from "@components/common/ExpandableText"
-import { ToastWithIcon } from "@components/common/Toasts"
+import { TextToastView } from "@components/common/Toasts"
 import ProfileImage from "@components/profileImageComponents/ProfileImage"
 import { User } from "@lib/users/User"
 import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native"
@@ -68,7 +68,7 @@ const ProfileView = ({ user, events }: ProfileScreenViewProps) => {
             {userStatus !== "blocked" && (
               <OutlinedButton style={styles.messageButton} title="Message" />
             )}
-            <ToastWithIcon
+            <TextToastView
               requestSent={requestSent}
               setRequestSent={setRequestSent}
               isVisible={userStatus === "friend-request-pending"}


### PR DESCRIPTION
All of the auth flows will at least have 1 edge case which require a verification code, so this PR creates a generic component and hook for verification flows called `AuthVerificationCodeForm` and `useAuthVerificationCodeForm` respectively.

Additionally, there's also a `USPhoneNumber` and `EmailAddress` types which are not only useful for validation purposes, but they also include a `formattedForPrivacy` computed property which hides sensitive details about their real value. This allows for the common pattern in which apps will "star out" a phone number minus the last 4 digits.

I also modified the existing Toast View that we had since it was ancient, and needed to communicate that the verification code was resent (or failed to be resent) when "Resend it." was tapped. This toast view was also renamed to `TextToastView` as it only is supposed to display text.

