### PR TITLE
Update email-phone toggle

### DIFF
--- a/.storybook/components/SignUp/SignUp.stories.tsx
+++ b/.storybook/components/SignUp/SignUp.stories.tsx
@@ -68,7 +68,7 @@ const HandleScreen = () => {
 
 const TestScreen = () => {
   const navigation = useNavigation()
-  const { text, activeTextType, onTextChanged, onActiveTextTypeChanged } =
+  const { text, activeTextType, onTextChanged, onActiveTextTypeToggled } =
     useEmailPhoneTextState("phone")
   return (
     <ScrollView>
@@ -86,7 +86,7 @@ const TestScreen = () => {
         value={text}
         activeTextType={activeTextType}
         onChangeText={onTextChanged}
-        onActiveTextTypeChanged={onActiveTextTypeChanged}
+        onActiveTextTypeToggled={onActiveTextTypeToggled}
         style={{ marginTop: 48, paddingHorizontal: 16 }}
       />
     </ScrollView>

--- a/auth/AuthTextFields.tsx
+++ b/auth/AuthTextFields.tsx
@@ -6,15 +6,12 @@ import {
   TextFieldProps,
   TextFieldRef
 } from "@components/TextFields"
-import {
-  CircularIonicon,
-  IoniconName,
-  TouchableIonicon
-} from "@components/common/Icons"
-import { StyleProp, View, ViewStyle, StyleSheet } from "react-native"
+import { CircularIonicon, Ionicon, IoniconName } from "@components/common/Icons"
+import { StyleProp, ViewStyle, StyleSheet } from "react-native"
 import { useFontScale } from "@hooks/Fonts"
 import { AppStyles } from "@lib/AppColorStyle"
 import { EmailPhoneTextType } from "./UseEmailPhoneText"
+import { TouchableOpacity } from "react-native-gesture-handler"
 
 export type AuthShadedTextFieldProps = {
   iconName: IoniconName
@@ -83,7 +80,7 @@ export const AuthShadedPasswordTextField = forwardRef(function TextField (
 
 export type AuthEmailPhoneTextFieldProps = {
   activeTextType: EmailPhoneTextType
-  onActiveTextTypeChanged: (textType: EmailPhoneTextType) => void
+  onActiveTextTypeToggled: () => void
 } & Omit<AuthShadedTextFieldProps, "rightAddon" | "keyboardType" | "iconName">
 
 /**
@@ -92,7 +89,7 @@ export type AuthEmailPhoneTextFieldProps = {
 export const AuthShadedEmailPhoneTextFieldView = forwardRef(function TextField (
   {
     activeTextType,
-    onActiveTextTypeChanged,
+    onActiveTextTypeToggled,
     ...props
   }: AuthEmailPhoneTextFieldProps,
   ref: TextFieldRef
@@ -101,57 +98,27 @@ export const AuthShadedEmailPhoneTextFieldView = forwardRef(function TextField (
     <AuthShadedTextField
       {...props}
       ref={ref}
-      iconName={activeTextType === "email" ? "mail" : "phone-portrait"}
+      iconName={activeTextType === "email" ? "mail" : "call"}
       keyboardType={activeTextType === "phone" ? "number-pad" : "email-address"}
       rightAddon={
-        <View style={styles.toggleButtonsContainer}>
-          <TouchableIonicon
-            icon={{
-              name: "phone-portrait",
-              color:
-                activeTextType === "phone"
-                  ? AppStyles.darkColor
-                  : AppStyles.colorOpacity35
-            }}
-            onPress={() => onActiveTextTypeChanged("phone")}
-            style={styles.toggleButtonSpacing}
+        <TouchableOpacity
+          style={styles.emailPhoneToggleButtonContainer}
+          onPress={onActiveTextTypeToggled}
+        >
+          <Ionicon name="refresh" color={AppStyles.colorOpacity35} />
+          <Ionicon
+            name={activeTextType === "phone" ? "mail" : "call"}
+            color={AppStyles.colorOpacity35}
           />
-
-          <TouchableIonicon
-            icon={{
-              name: "mail",
-              color:
-                activeTextType === "email"
-                  ? AppStyles.darkColor
-                  : AppStyles.colorOpacity35
-            }}
-            onPress={() => onActiveTextTypeChanged("email")}
-          />
-        </View>
+        </TouchableOpacity>
       }
     />
   )
 })
 
 const styles = StyleSheet.create({
-  toggleContainer: {
-    position: "relative"
-  },
-  toggleButtonsContainer: {
+  emailPhoneToggleButtonContainer: {
     display: "flex",
     flexDirection: "row"
-  },
-  toggleButtonSpacing: {
-    marginRight: 8
-  },
-  toggleSelectionIndicator: {
-    width: 32,
-    height: 32,
-    borderRadius: 12,
-    backgroundColor: AppStyles.darkColor
-  },
-  toggleSelectionContainer: {
-    position: "absolute",
-    left: 0
   }
 })


### PR DESCRIPTION
This PR updates the toggle used in the `AuthShadedEmailPhoneTextField` component to use a refresh icon instead of having buttons that indicate which mode the user is in. The reasoning for this is to illustrate that pressing the button will actually switch the text field to use email or phone number.
<img width="535" alt="Screenshot 2023-09-22 at 9 04 34 PM" src="https://github.com/tifapp/FitnessProject/assets/75196016/5de80e4f-08a8-41bd-a91f-4b19b1091b69">
