### PR TITLE
Read more text

### DIFF
--- a/.storybook/components/ContentText/ContextText.stories.tsx
+++ b/.storybook/components/ContentText/ContextText.stories.tsx
@@ -1,30 +1,45 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
 import React, { useState } from "react"
-import IconButton from "../../../components/common/IconButton"
-import { View } from "react-native"
-import { ContentText } from "@components/ContentText"
-import { TextInput } from "react-native-gesture-handler"
+import { ContentText, ExpandableContentText } from "@components/ContentText"
+import { ScrollView, TextInput } from "react-native-gesture-handler"
+import { Headline } from "@components/Text"
 
 const StoryText = () => {
-  const [text, setText] = useState("")
+  const [text, setText] = useState(
+    "Hello world, this is an @event of some kind. Please join it if you like to do nothing. \n\nNow I write this endless storybook story in the void, where \nI can test things like @hello to make sure that links are highlighting and I am not going absolutely crazy."
+  )
   return (
-    <View
-      style={{ height: "100%", justifyContent: "center", alignItems: "center" }}
-    >
-      <ContentText
-        style={{ width: "100%" }}
+    <ScrollView style={{ marginTop: 64 }}>
+      <Headline>Expandable Text</Headline>
+      <ExpandableContentText
+        initialText={text}
+        collapsedLineLimit={2}
         onUserHandleTapped={console.log}
-        text={text}
+        onEventHandleTapped={console.log}
+        expandButtonTextStyle={{ color: "red" }}
+        style={{ marginBottom: 24, marginTop: 8 }}
       />
+      <Headline>No Long Enought Text</Headline>
+      <ExpandableContentText
+        initialText="Hello world, this is longer than one line possibly. Now it is..."
+        collapsedLineLimit={5}
+        onUserHandleTapped={console.log}
+        onEventHandleTapped={console.log}
+      />
+      <Headline style={{ marginTop: 24 }}>Text Input</Headline>
       <TextInput multiline style={{ width: "100%" }} onChangeText={setText}>
-        <ContentText onUserHandleTapped={console.log} text={text} />
+        <ContentText
+          onUserHandleTapped={console.log}
+          onEventHandleTapped={console.log}
+          text={text}
+        />
       </TextInput>
-    </View>
+    </ScrollView>
   )
 }
 
 const ContentTextMeta: ComponentMeta<typeof StoryText> = {
-  title: "LinkedText",
+  title: "Content Text",
   component: StoryText
 }
 

