### PR TITLE
Update change password

### DIFF
--- a/.storybook/.ondevice/Storybook.tsx
+++ b/.storybook/.ondevice/Storybook.tsx
@@ -34,6 +34,9 @@ import SignUpMeta, {
 import VerifcationCodeMeta, {
   Basic as VerifcationCodeBasic
 } from "../components/VerificationCode/VerifyCode.stories"
+import ChangePasswordMeta, {
+  Basic as ChangePasswordBasic
+} from "../components/ChangePassword/ChangePassword.stories"
 
 // Create an array of stories
 const stories = [
@@ -86,6 +89,11 @@ const stories = [
     name: VerifcationCodeMeta.title,
     component: VerifcationCodeBasic,
     args: VerifcationCodeMeta.args
+  },
+  {
+    name: ChangePasswordMeta.title,
+    component: ChangePasswordBasic,
+    args: ChangePasswordMeta.args
   }
   // Add more stories here...
 ]

--- a/.storybook/.ondevice/storybook.requires.js
+++ b/.storybook/.ondevice/storybook.requires.js
@@ -50,6 +50,7 @@ try {
 const getStories = () => {
   return {
     "./components/AttendeesList/AttendeesList.stories.tsx": require("../components/AttendeesList/AttendeesList.stories.tsx"),
+    "./components/ChangePassword/ChangePassword.stories.tsx": require("../components/ChangePassword/ChangePassword.stories.tsx"),
     "./components/ContentReporting/ContentReporting.stories.tsx": require("../components/ContentReporting/ContentReporting.stories.tsx"),
     "./components/ContentText/ContextText.stories.tsx": require("../components/ContentText/ContextText.stories.tsx"),
     "./components/Explore/Explore.stories.tsx": require("../components/Explore/Explore.stories.tsx"),

--- a/.storybook/components/ChangePassword/ChangePassword.stories.tsx
+++ b/.storybook/components/ChangePassword/ChangePassword.stories.tsx
@@ -1,0 +1,69 @@
+import {
+  BASE_HEADER_SCREEN_OPTIONS,
+  ChevronBackButton
+} from "@components/Navigation"
+import { NavigationContainer, useNavigation } from "@react-navigation/native"
+import { createStackNavigator } from "@react-navigation/stack"
+import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
+import { ComponentMeta, ComponentStory } from "@storybook/react-native"
+import { ChangePasswordFormView, useChangePasswordForm } from "@auth/index"
+import { RootSiblingParent } from "react-native-root-siblings"
+import { SafeAreaProvider } from "react-native-safe-area-context"
+import { Button, View } from "react-native"
+import React from "react"
+import { delayData } from "@lib/DelayData"
+import { TiFQueryClientProvider } from "@components/TiFQueryClientProvider"
+
+const ChangePasswordMeta: ComponentMeta<typeof SettingsScreen> = {
+  title: "Change Password"
+}
+
+export default ChangePasswordMeta
+
+type ChangePasswordStory = ComponentStory<typeof SettingsScreen>
+
+const Stack = createStackNavigator()
+
+export const Basic: ChangePasswordStory = () => (
+  <RootSiblingParent>
+    <TiFQueryClientProvider>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
+            <Stack.Screen name="test" component={TestScreen} />
+            <Stack.Screen
+              name="changePassword"
+              options={{ headerLeft: () => <ChevronBackButton />, title: "" }}
+              component={ChangePasswordScreen}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </TiFQueryClientProvider>
+  </RootSiblingParent>
+)
+
+const ChangePasswordScreen = () => {
+  const form = useChangePasswordForm({
+    onSubmitted: async () => await delayData("incorrect-password", 1500),
+    onSuccess: () => console.log("Success")
+  })
+  return (
+    <ChangePasswordFormView
+      {...form}
+      onForgotPasswordTapped={() => console.log("Forgot password")}
+    />
+  )
+}
+
+const TestScreen = () => {
+  const navigation = useNavigation()
+  return (
+    <View>
+      <Button
+        title="Go To Change Password"
+        onPress={() => navigation.navigate("changePassword")}
+      />
+    </View>
+  )
+}

--- a/auth/AuthTextFields.tsx
+++ b/auth/AuthTextFields.tsx
@@ -1,9 +1,10 @@
-import React from "react"
+import React, { forwardRef } from "react"
 import {
   ShadedPasswordTextField,
   ShadedTextField,
   PasswordTextFieldProps,
-  TextFieldProps
+  TextFieldProps,
+  TextFieldRef
 } from "@components/TextFields"
 import { CircularIonicon, IoniconName } from "@components/common/Icons"
 import { StyleProp, ViewStyle } from "react-native"
@@ -18,15 +19,14 @@ export type AuthShadedTextFieldProps = {
 /**
  * A filled text field matching the style of the auth screens.
  */
-export const AuthShadedTextField = ({
-  iconName,
-  iconBackgroundColor,
-  style,
-  ...props
-}: AuthShadedTextFieldProps) => {
+export const AuthShadedTextField = forwardRef(function TextField (
+  { iconName, iconBackgroundColor, style, ...props }: AuthShadedTextFieldProps,
+  ref: TextFieldRef
+) {
   const textFieldHeight = 32 * useFontScale()
   return (
     <ShadedTextField
+      ref={ref}
       leftAddon={
         <CircularIonicon
           backgroundColor={iconBackgroundColor}
@@ -38,7 +38,7 @@ export const AuthShadedTextField = ({
       textStyle={{ height: textFieldHeight }}
     />
   )
-}
+})
 
 export type AuthShadedPasswordTextFieldProps = {
   iconName: IoniconName
@@ -49,15 +49,19 @@ export type AuthShadedPasswordTextFieldProps = {
 /**
  * A filled password text field matching the style of the auth screens.
  */
-export const AuthShadedPasswordTextField = ({
-  iconName,
-  iconBackgroundColor,
-  style,
-  ...props
-}: AuthShadedPasswordTextFieldProps) => {
+export const AuthShadedPasswordTextField = forwardRef(function TextField (
+  {
+    iconName,
+    iconBackgroundColor,
+    style,
+    ...props
+  }: AuthShadedPasswordTextFieldProps,
+  ref: TextFieldRef
+) {
   const textFieldHeight = 32 * useFontScale()
   return (
     <ShadedPasswordTextField
+      ref={ref}
       leftAddon={
         <CircularIonicon
           backgroundColor={iconBackgroundColor}
@@ -69,4 +73,4 @@ export const AuthShadedPasswordTextField = ({
       textStyle={{ height: textFieldHeight }}
     />
   )
-}
+})

--- a/auth/ChangePassword.test.tsx
+++ b/auth/ChangePassword.test.tsx
@@ -110,7 +110,7 @@ describe("ChangePassword tests", () => {
       await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
 
-    test("incorrec current password submission flow, presents alert", async () => {
+    test("incorrect current password submission flow, presents alert", async () => {
       changePassword.mockResolvedValue("incorrect-password")
 
       const { result } = renderChangePassword()
@@ -145,16 +145,24 @@ describe("ChangePassword tests", () => {
         expect(alertPresentationSpy).toHaveBeenCalled()
       })
 
-      await act(async () => await retry())
+      retry()
 
       await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
 
-    it("should not produce error messages when no input is initially given", () => {
+    it("should not produce error messages when no new password is empty", () => {
       const { result } = renderChangePassword()
 
       expect(result.current.submission).toMatchObject({
-        status: "invalid"
+        status: "invalid",
+        error: undefined
+      })
+
+      act(() => result.current.updateField("currentPassword", "abc123"))
+
+      expect(result.current.submission).toMatchObject({
+        status: "invalid",
+        error: undefined
       })
     })
   })

--- a/auth/ChangePassword.test.tsx
+++ b/auth/ChangePassword.test.tsx
@@ -110,7 +110,7 @@ describe("ChangePassword tests", () => {
       await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
 
-    it("should have a failed submission flow", async () => {
+    test("incorrec current password submission flow, presents alert", async () => {
       changePassword.mockResolvedValue("incorrect-password")
 
       const { result } = renderChangePassword()
@@ -126,6 +126,7 @@ describe("ChangePassword tests", () => {
           error: "incorrect-current-password"
         })
       })
+      expect(alertPresentationSpy).toHaveBeenCalled()
     })
 
     it("should be able to retry when it gets an error", async () => {

--- a/auth/ChangePassword.test.tsx
+++ b/auth/ChangePassword.test.tsx
@@ -97,9 +97,7 @@ describe("ChangePassword tests", () => {
         result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
       })
 
-      expect(result.current.submission.status).toEqual("valid")
-
-      act(() => result.current.submission.submit?.())
+      act(() => (result.current.submission as any).submit())
 
       await waitFor(() => {
         expect(result.current.submission.status).toEqual("submitting")
@@ -127,9 +125,7 @@ describe("ChangePassword tests", () => {
         result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
       })
 
-      expect(result.current.submission.status).toEqual("valid")
-
-      act(() => result.current.submission.submit?.())
+      act(() => (result.current.submission as any).submit())
 
       await waitFor(() => expect(onSuccess).toHaveBeenCalled())
     })
@@ -145,16 +141,14 @@ describe("ChangePassword tests", () => {
         result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
       )
 
-      expect(result.current.submission.status).toEqual("valid")
-
-      act(() => result.current.submission.submit?.())
+      act(() => (result.current.submission as any).submit())
 
       await waitFor(() => {
-        expect(result.current.submission.status).toEqual("invalid")
+        expect(result.current.submission).toMatchObject({
+          status: "invalid",
+          error: "incorrect-current-password"
+        })
       })
-      expect(result.current.submission.error).toEqual(
-        "incorrect-current-password"
-      )
     })
 
     it("should be able to retry when it gets an error", async () => {
@@ -170,9 +164,7 @@ describe("ChangePassword tests", () => {
         result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
       )
 
-      expect(result.current.submission.status).toEqual("valid")
-
-      act(() => result.current.submission.submit?.())
+      act(() => (result.current.submission as any).submit())
 
       await waitFor(() => {
         expect(alertPresentationSpy).toHaveBeenCalled()
@@ -186,8 +178,9 @@ describe("ChangePassword tests", () => {
     it("should not produce error messages when no input is initially given", () => {
       const { result } = renderChangePassword()
 
-      expect(result.current.submission.status).toEqual("invalid")
-      expect(result.current.submission.error).toBeUndefined()
+      expect(result.current.submission).toMatchObject({
+        status: "invalid"
+      })
     })
   })
 })

--- a/auth/ChangePassword.test.tsx
+++ b/auth/ChangePassword.test.tsx
@@ -60,26 +60,12 @@ describe("ChangePassword tests", () => {
       })
     })
 
-    it("should give an invalid state, if the re-entered password does not match the new password", () => {
-      const reEnteredPassword = "WaterBottle2%"
-      const { result } = renderChangePassword()
-
-      act(() => result.current.updateField("newPassword", reEnteredPassword))
-      act(() => result.current.updateField("reEnteredPassword", "K"))
-
-      expect(result.current.submission).toMatchObject({
-        status: "invalid",
-        error: "reenter-does-not-match-new"
-      })
-    })
-
     it("should give an invalid state, if the new password is not strong enough: too short", () => {
       const newPassword = "Wat2%"
       const { result } = renderChangePassword()
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", newPassword))
-      act(() => result.current.updateField("reEnteredPassword", newPassword))
 
       expect(result.current.submission).toMatchObject({
         status: "invalid",
@@ -93,9 +79,6 @@ describe("ChangePassword tests", () => {
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
-      act(() => {
-        result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
-      })
 
       act(() => (result.current.submission as any).submit())
 
@@ -121,9 +104,6 @@ describe("ChangePassword tests", () => {
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
-      act(() => {
-        result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
-      })
 
       act(() => (result.current.submission as any).submit())
 
@@ -137,9 +117,6 @@ describe("ChangePassword tests", () => {
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
-      act(() =>
-        result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
-      )
 
       act(() => (result.current.submission as any).submit())
 
@@ -160,9 +137,6 @@ describe("ChangePassword tests", () => {
 
       act(() => result.current.updateField("currentPassword", "ReturnToAll32@"))
       act(() => result.current.updateField("newPassword", "OblivionAwaits43#"))
-      act(() =>
-        result.current.updateField("reEnteredPassword", "OblivionAwaits43#")
-      )
 
       act(() => (result.current.submission as any).submit())
 

--- a/auth/ChangePasswordForm.tsx
+++ b/auth/ChangePasswordForm.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "@tanstack/react-query"
 import { AuthFormView, BaseAuthFormSubmission } from "./AuthSection"
 import { AuthShadedPasswordTextField } from "./AuthTextFields"
 import { TextFieldRefValue } from "@components/TextFields"
+import Animated, { Layout } from "react-native-reanimated"
 
 export type ChangePasswordResult = "valid" | "incorrect-password"
 
@@ -150,26 +151,30 @@ export const ChangePasswordFormView = ({
         style={styles.textField}
       />
 
-      <AuthShadedPasswordTextField
-        iconName="md-key"
-        iconBackgroundColor="#14B329"
-        value={fields.newPassword}
-        placeholder="New Password"
-        returnKeyType="done"
-        ref={newPasswordRef}
-        error={
-          submission.status === "invalid"
-            ? newPasswordErrorMessage(submission.error)
-            : undefined
-        }
-        onChangeText={(text) => updateField("newPassword", text)}
-        style={styles.textField}
-      />
-      <TouchableOpacity onPress={onForgotPasswordTapped}>
-        <Headline style={{ color: AppStyles.highlightedText }}>
-          Forgot your password?
-        </Headline>
-      </TouchableOpacity>
+      <Animated.View layout={Layout.springify()}>
+        <AuthShadedPasswordTextField
+          iconName="md-key"
+          iconBackgroundColor="#14B329"
+          value={fields.newPassword}
+          placeholder="New Password"
+          returnKeyType="done"
+          ref={newPasswordRef}
+          error={
+            submission.status === "invalid"
+              ? newPasswordErrorMessage(submission.error)
+              : undefined
+          }
+          onChangeText={(text) => updateField("newPassword", text)}
+          style={styles.textField}
+        />
+      </Animated.View>
+      <Animated.View layout={Layout.springify()}>
+        <TouchableOpacity onPress={onForgotPasswordTapped}>
+          <Headline style={{ color: AppStyles.highlightedText }}>
+            Forgot your password?
+          </Headline>
+        </TouchableOpacity>
+      </Animated.View>
     </AuthFormView>
   )
 }

--- a/auth/ChangePasswordForm.tsx
+++ b/auth/ChangePasswordForm.tsx
@@ -26,7 +26,7 @@ export type UseChangePasswordFormEnvironment = {
 export type ChangePasswordSubmission =
   | {
       status: "invalid"
-      error?: ChangePasswordErrorReason
+      error: ChangePasswordErrorReason | undefined
     }
   | BaseAuthFormSubmission
 
@@ -80,8 +80,8 @@ export const useChangePasswordForm = ({
       setFields((fields) => ({ ...fields, [key]: value }))
     },
     get submission (): ChangePasswordSubmission {
-      if (fields.currentPassword === "" && fields.newPassword === "") {
-        return { status: "invalid" }
+      if (fields.newPassword === "") {
+        return { status: "invalid", error: undefined }
       } else if (fields.currentPassword === fields.newPassword) {
         return { status: "invalid", error: "current-matches-new" }
       } else if (!passwordResult) {

--- a/auth/ChangePasswordForm.tsx
+++ b/auth/ChangePasswordForm.tsx
@@ -8,7 +8,7 @@ import { useMutation } from "@tanstack/react-query"
 import { AuthFormView, BaseAuthFormSubmission } from "./AuthSection"
 import { AuthShadedPasswordTextField } from "./AuthTextFields"
 
-export type ChangePasswordResult = "valid" | "invalid" | "incorrect-password"
+export type ChangePasswordResult = "valid" | "incorrect-password"
 
 export type ChangePasswordErrorReason =
   | "current-matches-new"
@@ -51,8 +51,17 @@ export const useChangePasswordForm = ({
       return await onSubmitted(fields.currentPassword, password)
     },
     {
-      onSuccess,
-      onError: (_, password: Password) => {
+      onSuccess (result) {
+        if (result === "valid") {
+          onSuccess()
+        } else {
+          Alert.alert(
+            "Incorrect Password",
+            "You entered your current password incorrectly, please try again."
+          )
+        }
+      },
+      onError: (_, password) => {
         Alert.alert(
           "Whoops",
           "Sorry, something went wrong when trying to change your password. Please try again.",

--- a/auth/ChangePasswordForm.tsx
+++ b/auth/ChangePasswordForm.tsx
@@ -12,7 +12,6 @@ export type ChangePasswordResult = "valid" | "invalid" | "incorrect-password"
 
 export type ChangePasswordErrorReason =
   | "current-matches-new"
-  | "reenter-does-not-match-new"
   | "weak-new-password"
   | "incorrect-current-password"
 
@@ -34,7 +33,6 @@ export type ChangePasswordSubmission =
 export type ChangePasswordFormFields = {
   currentPassword: string
   newPassword: string
-  reEnteredPassword: string
 }
 
 export const useChangePasswordForm = ({
@@ -43,8 +41,7 @@ export const useChangePasswordForm = ({
 }: UseChangePasswordFormEnvironment) => {
   const [fields, setFields] = useState({
     currentPassword: "",
-    newPassword: "",
-    reEnteredPassword: ""
+    newPassword: ""
   })
 
   const passwordResult = Password.validate(fields.newPassword)
@@ -74,16 +71,10 @@ export const useChangePasswordForm = ({
       setFields((fields) => ({ ...fields, [key]: value }))
     },
     get submission (): ChangePasswordSubmission {
-      if (
-        fields.currentPassword === "" &&
-        fields.newPassword === "" &&
-        fields.reEnteredPassword === ""
-      ) {
+      if (fields.currentPassword === "" && fields.newPassword === "") {
         return { status: "invalid" }
       } else if (fields.currentPassword === fields.newPassword) {
         return { status: "invalid", error: "current-matches-new" }
-      } else if (fields.reEnteredPassword !== fields.newPassword) {
-        return { status: "invalid", error: "reenter-does-not-match-new" }
       } else if (!passwordResult) {
         return { status: "invalid", error: "weak-new-password" }
       } else if (mutation.isLoading) {
@@ -124,7 +115,7 @@ export const ChangePasswordFormView = ({
   >
     <AuthShadedPasswordTextField
       iconName="lock-closed"
-      iconBackgroundColor="#FB3640"
+      iconBackgroundColor={AppStyles.linkColor}
       value={fields.currentPassword}
       placeholder="Current Password"
       error={
@@ -138,8 +129,8 @@ export const ChangePasswordFormView = ({
     />
 
     <AuthShadedPasswordTextField
-      iconName="lock-closed"
-      iconBackgroundColor="#FB3640"
+      iconName="md-key"
+      iconBackgroundColor="#14B329"
       value={fields.newPassword}
       placeholder="New Password"
       error={
@@ -148,21 +139,6 @@ export const ChangePasswordFormView = ({
           : undefined
       }
       onChangeText={(text) => updateField("newPassword", text)}
-      style={styles.textField}
-    />
-
-    <AuthShadedPasswordTextField
-      iconName="lock-closed"
-      iconBackgroundColor="#FB3640"
-      value={fields.reEnteredPassword}
-      placeholder="Re-Enter New Password"
-      error={
-        submission.status === "invalid" &&
-        submission.error === "reenter-does-not-match-new"
-          ? "Your new password does not match, please enter it here again."
-          : undefined
-      }
-      onChangeText={(text) => updateField("reEnteredPassword", text)}
       style={styles.textField}
     />
 

--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -11,6 +11,7 @@ import { TextInput } from "react-native-gesture-handler"
 import { Caption } from "./Text"
 import { AppStyles } from "@lib/AppColorStyle"
 import { TouchableIonicon } from "./common/Icons"
+import Animated, { FadeInUp, FadeOutUp } from "react-native-reanimated"
 
 export type TextFieldRefValue = TextInput | null
 
@@ -42,7 +43,7 @@ export const TextField = forwardRef(function TextField (
           {...props}
         />
       </View>
-      <TextFieldErrorView error={error} />
+      {error && <TextFieldErrorView error={error} />}
     </View>
   )
 })
@@ -63,13 +64,13 @@ export const ShadedTextField = forwardRef(function TextField (
           {...props}
         />
       </View>
-      <TextFieldErrorView error={error} />
+      {error && <TextFieldErrorView error={error} />}
     </View>
   )
 })
 
-const TextFieldErrorView = ({ error }: { error?: ReactNode }) => (
-  <>
+const TextFieldErrorView = ({ error }: { error: ReactNode }) => (
+  <Animated.View entering={FadeInUp} exiting={FadeOutUp}>
     {typeof error === "string" || typeof error === "number"
       ? (
         <Caption style={styles.errorText}>{error}</Caption>
@@ -77,7 +78,7 @@ const TextFieldErrorView = ({ error }: { error?: ReactNode }) => (
       : (
         error
       )}
-  </>
+  </Animated.View>
 )
 
 const InternalTextField = forwardRef(function TextField (
@@ -162,7 +163,6 @@ const InternalPasswordTextField = forwardRef(function TextField (
           }
         />
       }
-      // value={isShowingPassword ? value : "•".repeat(value?.length ?? 0)}
       autoCorrect={false}
       autoCapitalize="none"
       autoComplete="password"

--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef, useState } from "react"
+import React, { ReactNode, Ref, forwardRef, useState } from "react"
 import {
   TextInputProps,
   StyleSheet,
@@ -12,6 +12,10 @@ import { Caption } from "./Text"
 import { AppStyles } from "@lib/AppColorStyle"
 import { TouchableIonicon } from "./common/Icons"
 
+export type TextFieldRefValue = TextInput | null
+
+export type TextFieldRef = Ref<TextInput> | undefined
+
 export type TextFieldProps = {
   leftAddon?: JSX.Element
   rightAddon?: JSX.Element
@@ -24,12 +28,16 @@ export type TextFieldProps = {
 /**
  * A generic Text Field component.
  */
-export const TextField = ({ error, style, ...props }: TextFieldProps) => {
+export const TextField = forwardRef(function TextField (
+  { error, style, ...props }: TextFieldProps,
+  ref: TextFieldRef
+) {
   const borderColor = error ? AppStyles.errorColor : "rgba(0, 0, 0, 0.10)"
   return (
     <View style={style}>
       <View style={[styles.card, { borderColor }]}>
         <InternalTextField
+          ref={ref}
           placeholderTextColor={AppStyles.colorOpacity35}
           {...props}
         />
@@ -37,22 +45,28 @@ export const TextField = ({ error, style, ...props }: TextFieldProps) => {
       <TextFieldErrorView error={error} />
     </View>
   )
-}
+})
 
 /**
  * A text field with a filled background.
  */
-export const ShadedTextField = ({ error, style, ...props }: TextFieldProps) => (
-  <View style={style}>
-    <View style={[styles.filledCard]}>
-      <InternalTextField
-        placeholderTextColor={AppStyles.colorOpacity35}
-        {...props}
-      />
+export const ShadedTextField = forwardRef(function TextField (
+  { error, style, ...props }: TextFieldProps,
+  ref: TextFieldRef
+) {
+  return (
+    <View style={style}>
+      <View style={[styles.filledCard]}>
+        <InternalTextField
+          ref={ref}
+          placeholderTextColor={AppStyles.colorOpacity35}
+          {...props}
+        />
+      </View>
+      <TextFieldErrorView error={error} />
     </View>
-    <TextFieldErrorView error={error} />
-  </View>
-)
+  )
+})
 
 const TextFieldErrorView = ({ error }: { error?: ReactNode }) => (
   <>
@@ -66,23 +80,10 @@ const TextFieldErrorView = ({ error }: { error?: ReactNode }) => (
   </>
 )
 
-const InternalTextField = ({
-  leftAddon,
-  rightAddon,
-  textStyle,
-  isFocused,
-  ...props
-}: TextFieldProps) => {
-  const ref = useRef<TextInput>(null)
-
-  useEffect(() => {
-    if (isFocused) {
-      ref.current?.focus()
-    } else {
-      ref.current?.blur()
-    }
-  }, [isFocused])
-
+const InternalTextField = forwardRef(function TextField (
+  { leftAddon, rightAddon, textStyle, isFocused, ...props }: TextFieldProps,
+  ref: TextFieldRef
+) {
   return (
     <View style={styles.container}>
       <View style={styles.leftAddon}>{leftAddon}</View>
@@ -97,7 +98,7 @@ const InternalTextField = ({
       <View style={styles.rightAddon}>{rightAddon}</View>
     </View>
   )
-}
+})
 
 export type PasswordTextFieldProps = Omit<
   TextFieldProps,
@@ -107,36 +108,45 @@ export type PasswordTextFieldProps = Omit<
 /**
  * A text field component for password inputs.
  */
-export const PasswordTextField = ({ ...props }: PasswordTextFieldProps) => (
-  <InternalPasswordTextField TextFieldView={TextField} {...props} />
-)
+export const PasswordTextField = forwardRef(function Field (
+  { ...props }: PasswordTextFieldProps,
+  ref: TextFieldRef
+) {
+  return (
+    <InternalPasswordTextField TextFieldView={TextField} ref={ref} {...props} />
+  )
+})
 
 /**
  * A password text field which is filled with a solic background
  */
-export const ShadedPasswordTextField = ({
-  ...props
-}: PasswordTextFieldProps) => (
-  <InternalPasswordTextField
-    TextFieldView={ShadedTextField}
-    iconColor={AppStyles.colorOpacity50}
-    {...props}
-  />
-)
+export const ShadedPasswordTextField = forwardRef(function TextField (
+  { ...props }: PasswordTextFieldProps,
+  ref: TextFieldRef
+) {
+  return (
+    <InternalPasswordTextField
+      TextFieldView={ShadedTextField}
+      iconColor={AppStyles.colorOpacity50}
+      ref={ref}
+      {...props}
+    />
+  )
+})
 
 type InternalPasswordTextFieldProps = {
   TextFieldView: typeof TextField
   iconColor?: string
 } & PasswordTextFieldProps
 
-const InternalPasswordTextField = ({
-  TextFieldView,
-  iconColor,
-  ...props
-}: InternalPasswordTextFieldProps) => {
+const InternalPasswordTextField = forwardRef(function TextField (
+  { TextFieldView, iconColor, ...props }: InternalPasswordTextFieldProps,
+  ref: TextFieldRef
+) {
   const [isShowingPassword, setIsShowingPassword] = useState(false)
   return (
     <TextFieldView
+      ref={ref}
       secureTextEntry={!isShowingPassword}
       rightAddon={
         <TouchableIonicon
@@ -152,13 +162,14 @@ const InternalPasswordTextField = ({
           }
         />
       }
+      // value={isShowingPassword ? value : "•".repeat(value?.length ?? 0)}
       autoCorrect={false}
       autoCapitalize="none"
       autoComplete="password"
       {...props}
     />
   )
-}
+})
 
 const styles = StyleSheet.create({
   filledCard: {

--- a/components/TextFields.tsx
+++ b/components/TextFields.tsx
@@ -21,7 +21,6 @@ export type TextFieldProps = {
   leftAddon?: JSX.Element
   rightAddon?: JSX.Element
   error?: ReactNode
-  isFocused?: boolean
   textStyle?: StyleProp<TextStyle>
   style?: StyleProp<ViewStyle>
 } & Omit<TextInputProps, "style" | "placeholderStyle">
@@ -82,7 +81,7 @@ const TextFieldErrorView = ({ error }: { error: ReactNode }) => (
 )
 
 const InternalTextField = forwardRef(function TextField (
-  { leftAddon, rightAddon, textStyle, isFocused, ...props }: TextFieldProps,
+  { leftAddon, rightAddon, textStyle, ...props }: TextFieldProps,
   ref: TextFieldRef
 ) {
   return (

--- a/screens/ProfileScreen/Navigation/ProfileScreensNavigation.tsx
+++ b/screens/ProfileScreen/Navigation/ProfileScreensNavigation.tsx
@@ -150,7 +150,7 @@ const ProfileScreen = ({ route }: ProfileScreenProps) => {
 
 const ChangePasswordScreen = ({ navigation }: ChangePasswordScreenProps) => {
   const changePassword = useChangePasswordForm({
-    onSubmitted: async () => await delayData<ChangePasswordResult>("valid"),
+    changePassword: async () => await delayData<ChangePasswordResult>("valid"),
     onSuccess: () => navigation.goBack()
   })
   return <ChangePasswordFormView {...changePassword} />


### PR DESCRIPTION
This PR updates the change password to match the rest of the auth screens. Additionally, there were some bugs in the change password that needed to be fixed which required that we also need to display multiple error messages to the user.

Furthermore, the `isFocused` field was causing some weird issues on iOS when trying to do the "focus the next field when the user taps next on their keyboard" so we're back to using refs. This of course involved wrapping every single text field component with `forwardRef`...

Additionally, the text field error now animates in when it appears, which makes layout animations possible within these forms (as seen in the new change password screen).

I also added a storybook story for the screen and removed the password re-enter since it was an extra step that isn't really needed.