### PR TITLE
Event Handle New Format + Cleanup Linkify Parsing

### DIFF
--- a/components/ContentText.test.tsx
+++ b/components/ContentText.test.tsx
@@ -56,18 +56,18 @@ describe("ContentText tests", () => {
   })
 
   it("allows for opening an event based on its handle", () => {
-    const handle = "!why_people"
+    const handle = "!17|123/Pickup Basketball"
     renderLinkedText(
       `This is a handle\n${handle}\nthat brings you to an event.`
     )
-    tapText(handle)
+    tapText("Pickup Basketball")
     expect(eventHandleTappedAction).toHaveBeenCalledWith(
-      EventHandle.parse("why_people")
+      new EventHandle(123, "Pickup Basketball")
     )
   })
 
   it("does not detect !!handles as an event handle", () => {
-    const invalidHandle = "!!why_people"
+    const invalidHandle = "!!17|123/Pickup Basketball"
     renderLinkedText(invalidHandle)
     expectRegularText(invalidHandle)
   })
@@ -79,7 +79,7 @@ describe("ContentText tests", () => {
   })
 
   test("the character before an event handle must be whitespace for it to be valid", () => {
-    const text = "...!why_people"
+    const text = "...!17|123/Pickup Basketball"
     renderLinkedText(text)
     expectRegularText(text)
   })

--- a/components/ContentText.tsx
+++ b/components/ContentText.tsx
@@ -4,8 +4,8 @@ import { openURL } from "expo-linking"
 import { BodyText, Headline } from "./Text"
 import { linkify } from "@lib/Linkify"
 import { Match } from "linkify-it"