--- a/components/ContentText.tsx
+++ b/components/ContentText.tsx
@@ -86,11 +86,7 @@ export const ExpandableContentText = ({
   const [expansionStatus, setExpansionStatus] = useState<
     "expandable" | "unexpandable" | undefined
   >()
-  const textSplitsRef = useRef({
-    collapsedText: "",
-    expandedText: "",
-    originalText: ""
-  })
+  const textSplitsRef = useRef({ collapsedText: "", expandedText: "" })
   const numberOfLines = expansionStatus
     ? collapsedLineLimit
     : collapsedLineLimit + 1
@@ -106,7 +102,6 @@ export const ExpandableContentText = ({
             return
           }
           const textBlocks = e.nativeEvent.lines.map((line) => line.text)
-          textSplitsRef.current.originalText = initialText
           const visibleText = textBlocks
             .slice(0, textBlocks.length - 1)
             .join("")

--- a/components/ContentText.tsx
+++ b/components/ContentText.tsx
@@ -1,11 +1,20 @@
-import React, { useMemo } from "react"
-import { StyleSheet, TextProps } from "react-native"
+import React, { useMemo, useRef, useState } from "react"
+import {
+  StyleProp,
+  StyleSheet,
+  TextProps,
+  TextStyle,
+  TouchableOpacity,
+  View,
+  ViewStyle
+} from "react-native"
 import { openURL } from "expo-linking"
 import { BodyText, Headline } from "./Text"
 import { linkify } from "@lib/Linkify"
 import { Match } from "linkify-it"
 import { UserHandle, UserHandleLinkifyMatch } from "@lib/users"
 import { EventHandle, EventHandleLinkifyMatch } from "@event-details"
+import Animated, { FadeIn, Layout } from "react-native-reanimated"
 
 export type ContentTextCallbacks = {
   onUserHandleTapped: (handle: UserHandle) => void
@@ -49,6 +58,94 @@ export const ContentText = ({
     )}
   </BodyText>
 )
+
+export type ExpandableContentTextProps = {
+  collapsedLineLimit: number
+  initialText: string
+  contentTextStyle?: StyleProp<TextStyle>
+  expandButtonTextStyle?: StyleProp<TextStyle>
+  style?: StyleProp<ViewStyle>
+} & Omit<ContentTextProps, "numberOfLines" | "text" | "style">
+
+/**
+ * Content text that expands when the user presses a "Read More" button.
+ *
+ * At the moment, this only renders the initial text given to it correctly, it does not
+ * render any changes to the input text.
+ */
+export const ExpandableContentText = ({
+  collapsedLineLimit,
+  onTextLayout,
+  initialText,
+  contentTextStyle,
+  expandButtonTextStyle,
+  style,
+  ...props
+}: ExpandableContentTextProps) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [expansionStatus, setExpansionStatus] = useState<
+    "expandable" | "unexpandable" | undefined
+  >()
+  const textSplitsRef = useRef({
+    collapsedText: "",
+    expandedText: "",
+    originalText: ""
+  })
+  const numberOfLines = expansionStatus
+    ? collapsedLineLimit
+    : collapsedLineLimit + 1
+  return (
+    <View style={style}>
+      <ContentText
+        {...props}
+        text={isExpanded ? textSplitsRef.current.collapsedText : initialText}
+        numberOfLines={isExpanded ? undefined : numberOfLines}
+        onTextLayout={(e) => {
+          if (expansionStatus) {
+            onTextLayout?.(e)
+            return
+          }
+          const textBlocks = e.nativeEvent.lines.map((line) => line.text)
+          textSplitsRef.current.originalText = initialText
+          const visibleText = textBlocks
+            .slice(0, textBlocks.length - 1)
+            .join("")
+          textSplitsRef.current.collapsedText = visibleText.endsWith("\n")
+            ? visibleText.slice(0, visibleText.length - 1)
+            : visibleText
+          textSplitsRef.current.expandedText = initialText.slice(
+            visibleText.length
+          )
+          setExpansionStatus(
+            textBlocks.length !== collapsedLineLimit + 1
+              ? "unexpandable"
+              : "expandable"
+          )
+          onTextLayout?.(e)
+        }}
+        style={[contentTextStyle, { opacity: expansionStatus ? 1 : 0 }]}
+      />
+      {isExpanded && (
+        <Animated.View entering={FadeIn.duration(300)}>
+          <ContentText {...props} text={textSplitsRef.current.expandedText} />
+        </Animated.View>
+      )}
+      {expansionStatus === "expandable" && (
+        <Animated.View layout={Layout.duration(300)}>
+          <TouchableOpacity
+            onPress={() => setIsExpanded((expanded) => !expanded)}
+            style={styles.readMore}
+            hitSlop={44}
+          >
+            <Headline style={expandButtonTextStyle}>
+              {isExpanded ? "Read Less" : "Read More"}
+            </Headline>
+          </TouchableOpacity>
+        </Animated.View>
+      )}
+    </View>
+  )
+}
 
 const useTextBlocks = (text: string, callbacks: ContentTextCallbacks) => {
   return useMemo(() => renderLinkTextBlocks(text, callbacks), [text, callbacks])
@@ -119,5 +216,8 @@ const styles = StyleSheet.create({
   },
   handle: {
     color: "#4285F4"
+  },
+  readMore: {
+    marginTop: 8
   }
 })

--- a/lib/Reanimated.ts
+++ b/lib/Reanimated.ts
@@ -3,4 +3,4 @@ import { Layout } from "react-native-reanimated"
 /**
  * The default layout transition to use whe working with reanimated.
  */
-export const TiFDefaultLayoutTransition = Layout.springify().damping(12.5)
+export const TiFDefaultLayoutTransition = Layout.springify().damping(14)


### PR DESCRIPTION
Adds a new expanding text component that uses `ContentText` under the hood so that handles and whatnot are rendered. It also has a much smoother fade animation when the text expands, and doesn't rely on a hardcoded text height such that it works with dynamic type.

Of course, solving the layout issues was quite a bit hacky, and the approach used splits the text up into 2 groups based on what is supposed to render and what isn't.