### PR TITLE
Add stateful focus to custom Textfields

### DIFF
--- a/.storybook/components/TextField/TextField.stories.tsx
+++ b/.storybook/components/TextField/TextField.stories.tsx
@@ -5,7 +5,7 @@ import {
   TextField
 } from "@components/TextFields"
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
-import { KeyboardAvoidingView, View } from "react-native"
+import { Button, KeyboardAvoidingView, View } from "react-native"
 import { ContentText } from "@components/ContentText"
 import { Ionicon } from "@components/common/Icons"
 
@@ -85,13 +85,18 @@ const ErrorView = () => {
 
 const Password = () => {
   const [text, setText] = useState("")
+  const [isFocused, setIsFocused] = useState(false)
   return (
-    <PasswordTextField
-      value={text}
-      placeholder="Enter Text"
-      onChangeText={setText}
-      style={{ padding: 16 }}
-    />
+    <View style={{ width: "100%" }}>
+      <PasswordTextField
+        isFocused={isFocused}
+        value={text}
+        placeholder="Enter Text"
+        onChangeText={setText}
+        style={{ padding: 16 }}
+      />
+      <Button title="Toggle Focus" onPress={() => setIsFocused((f) => !f)} />
+    </View>
   )
 }
 

--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react"
+import React, { ReactNode, useEffect, useRef, useState } from "react"
 import {
   TextInputProps,
   StyleSheet,
@@ -16,6 +16,7 @@ export type TextFieldProps = {
   leftAddon?: JSX.Element
   rightAddon?: JSX.Element
   error?: ReactNode
+  isFocused?: boolean
   textStyle?: StyleProp<TextStyle>
   style?: StyleProp<ViewStyle>
 } & Omit<TextInputProps, "style" | "placeholderStyle">
@@ -23,37 +24,17 @@ export type TextFieldProps = {
 /**
  * A generic Text Field component.
  */
-export const TextField = ({
-  leftAddon,
-  rightAddon,
-  error,
-  textStyle,
-  style,
-  ...props
-}: TextFieldProps) => {
+export const TextField = ({ error, style, ...props }: TextFieldProps) => {
   const borderColor = error ? AppStyles.errorColor : "rgba(0, 0, 0, 0.10)"
   return (
     <View style={style}>
       <View style={[styles.card, { borderColor }]}>
-        <View style={styles.container}>
-          <View style={styles.leftAddon}>{leftAddon}</View>
-          <View style={styles.leftContainer}>
-            <TextInput
-              style={[styles.textInput, textStyle]}
-              placeholderTextColor={AppStyles.colorOpacity35}
-              {...props}
-            />
-          </View>
-          <View style={styles.rightAddon}>{rightAddon}</View>
-        </View>
+        <InternalTextField
+          placeholderTextColor={AppStyles.colorOpacity35}
+          {...props}
+        />
       </View>
-      {typeof error === "string" || typeof error === "number"
-        ? (
-          <Caption style={styles.errorText}>{error}</Caption>
-        )
-        : (
-          error
-        )}
+      <TextFieldErrorView error={error} />
     </View>
   )
 }
@@ -61,28 +42,20 @@ export const TextField = ({
 /**
  * A text field with a filled background.
  */
-export const ShadedTextField = ({
-  leftAddon,
-  rightAddon,
-  error,
-  textStyle,
-  style,
-  ...props
-}: TextFieldProps) => (
+export const ShadedTextField = ({ error, style, ...props }: TextFieldProps) => (
   <View style={style}>
     <View style={[styles.filledCard]}>
-      <View style={styles.container}>
-        <View style={styles.leftAddon}>{leftAddon}</View>
-        <View style={styles.leftContainer}>
-          <TextInput
-            style={[styles.textInput, textStyle]}
-            placeholderTextColor={AppStyles.colorOpacity50}
-            {...props}
-          />
-        </View>
-        <View style={styles.rightAddon}>{rightAddon}</View>
-      </View>
+      <InternalTextField
+        placeholderTextColor={AppStyles.colorOpacity35}
+        {...props}
+      />
     </View>
+    <TextFieldErrorView error={error} />
+  </View>
+)
+
+const TextFieldErrorView = ({ error }: { error?: ReactNode }) => (
+  <>
     {typeof error === "string" || typeof error === "number"
       ? (
         <Caption style={styles.errorText}>{error}</Caption>
@@ -90,8 +63,41 @@ export const ShadedTextField = ({
       : (
         error
       )}
-  </View>
+  </>
 )
+
+const InternalTextField = ({
+  leftAddon,
+  rightAddon,
+  textStyle,
+  isFocused,
+  ...props
+}: TextFieldProps) => {
+  const ref = useRef<TextInput>(null)
+
+  useEffect(() => {
+    if (isFocused) {
+      ref.current?.focus()
+    } else {
+      ref.current?.blur()
+    }
+  }, [isFocused])
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.leftAddon}>{leftAddon}</View>
+      <View style={styles.leftContainer}>
+        <TextInput
+          ref={ref}
+          style={[styles.textInput, textStyle]}
+          placeholderTextColor={AppStyles.colorOpacity50}
+          {...props}
+        />
+      </View>
+      <View style={styles.rightAddon}>{rightAddon}</View>
+    </View>
+  )
+}
 
 export type PasswordTextFieldProps = Omit<
   TextFieldProps,
@@ -101,42 +107,42 @@ export type PasswordTextFieldProps = Omit<
 /**
  * A text field component for password inputs.
  */
-export const PasswordTextField = ({ ...props }: PasswordTextFieldProps) => {
-  const [isShowingPassword, setIsShowingPassword] = useState(false)
-  return (
-    <TextField
-      secureTextEntry={!isShowingPassword}
-      rightAddon={
-        <TouchableIonicon
-          icon={{ name: isShowingPassword ? "eye" : "eye-off" }}
-          onPress={() => {
-            setIsShowingPassword((isShowing) => !isShowing)
-          }}
-          accessibilityLabel={
-            isShowingPassword ? "Hide password" : "Show password"
-          }
-        />
-      }
-      {...props}
-    />
-  )
-}
+export const PasswordTextField = ({ ...props }: PasswordTextFieldProps) => (
+  <InternalPasswordTextField TextFieldView={TextField} {...props} />
+)
 
 /**
  * A password text field which is filled with a solic background
  */
 export const ShadedPasswordTextField = ({
   ...props
-}: PasswordTextFieldProps) => {
+}: PasswordTextFieldProps) => (
+  <InternalPasswordTextField
+    TextFieldView={ShadedTextField}
+    iconColor={AppStyles.colorOpacity50}
+    {...props}
+  />
+)
+
+type InternalPasswordTextFieldProps = {
+  TextFieldView: typeof TextField
+  iconColor?: string
+} & PasswordTextFieldProps
+
+const InternalPasswordTextField = ({
+  TextFieldView,
+  iconColor,
+  ...props
+}: InternalPasswordTextFieldProps) => {
   const [isShowingPassword, setIsShowingPassword] = useState(false)
   return (
-    <ShadedTextField
+    <TextFieldView
       secureTextEntry={!isShowingPassword}
       rightAddon={
         <TouchableIonicon
           icon={{
             name: isShowingPassword ? "eye" : "eye-off",
-            color: AppStyles.colorOpacity50
+            color: iconColor
           }}
           onPress={() => {
             setIsShowingPassword((isShowing) => !isShowing)


### PR DESCRIPTION
Normally text field focus is done through refs, and apparently the `TextFieldProps` did not accept a ref. No matter, it turns out that even if `TextFieldProps` accepted a ref, it would've required that all other Text field components wrapping ours (Auth text fields for instance) use `forwardRef`. And don't even get me started on what it takes to get typesafety for that.

So instead we'll use a simple `isFocused` prop, and handle the ref BS inside our text field. Additionally, this allows us to completely get rid of `forwardRef`. Furthermore, this also makes focus state a lot more easily testable.

I also cleaned up the existing text field code, mainly the duplication.

PS. There is 1 gotcha around autofocusing a text field when the view loads, for that use `autoFocus` instead of `isFocused` as the latter incurs a delay for the first time a text field is focused after the app is launched. `autoFocus` does native hacks to get around this problem.