-import { UserHandle } from "@lib/users"
-import { EventHandle } from "@event-details"
+import { UserHandle, UserHandleLinkifyMatch } from "@lib/users"
+import { EventHandle, EventHandleLinkifyMatch } from "@event-details"
 
 export type ContentTextCallbacks = {
   onUserHandleTapped: (handle: UserHandle) => void
@@ -74,29 +74,25 @@ const renderLinkifyMatches = (
     blocks.push(text.substring(anchorIndex, match.index))
 
     if (match.schema === "@") {
+      const userHandleMatch = match as UserHandleLinkifyMatch
       blocks.push(
         <Headline
           key={`user-handle-${match.index}`}
           style={styles.handle}
-          onPress={() => {
-            const handle = UserHandle.parse(match.text.slice(1)).handle
-            if (handle) onUserHandleTapped(handle)
-          }}
+          onPress={() => onUserHandleTapped(userHandleMatch.userHandle)}
         >
-          {match.text}
+          {userHandleMatch.text}
         </Headline>
       )
     } else if (match.schema === "!") {
+      const eventHandleMatch = match as EventHandleLinkifyMatch
       blocks.push(
         <Headline
           key={`event-handle-${match.index}`}
           style={styles.handle}
-          onPress={() => {
-            const handle = EventHandle.parse(match.text.slice(1))
-            if (handle) onEventHandleTapped(handle)
-          }}
+          onPress={() => onEventHandleTapped(eventHandleMatch.eventHandle)}
         >
-          {match.text}
+          {eventHandleMatch.eventHandle.eventName}
         </Headline>
       )
     } else {

--- a/event-details/Event.test.ts
+++ b/event-details/Event.test.ts
@@ -84,26 +84,42 @@ describe("Event tests", () => {
   })
 
   describe("EventHandle tests", () => {
-    it("should parse a handle with letters, numbers, and underscores", () => {
-      expect(EventHandle.parse("jumping_in_the_air_642")!.toString()).toEqual(
-        "!jumping_in_the_air_642"
-      )
-      expect(EventHandle.parse("e")!.toString()).toEqual("!e")
-      expect(EventHandle.parse("Hello_World")!.toString()).toEqual(
-        "!Hello_World"
-      )
+    it("should be able to parse a valid handle string", () => {
+      const handle = EventHandle.parse("17|123/Pickup Basketball")
+      expect(handle?.eventId).toEqual(123)
+      expect(handle?.eventName).toEqual("Pickup Basketball")
     })
 
-    it("should not parse invalid handles", () => {
-      expect(EventHandle.parse("123")).toBeUndefined()
-      expect(EventHandle.parse("123_hello")).toBeUndefined()
-      expect(EventHandle.parse("123hello")).toBeUndefined()
+    it("should truncate the event name based on the length encoded in the handle", () => {
+      const handle = EventHandle.parse("12|123/Pickup Basketball")
+      expect(handle?.eventName).toEqual("Pickup Baske")
+    })
+
+    it("should be able to parse a valid handle string where the length is longer than the name", () => {
+      const handle = EventHandle.parse("420|123/Pickup Basketball")
+      expect(handle?.eventName).toEqual("Pickup Basketball")
+    })
+
+    it("should be able to parse a valid handle from a starting point in the given string", () => {
+      const handle = EventHandle.parse("!!!!17|123/Pickup Basketball", 4)
+      expect(handle?.eventId).toEqual(123)
+      expect(handle?.eventName).toEqual("Pickup Basketball")
+    })
+
+    test("invalid handles", () => {
       expect(EventHandle.parse("")).toBeUndefined()
-      expect(EventHandle.parse("__________")).toBeUndefined()
-      expect(EventHandle.parse("_hello")).toBeUndefined()
-      expect(EventHandle.parse("!hello")).toBeUndefined()
-      expect(EventHandle.parse("{}{}}{}{}{}{")).toBeUndefined()
-      expect(EventHandle.parse("*(&^*(&*(&*(&")).toBeUndefined()
+      expect(EventHandle.parse("123/Pickup Basketball")).toBeUndefined()
+      expect(EventHandle.parse("17|Pickup Basketball")).toBeUndefined()
+      expect(EventHandle.parse("hello world")).toBeUndefined()
+      expect(EventHandle.parse("abc|123/Pickup Basketball")).toBeUndefined()
+      expect(EventHandle.parse("17|abc/Pickup Basketball")).toBeUndefined()
+      expect(EventHandle.parse("!17|123/Pickup Basketball")).toBeUndefined()
+    })
+
+    test("toString", () => {
+      expect(new EventHandle(123, "Pickup Basketball").toString()).toEqual(
+        "!17|123/Pickup Basketball"
+      )
     })
   })
 })

--- a/event-details/Event.ts
+++ b/event-details/Event.ts
@@ -88,7 +88,6 @@ export const linkifyAddEventHandleValidation = (linkify: LinkifyIt) => {
   linkify.add("!", {
     validate: (text: string, pos: number) => {
       parsedHandle = EventHandle.parse(text, pos)
-      console.log(parsedHandle, text, pos)
       if (!parsedHandle) return false
       if (pos >= 2 && !StringUtils.isWhitespaceCharacter(text, pos - 2)) {
         return false

--- a/event-details/Event.ts
+++ b/event-details/Event.ts
@@ -9,52 +9,74 @@ import { uuid } from "@lib/uuid"
 import * as Clipboard from "expo-clipboard"
 import { StringUtils } from "@lib/String"
 import { ZodUtils } from "@lib/Zod"
-import { LinkifyIt } from "linkify-it"
+import { LinkifyIt, Match } from "linkify-it"
 import { showLocation } from "react-native-map-link"
 
 /**
  * A handle that users can reference other events with.
  *
- * Each event has a handle that is generated from its name similar to user handles.
- * Since {@link UserHandle}s are already referenced through the `@` sign, event handles
- * are referenced via `!`.
+ * Event handles are not visible to users, rather they are an internal detail
+ * that allow users to reference events easily. A raw form of the handle is
+ * embedded in text like bios, chat messages, etc. that takes the form:
  *
- * A valid event handle consists of only letters, numbers, and underscores, but
- * must start with a letter and be at least 1 character long.
+ * `"!<event-name-length>|<event-id>/<event-name>"`
+ *
+ * This form is not visible to the user, but rather just the event name is shown in
+ * the resulting text to the user.
  */
 export class EventHandle {
   static zodSchema = ZodUtils.createOptionalParseableSchema(EventHandle)
 
-  readonly rawValue: string
+  readonly eventId: number
+  readonly eventName: string
 
-  private constructor (rawValue: string) {
-    this.rawValue = rawValue
+  constructor (eventId: number, eventName: string) {
+    this.eventId = eventId
+    this.eventName = eventName
   }
 
   /**
-   * Formats this handle by prefixing it with an "!".
+   * Formats this event handle back to its raw form.
    */
   toString () {
-    return `!${this.rawValue}`
+    return `!${this.eventName.length}|${this.eventId}/${this.eventName}`
   }
-
-  private static REGEX = /^[a-zA-Z]{1}[a-zA-Z0-9_]*$/
 
   /**
    * Attempts to parse an {@link EventHandle} from a raw string.
    *
-   * A valid event handle consists of only letters, numbers, and underscores, but
-   * must start with a letter and be at least 1 character long.
+   * A valid event handle takes the form `"<event-name-length>|<event-id>/<event-name>""`
+   * (note the omitted `"!"` at the start).
    *
    * @param rawValue the raw string to attempt to parse.
+   * @param startPosition the position of the string to begin parsing at (defaults to 0).
    * @returns an {@link EventHandle} instance if valid.
    */
-  static parse (rawValue: string) {
-    return EventHandle.REGEX.test(rawValue)
-      ? new EventHandle(rawValue)
-      : undefined
+  static parse (rawValue: string, startPosition: number = 0) {
+    const lengthSeparatorIndex = rawValue.indexOf("|", startPosition)
+    if (lengthSeparatorIndex === -1) return undefined
+
+    const slashIndex = rawValue.indexOf("/", lengthSeparatorIndex)
+    if (slashIndex === -1) return undefined
+
+    const eventId = parseInt(
+      rawValue.substring(lengthSeparatorIndex + 1, slashIndex)
+    )
+    if (Number.isNaN(eventId)) return undefined
+
+    const nameLength = parseInt(
+      rawValue.substring(startPosition, lengthSeparatorIndex)
+    )
+    if (Number.isNaN(nameLength)) return undefined
+
+    return new EventHandle(
+      eventId,
+      rawValue.substring(slashIndex + 1, slashIndex + 1 + nameLength)
+    )
   }
 }
+
+export type EventHandleLinkifyMatch = Match & { eventHandle: EventHandle }
 
 /**
  * Adds event handle validation to a linkify config.
@@ -62,19 +84,19 @@ export class EventHandle {
  * @param linkify see {@link LinkifyIt}
  */
 export const linkifyAddEventHandleValidation = (linkify: LinkifyIt) => {
+  let parsedHandle: EventHandle | undefined
   linkify.add("!", {
     validate: (text: string, pos: number) => {
-      const slice = text.slice(pos)
-      const handle = slice.split(/\s/)[0] ?? slice
-
-      if (!EventHandle.parse(handle)) return false
+      parsedHandle = EventHandle.parse(text, pos)
+      console.log(parsedHandle, text, pos)
+      if (!parsedHandle) return false
       if (pos >= 2 && !StringUtils.isWhitespaceCharacter(text, pos - 2)) {
         return false
       }
-      return handle.length
+      return parsedHandle.toString().length
     },
-    normalize: (match) => {
-      match.url = "tifapp://event/" + match.url.replace(/^!/, "")
+    normalize: (match: EventHandleLinkifyMatch) => {
+      if (parsedHandle) match.eventHandle = parsedHandle
     }
   })
 }
@@ -201,7 +223,6 @@ export const openEventLocationInMaps = (
 export type Event = {
   host: EventAttendee
   id: string
-  handle: EventHandle
   title: string
   description: string
   dateRange: FixedDateRange
@@ -250,7 +271,6 @@ export namespace EventMocks {
   export const PickupBasketball = {
     host: EventAttendeeMocks.Alivs,
     id: uuid(),
-    handle: EventHandle.parse("pickup_basketball1234")!,
     title: "Pickup Basketball",
     description: "I'm better than Lebron James.",
     dateRange: dateRange(
@@ -279,7 +299,6 @@ export namespace EventMocks {
   export const Multiday = {
     host: EventAttendeeMocks.Alivs,
     id: uuid(),
-    handle: EventHandle.parse("multiday_marathon6666")!,
     title: "Multiday Event",
     description: "This event runs for more than one day.",
     dateRange: dateRange(
@@ -308,7 +327,6 @@ export namespace EventMocks {
   export const NoPlacemarkInfo = {
     host: EventAttendeeMocks.Alivs,
     id: uuid(),
-    handle: EventHandle.parse("lol")!,
     title: "No Placemark Info",
     attendeeCount: 5,
     description:


### PR DESCRIPTION
Updates the `EventHandle` class to support the new format we agreed on. Additionally, the initializer is now public provided that you have and event id and event name.

I also updated the linkify parsing using a similar hack to the zod optional parsing approach so that we don't need to parse handles multiple times (once in linkify parsing, the other in `ContentText`).