### PR TITLE
Fix Sign-Up tests act warning

### DIFF
--- a/auth/sign-up/Navigation.test.tsx
+++ b/auth/sign-up/Navigation.test.tsx
@@ -24,6 +24,7 @@ import { TestQueryClientProvider } from "../../tests/helpers/ReactQuery"
 import { mswServer } from "../../tests/helpers/msw"
 import { createSignUpEnvironment } from "./Environment"
 import { SignUpParamsList, createSignUpScreens } from "./Navigation"
+import { fakeTimers } from "../../tests/helpers/Timers"
 
 type TestSignUpParamsList = {
   test: undefined
@@ -47,6 +48,9 @@ describe("SignUpNavigation tests", () => {
       )
     )
   )
+
+  afterEach(() => act(jest.runAllTimers))
+  fakeTimers()
 
   beforeEach(() => {
     jest.resetAllMocks()


### PR DESCRIPTION
It seems a recent change caused sign-up tests to get the act error. It turns out that it has to do with some random component animation in react-navigation, so I simply faked the timers and ran `jest.runAllTimers` in an act block at the end of each test.