### PR TITLE
Add color to Event Handles

### DIFF
--- a/.storybook/components/ContentText/ContextText.stories.tsx
+++ b/.storybook/components/ContentText/ContextText.stories.tsx
@@ -21,7 +21,7 @@ const StoryText = () => {
       />
       <Headline>No Long Enought Text</Headline>
       <ExpandableContentText
-        initialText="Hello world, this is longer than one line possibly. Now it is..."
+        initialText="Now, for the new event! !17|123/#2BC016/Pickup Basketball"
         collapsedLineLimit={5}
         onUserHandleTapped={console.log}
         onEventHandleTapped={console.log}

--- a/content-parsing/ContentText.test.tsx
+++ b/content-parsing/ContentText.test.tsx
@@ -2,6 +2,7 @@ import { ContentText } from "./ContentText"
 import { EventHandle } from "./EventHandle"
 import { fireEvent, render, screen } from "@testing-library/react-native"
 import { UserHandle } from "./UserHandle"
+import { ColorString } from "@lib/Color"
 
 describe("ContentText tests", () => {
   beforeEach(() => jest.resetAllMocks())
@@ -56,13 +57,13 @@ describe("ContentText tests", () => {
   })
 
   it("allows for opening an event based on its handle", () => {
-    const handle = "!17|123/Pickup Basketball"
+    const handle = "!17|123/#123456/Pickup Basketball"
     renderLinkedText(
       `This is a handle\n${handle}\nthat brings you to an event.`
     )
     tapText("Pickup Basketball")
     expect(eventHandleTappedAction).toHaveBeenCalledWith(
-      new EventHandle(123, "Pickup Basketball")
+      new EventHandle(123, "Pickup Basketball", ColorString.parse("#123456")!)
     )
   })
 

--- a/content-parsing/ContentText.tsx
+++ b/content-parsing/ContentText.tsx
@@ -93,7 +93,7 @@ const renderLinkifyMatches = (
       blocks.push(
         <Headline
           key={`event-handle-${match.index}`}
-          style={styles.handle}
+          style={{ color: eventHandleMatch.eventHandle.color.toString() }}
           onPress={() => onEventHandleTapped(eventHandleMatch.eventHandle)}
         >
           {eventHandleMatch.eventHandle.eventName}

--- a/content-parsing/EventHandle.test.ts
+++ b/content-parsing/EventHandle.test.ts
@@ -1,24 +1,26 @@
+import { ColorString } from "@lib/Color"
 import { EventHandle } from "./EventHandle"
 
 describe("EventHandle tests", () => {
   it("should be able to parse a valid handle string", () => {
-    const handle = EventHandle.parse("17|123/Pickup Basketball")
+    const handle = EventHandle.parse("17|123/#123456/Pickup Basketball")
     expect(handle?.eventId).toEqual(123)
     expect(handle?.eventName).toEqual("Pickup Basketball")
+    expect(handle?.color).toEqual(ColorString.parse("#123456"))
   })
 
   it("should truncate the event name based on the length encoded in the handle", () => {
-    const handle = EventHandle.parse("12|123/Pickup Basketball")
+    const handle = EventHandle.parse("12|123/#123456/Pickup Basketball")
     expect(handle?.eventName).toEqual("Pickup Baske")
   })
 
   it("should be able to parse a valid handle string where the length is longer than the name", () => {
-    const handle = EventHandle.parse("420|123/Pickup Basketball")
+    const handle = EventHandle.parse("420|123/#123456/Pickup Basketball")
     expect(handle?.eventName).toEqual("Pickup Basketball")
   })
 
   it("should be able to parse a valid handle from a starting point in the given string", () => {
-    const handle = EventHandle.parse("!!!!17|123/Pickup Basketball", 4)
+    const handle = EventHandle.parse("!!!!17|123/#123456/Pickup Basketball", 4)
     expect(handle?.eventId).toEqual(123)
     expect(handle?.eventName).toEqual("Pickup Basketball")
   })
@@ -31,11 +33,18 @@ describe("EventHandle tests", () => {
     expect(EventHandle.parse("abc|123/Pickup Basketball")).toBeUndefined()
     expect(EventHandle.parse("17|abc/Pickup Basketball")).toBeUndefined()
     expect(EventHandle.parse("!17|123/Pickup Basketball")).toBeUndefined()
+    expect(
+      EventHandle.parse("17|123/#ZZZZZZ/Pickup Basketball")
+    ).toBeUndefined()
   })
 
   test("toString", () => {
-    expect(new EventHandle(123, "Pickup Basketball").toString()).toEqual(
-      "!17|123/Pickup Basketball"
-    )
+    expect(
+      new EventHandle(
+        123,
+        "Pickup Basketball",
+        ColorString.parse("#123456")!
+      ).toString()
+    ).toEqual("!17|123/#123456/Pickup Basketball")
   })
 })

--- a/content-parsing/EventHandle.ts
+++ b/content-parsing/EventHandle.ts
@@ -1,3 +1,4 @@
+import { ColorString } from "@lib/Color"
 import { ZodUtils } from "@lib/Zod"
 
 /**
@@ -7,7 +8,7 @@ import { ZodUtils } from "@lib/Zod"
  * that allow users to reference events easily. A raw form of the handle is
  * embedded in text like bios, chat messages, etc. that takes the form:
  *
- * `"!<event-name-length>|<event-id>/<event-name>"`
+ * `"!<event-name-length>|<event-id>/<event-color>/<event-name>"`
  *
  * This form is not visible to the user, but rather just the event name is shown in
  * the resulting text to the user.
@@ -17,23 +18,25 @@ export class EventHandle {
 
   readonly eventId: number
   readonly eventName: string
+  readonly color: ColorString
 
-  constructor (eventId: number, eventName: string) {
+  constructor (eventId: number, eventName: string, color: ColorString) {
     this.eventId = eventId
     this.eventName = eventName
+    this.color = color
   }
 
   /**
    * Formats this event handle back to its raw form.
    */
   toString () {
-    return `!${this.eventName.length}|${this.eventId}/${this.eventName}`
+    return `!${this.eventName.length}|${this.eventId}/${this.color}/${this.eventName}`
   }
 
   /**
    * Attempts to parse an {@link EventHandle} from a raw string.
    *
-   * A valid event handle takes the form `"<event-name-length>|<event-id>/<event-name>""`
+   * A valid event handle takes the form `"<event-name-length>|<event-id>/<event-color>/<event-name>"`
    * (note the omitted `"!"` at the start).
    *
    * @param rawValue the raw string to attempt to parse.
@@ -44,13 +47,21 @@ export class EventHandle {
     const lengthSeparatorIndex = rawValue.indexOf("|", startPosition)
     if (lengthSeparatorIndex === -1) return undefined
 
-    const slashIndex = rawValue.indexOf("/", lengthSeparatorIndex)
-    if (slashIndex === -1) return undefined
+    const firstSlashIndex = rawValue.indexOf("/", lengthSeparatorIndex)
+    if (firstSlashIndex === -1) return undefined
+
+    const secondSlashIndex = rawValue.indexOf("/", firstSlashIndex + 1)
+    if (secondSlashIndex === -1) return undefined
 
     const eventId = parseInt(
-      rawValue.substring(lengthSeparatorIndex + 1, slashIndex)
+      rawValue.substring(lengthSeparatorIndex + 1, firstSlashIndex)
     )
     if (Number.isNaN(eventId)) return undefined
+
+    const color = ColorString.parse(
+      rawValue.substring(firstSlashIndex + 1, secondSlashIndex)
+    )
+    if (!color) return undefined
 
     const nameLength = parseInt(
       rawValue.substring(startPosition, lengthSeparatorIndex)
@@ -59,7 +70,11 @@ export class EventHandle {
 
     return new EventHandle(
       eventId,
-      rawValue.substring(slashIndex + 1, slashIndex + 1 + nameLength)
+      rawValue.substring(
+        secondSlashIndex + 1,
+        secondSlashIndex + 1 + nameLength
+      ),
+      color
     )
   }
 }

--- a/lib/AppColorStyle.ts
+++ b/lib/AppColorStyle.ts
@@ -1,8 +1,16 @@
+import { ColorString } from "./Color"
+
 export namespace AppStyles {
-  export const darkColor = "#26282A"
-  export const colorOpacity15 = "#26282A26" // 15% Opacity
-  export const colorOpacity50 = "#26282A80" // 50% Opacity
-  export const colorOpacity35 = "#26282A59" // 35% Opacity
+  export const darkColor = ColorString.primaryDarkColor.toString()
+  export const colorOpacity15 = ColorString.primaryDarkColor
+    .withOpacity(0.15)
+    .toString()
+  export const colorOpacity50 = ColorString.primaryDarkColor
+    .withOpacity(0.5)
+    .toString()
+  export const colorOpacity35 = ColorString.primaryDarkColor
+    .withOpacity(0.35)
+    .toString()
   export const errorColor = "#EA4335"
   export const highlightedText = "#4285F4"
   export const eventCardColor = "#F4F4F6"

--- a/lib/Color.test.ts
+++ b/lib/Color.test.ts
@@ -1,0 +1,48 @@
+import { ColorString } from "./Color"
+
+describe("ColorString tests", () => {
+  it("should parse rrggbb color strings", () => {
+    expectParses("#123456")
+    expectParses("#aabbcc")
+    expectParses("#AAbbCC")
+    expectParses("#FF12EE")
+    expectParses("#Ab66Ff")
+    expectParses("#999999")
+    expectParses("#000000")
+    expectParses("#DDddDD")
+  })
+
+  it("should parse rrggbbaa color strings", () => {
+    expectParses("#12345612")
+    expectParses("#aabbccAA")
+    expectParses("#FFFFFFaa")
+  })
+
+  test("invalid color strings", () => {
+    expectNotParses("12345677")
+    expectNotParses("#ZZZZZZ")
+    expectNotParses("#123")
+    expectNotParses("Hello world")
+    expectNotParses("white")
+    expectNotParses("")
+  })
+
+  const expectParses = (rawString: string) => {
+    const hexString = ColorString.parse(rawString)?.toString().toLowerCase()
+    expect(hexString).toEqual(rawString.toLowerCase())
+  }
+
+  const expectNotParses = (rawString: string) => {
+    expect(ColorString.parse(rawString)).toBeUndefined()
+  }
+
+  test("opacity", () => {
+    expect(
+      ColorString.parse("#ffffff")?.withOpacity(0.66666666666).toString()
+    ).toEqual("#ffffffaa")
+
+    expect(ColorString.parse("#ffffff")?.withOpacity(0.49).toString()).toEqual(
+      "#ffffff7d"
+    )
+  })
+})

--- a/lib/Color.ts
+++ b/lib/Color.ts
@@ -40,7 +40,7 @@ export class ColorString {
     return this.rgbHexString + opacityHexString
   }
 
-  private static RGB_LENGTH = 7
+  private static RGB_HEX_STRING_LENGTH = 7
   private static REGEX = /^#([a-f0-9]{2}){3,4}$/i
 
   /**
@@ -58,19 +58,16 @@ export class ColorString {
    */
   static parse (hexString: string) {
     if (!ColorString.REGEX.test(hexString)) return undefined
+    const opacityHex = hexString.slice(ColorString.RGB_HEX_STRING_LENGTH)
     return new ColorString(
-      hexString.substring(0, ColorString.RGB_LENGTH),
-      hexString.length === ColorString.RGB_LENGTH
+      hexString.substring(0, ColorString.RGB_HEX_STRING_LENGTH),
+      hexString.length === ColorString.RGB_HEX_STRING_LENGTH
         ? 1
-        : normalizeFrom0To1(hexString.substring(ColorString.RGB_LENGTH))
+        : parseInt(opacityHex, 16) / 255
     )
   }
 
   static primaryDarkColor = ColorString.parse("#26282A")!
 
   static zodSchema = ZodUtils.createOptionalParseableSchema(ColorString)
-}
-
-const normalizeFrom0To1 = (hexString: string) => {
-  return (parseInt(hexString, 16) & 0xff) / 255
 }

--- a/lib/Color.ts
+++ b/lib/Color.ts
@@ -1,3 +1,5 @@
+import { ZodUtils } from "./Zod"
+
 /**
  * A simple type to ensure that a hex color string takes somewhat the shape
  * of a hex string.
@@ -7,3 +9,68 @@
  * an attempt was made...
  */
 export type HexColor = `#${string}`
+
+/**
+ * An easy way to manipulate characteristics of color strings (Alpha, RGB, etc.).
+ */
+export class ColorString {
+  private readonly rgbHexString: string
+  readonly opacity: number
+
+  private constructor (rgbaHexString: string, opacity: number) {
+    this.rgbHexString = rgbaHexString
+    this.opacity = opacity
+  }
+
+  /**
+   * Returns a new {@link ColorString} instance with the set opacity.
+   *
+   * @param value a number in the range from 0 to 1
+   */
+  withOpacity (value: number) {
+    return new ColorString(this.rgbHexString, value)
+  }
+
+  /**
+   * Outputs this string in hex omitting the alpha if `opacity` is 1.
+   */
+  toString () {
+    const opacityHexString =
+      this.opacity === 1 ? "" : Math.ceil(255 * this.opacity).toString(16)
+    return this.rgbHexString + opacityHexString
+  }
+
+  private static RGB_LENGTH = 7
+  private static REGEX = /^#([a-f0-9]{2}){3,4}$/i
+
+  /**
+   * Parses a color string from a hex rgb or rgba string.
+   *
+   * Ex.
+   *
+   * `#aabbcc -> ✅`
+   *
+   * `#123456aa -> ✅`
+   *
+   * `#123456AA -> ✅` (Case insensitive)
+   *
+   * `123456AA -> 🔴` (Needs #)
+   */
+  static parse (hexString: string) {
+    if (!ColorString.REGEX.test(hexString)) return undefined
+    return new ColorString(
+      hexString.substring(0, ColorString.RGB_LENGTH),
+      hexString.length === ColorString.RGB_LENGTH
+        ? 1
+        : normalizeFrom0To1(hexString.substring(ColorString.RGB_LENGTH))
+    )
+  }
+
+  static primaryDarkColor = ColorString.parse("#26282A")!
+
+  static zodSchema = ZodUtils.createOptionalParseableSchema(ColorString)
+}
+
+const normalizeFrom0To1 = (hexString: string) => {
+  return (parseInt(hexString, 16) & 0xff) / 255
+}


### PR DESCRIPTION
This PR experiments with adding a color to the event handle so that the event name when rendered in text could be the same color of the actual event. This changes the handle format slightly of course:

`!<name-length>|<id>/<name>` -> `!<name-length>|<id>/<hex-color>/<name>`

To do this, I added a new `ColorString` class which can be constructed by parsing a typical hex color string. However, this class also can serve as a utility for manipulating attributes of colors such as opacity, which we do a few times especially around background and border colors.

Anyways, here's an event name colored in green for reference:
<img width="407" alt="Screenshot 2023-11-19 at 8 22 38 PM" src="https://github.com/tifapp/FitnessProject/assets/75196016/cd95d817-7955-4dd0-93e8-1ff565208181">
