### PR TITLE
Resend forgot password code + cleanup cognito code

### DIFF
--- a/.storybook/components/ForgotPassword/ForgotPasswordForm.stories.tsx
+++ b/.storybook/components/ForgotPassword/ForgotPasswordForm.stories.tsx
@@ -24,15 +24,7 @@ const Stack = createStackNavigator<ForgotPasswordParamsList>()
 
 const signUpScreens = createForgotPasswordScreens(
   Stack,
-  createForgotPasswordEnvironment({
-    forgotPassword: async (username: string) =>
-      await Auth.forgotPassword(username),
-    forgotPasswordSubmit: async (
-      username: string,
-      code: string,
-      password: string
-    ) => await Auth.forgotPasswordSubmit(username, code, password)
-  })
+  createForgotPasswordEnvironment(Auth)
 )
 
 export const Basic: ForgotPasswordStory = () => (

--- a/auth/AuthTextFields.tsx
+++ b/auth/AuthTextFields.tsx
@@ -119,6 +119,7 @@ export const AuthShadedEmailPhoneTextFieldView = forwardRef(function TextField (
       keyboardType={activeTextType === "phone" ? "number-pad" : "email-address"}
       placeholder="Phone number or Email"
       autoCapitalize="none"
+      autoCorrect={false}
       error={errorReason && emailPhoneTextStateErrorMessage(errorReason)}
       rightAddon={
         <TouchableOpacity

--- a/auth/AuthTextFields.tsx
+++ b/auth/AuthTextFields.tsx
@@ -118,6 +118,7 @@ export const AuthShadedEmailPhoneTextFieldView = forwardRef(function TextField (
       iconBackgroundColor="#14B329"
       keyboardType={activeTextType === "phone" ? "number-pad" : "email-address"}
       placeholder="Phone number or Email"
+      autoCapitalize="none"
       error={errorReason && emailPhoneTextStateErrorMessage(errorReason)}
       rightAddon={
         <TouchableOpacity

--- a/auth/CognitoHelpers.ts
+++ b/auth/CognitoHelpers.ts
@@ -2,7 +2,6 @@ import { Auth } from "@aws-amplify/auth"
 import * as ExpoSecureStore from "expo-secure-store"
 import awsExports from "../src/aws-exports"
 import { CognitoSecureStorage, SecureStore } from "./CognitoSecureStorage"
-import { EmailAddress, USPhoneNumber } from "./Models"
 
 /**
  * Sets up cognito with a secure store.
@@ -52,19 +51,4 @@ export const isCognitoErrorWithCode = (
     return error.code === code
   }
   return false
-}
-
-/**
- * Formats an email or phone number in the way cognito expects it.
- *
- * Phone Number -> `emailOrPhoneNumber.e164Formatted`
- *
- * Email -> `emailOrPhoneNumber.toString()`
- */
-export const cognitoFormatEmailOrPhoneNumber = (
-  emailOrPhoneNumber: EmailAddress | USPhoneNumber
-) => {
-  return emailOrPhoneNumber instanceof USPhoneNumber
-    ? emailOrPhoneNumber.e164Formatted
-    : emailOrPhoneNumber.toString()
 }

--- a/auth/Models.test.ts
+++ b/auth/Models.test.ts
@@ -41,19 +41,19 @@ describe("AuthModels tests", () => {
     })
 
     it("should parse phone numbers with exactly 10 digits", () => {
-      expect(USPhoneNumber.parse("1234567890")?.e164Formatted).toEqual(
+      expect(USPhoneNumber.parse("1234567890")?.toString()).toEqual(
         "+11234567890"
       )
     })
 
     it("should allow phone numbers in the format (***) ***-****", () => {
-      expect(USPhoneNumber.parse("(123) 456-7890")?.e164Formatted).toEqual(
+      expect(USPhoneNumber.parse("(123) 456-7890")?.toString()).toEqual(
         "+11234567890"
       )
     })
 
     it("should parse e.164 formatted phone numbers", () => {
-      expect(USPhoneNumber.parse("+11234567890")?.e164Formatted).toEqual(
+      expect(USPhoneNumber.parse("+11234567890")?.toString()).toEqual(
         "+11234567890"
       )
     })

--- a/auth/Models.ts
+++ b/auth/Models.ts
@@ -100,12 +100,14 @@ export class USPhoneNumber implements PrivacyFormattable {
     return `(***) ***-${this.rawValue.substring(6)}`
   }
 
-  get e164Formatted () {
-    return `+1${this.rawValue}`
-  }
-
+  /**
+   * Formats this phone number as an e.164 formatted string.
+   *
+   * Ex.
+   * `(123) 456-7890` -> `+11234567890`
+   */
   toString () {
-    return this.rawValue
+    return `+1${this.rawValue}`
   }
 
   /**

--- a/auth/forgot-password/Environment.test.tsx
+++ b/auth/forgot-password/Environment.test.tsx
@@ -33,13 +33,7 @@ describe("ForgotPasswordEnvironment tests", () => {
     cognito.forgotPassword.mockRejectedValueOnce(
       new TestCognitoError("UserNotFoundException")
     )
-
     const result = await env.initiateForgotPassword(USPhoneNumber.mock)
-
-    expect(cognito.forgotPassword).toHaveBeenCalledWith(
-      USPhoneNumber.mock.e164Formatted
-    )
-
     expect(result).toEqual("invalid-phone-number")
   })
 

--- a/auth/forgot-password/Environment.ts
+++ b/auth/forgot-password/Environment.ts
@@ -1,7 +1,4 @@
-import {
-  cognitoFormatEmailOrPhoneNumber,
-  isCognitoErrorWithCode
-} from "@auth/CognitoHelpers"
+import { isCognitoErrorWithCode } from "@auth/CognitoHelpers"
 import { Auth } from "@aws-amplify/auth"
 import { EmailAddress, Password, USPhoneNumber } from ".."
 
@@ -26,9 +23,7 @@ export const createForgotPasswordEnvironment = (
     emailOrPhoneNumber: EmailAddress | USPhoneNumber
   ): Promise<ForgotPasswordResult> => {
     try {
-      await cognito.forgotPassword(
-        cognitoFormatEmailOrPhoneNumber(emailOrPhoneNumber)
-      )
+      await cognito.forgotPassword(emailOrPhoneNumber.toString())
       return "success"
     } catch (err) {
       if (!isCognitoErrorWithCode(err, "UserNotFoundException")) throw err
@@ -36,6 +31,16 @@ export const createForgotPasswordEnvironment = (
         ? "invalid-email"
         : "invalid-phone-number"
     }
+  },
+  /**
+   * Attemps to resend a forgot password code.
+   *
+   * @param emailOrPhoneNumber the email or phone number of the account to resend the code to.
+   */
+  resendForgotPasswordCode: async (
+    emailOrPhoneNumber: EmailAddress | USPhoneNumber
+  ) => {
+    await cognito.forgotPassword(emailOrPhoneNumber.toString())
   },
   /**
    * Resets the user's password.
@@ -51,7 +56,7 @@ export const createForgotPasswordEnvironment = (
   ): Promise<ResetPasswordResult> => {
     try {
       await cognito.forgotPasswordSubmit(
-        cognitoFormatEmailOrPhoneNumber(emailOrPhoneNumber),
+        emailOrPhoneNumber.toString(),
         verificationCode,
         password.toString()
       )

--- a/auth/forgot-password/ForgotPasswordNavigation.test.tsx
+++ b/auth/forgot-password/ForgotPasswordNavigation.test.tsx
@@ -125,7 +125,8 @@ const renderForgotPasswordNavigation = () => {
   const Stack = createStackNavigator<TestForgotPasswordParamsList>()
   const signUpScreens = createForgotPasswordScreens(Stack, {
     initiateForgotPassword,
-    submitResettedPassword
+    submitResettedPassword,
+    resendForgotPasswordCode: jest.fn()
   })
   return render(
     <TestQueryClientProvider>

--- a/auth/forgot-password/ForgotPasswordNavigation.tsx
+++ b/auth/forgot-password/ForgotPasswordNavigation.tsx
@@ -45,7 +45,7 @@ type VerifyCodeScreenProps = StackScreenProps<
   ForgotPasswordParamsList,
   "verifyCode"
 > &
-  Pick<ForgotPasswordEnvironment, "initiateForgotPassword">
+  Pick<ForgotPasswordEnvironment, "resendForgotPasswordCode">
 
 type ResetPasswordScreenProps = StackScreenProps<
   ForgotPasswordParamsList,
@@ -87,7 +87,12 @@ export const createForgotPasswordScreens = <T extends ForgotPasswordParamsList>(
           title: ""
         })}
       >
-        {(props: any) => <VerifyCodeScreen {...props} />}
+        {(props: any) => (
+          <VerifyCodeScreen
+            {...props}
+            resendForgotPasswordCode={env.resendForgotPasswordCode}
+          />
+        )}
       </stack.Screen>
 
       <stack.Screen
@@ -123,9 +128,15 @@ const ForgotPasswordScreen = ({
   return <ForgotPasswordFormView {...forgotPassword} />
 }
 
-const VerifyCodeScreen = ({ navigation, route }: VerifyCodeScreenProps) => {
+const VerifyCodeScreen = ({
+  navigation,
+  route,
+  resendForgotPasswordCode
+}: VerifyCodeScreenProps) => {
   const form = useAuthVerificationCodeForm({
-    resendCode: async () => {},
+    resendCode: async () => {
+      await resendForgotPasswordCode(route.params.emailOrPhoneNumber)
+    },
     submitCode: async (code) => {
       return { isCorrect: true, data: code }
     },

--- a/auth/sign-in/Authenticator.test.ts
+++ b/auth/sign-in/Authenticator.test.ts
@@ -34,10 +34,6 @@ describe("CognitoSignInAuthenticator tests", () => {
         TEST_PASSWORD
       )
       expect(result).toEqual("success")
-      expect(cognito.signIn).toHaveBeenCalledWith(
-        USPhoneNumber.mock.e164Formatted,
-        TEST_PASSWORD
-      )
     })
 
     test("UserNotFoundException returns incorrect-credentials", async () => {
@@ -80,9 +76,6 @@ describe("CognitoSignInAuthenticator tests", () => {
         TEST_PASSWORD
       )
       expect(result).toEqual("sign-up-verification-required")
-      expect(cognito.resendSignUp).toHaveBeenCalledWith(
-        USPhoneNumber.mock.e164Formatted
-      )
     })
   })
 

--- a/auth/sign-in/Authenticator.ts
+++ b/auth/sign-in/Authenticator.ts
@@ -1,7 +1,4 @@
-import {
-  cognitoFormatEmailOrPhoneNumber,
-  isCognitoErrorWithCode
-} from "@auth/CognitoHelpers"
+import { isCognitoErrorWithCode } from "@auth/CognitoHelpers"
 import { Auth } from "@aws-amplify/auth"
 import { EmailAddress, USPhoneNumber } from ".."
 import { CognitoUser } from "amazon-cognito-identity-js"
@@ -55,7 +52,7 @@ export class CognitoSignInAuthenticator implements SignInAuthenticator {
 
   private signedInCognitoUser?: CognitoUser
   private previousSignInCredentials?: {
-    emailOrPhoneNumber: EmailAddress | USPhoneNumber
+    emailOrPhoneNumber: string
     uncheckedPassword: string
   }
 
@@ -69,11 +66,11 @@ export class CognitoSignInAuthenticator implements SignInAuthenticator {
   ) {
     try {
       this.previousSignInCredentials = {
-        emailOrPhoneNumber,
+        emailOrPhoneNumber: emailOrPhoneNumber.toString(),
         uncheckedPassword
       }
       this.signedInCognitoUser = await this.cognito.signIn(
-        cognitoFormatEmailOrPhoneNumber(emailOrPhoneNumber),
+        emailOrPhoneNumber.toString(),
         uncheckedPassword
       )
       return this.signedInCognitoUser?.challengeName === "SMS_MFA"
@@ -86,9 +83,7 @@ export class CognitoSignInAuthenticator implements SignInAuthenticator {
       ) {
         return "incorrect-credentials"
       } else if (isCognitoErrorWithCode(err, "UserNotConfirmedException")) {
-        await this.cognito.resendSignUp(
-          cognitoFormatEmailOrPhoneNumber(emailOrPhoneNumber)
-        )
+        await this.cognito.resendSignUp(emailOrPhoneNumber.toString())
         return "sign-up-verification-required"
       } else {
         throw err
@@ -99,9 +94,7 @@ export class CognitoSignInAuthenticator implements SignInAuthenticator {
   async resendSignInVerificationCode () {
     if (!this.previousSignInCredentials) return
     this.signedInCognitoUser = await this.cognito.signIn(
-      cognitoFormatEmailOrPhoneNumber(
-        this.previousSignInCredentials.emailOrPhoneNumber
-      ),
+      this.previousSignInCredentials.emailOrPhoneNumber,
       this.previousSignInCredentials.uncheckedPassword
     )
   }


### PR DESCRIPTION
This PR added the ability to resend the forgot password code. I also made `USPhoneNumber` return the e.164 formatted string inside its `toString` instead of as a separate property. This removed the cognito format function in exchange for a less verbose `toString`.