### PR TITLE
Background Location Permissions Setup

### DIFF
--- a/.storybook/components/Explore/Explore.stories.tsx
+++ b/.storybook/components/Explore/Explore.stories.tsx
@@ -15,6 +15,7 @@ import { NavigationContainer } from "@react-navigation/native"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import {
   getCurrentPositionAsync,
+  requestBackgroundPermissionsAsync,
   requestForegroundPermissionsAsync
 } from "expo-location"
 
@@ -43,6 +44,7 @@ export const Basic: ExploreEventsStory = () => (
       <UserLocationFunctionsProvider
         getCurrentLocation={getCurrentPositionAsync}
         requestForegroundPermissions={requestForegroundPermissionsAsync}
+        requestBackgroundPermissions={requestBackgroundPermissionsAsync}
       >
         <SafeAreaProvider>
           <NavigationContainer onStateChange={console.log}>

--- a/.storybook/components/LocationSearch/LocationSearch.stories.tsx
+++ b/.storybook/components/LocationSearch/LocationSearch.stories.tsx
@@ -18,10 +18,7 @@ import {
 import { createStackNavigator } from "@react-navigation/stack"
 import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
-import {
-  getCurrentPositionAsync,
-  requestForegroundPermissionsAsync
-} from "expo-location"
+import { PermissionStatus, getCurrentPositionAsync } from "expo-location"
 import React from "react"
 import { Button } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -40,18 +37,27 @@ export const Basic: LocationSearchStory = () => (
   <TiFQueryClientProvider>
     <UserLocationFunctionsProvider
       getCurrentLocation={getCurrentPositionAsync}
-      requestForegroundPermissions={requestForegroundPermissionsAsync}
+      requestForegroundPermissions={async () => ({
+        expires: Infinity,
+        canAskAgain: true,
+        granted: true,
+        status: PermissionStatus.GRANTED
+      })}
+      requestBackgroundPermissions={async () => ({
+        expires: Infinity,
+        canAskAgain: true,
+        granted: true,
+        status: PermissionStatus.GRANTED
+      })}
     >
       <NavigationContainer>
-        <Stack.Navigator
-          screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}
-          headerMode="screen"
-        >
+        <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
           <Stack.Screen name="settings" component={TestScreen} />
           <Stack.Screen
             name="search"
             options={{
-              header: () => <LocationSearchHeader />
+              header: () => <LocationSearchHeader />,
+              headerMode: "screen"
             }}
             component={LocationSearchScreen}
           />

--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import { createStackNavigator } from "@react-navigation/stack"
 import { TabNavigation } from "@stacks/ActivitiesStack"
 import {
   getCurrentPositionAsync,
+  requestBackgroundPermissionsAsync,
   requestForegroundPermissionsAsync
 } from "expo-location"
 import React from "react"
@@ -72,6 +73,7 @@ const App = () => {
       <UserLocationFunctionsProvider
         getCurrentLocation={getCurrentPositionAsync}
         requestForegroundPermissions={requestForegroundPermissionsAsync}
+        requestBackgroundPermissions={requestBackgroundPermissionsAsync}
       >
         <HapticsProvider
           isSupportedOnDevice={IS_HAPTICS_SUPPORTED_ON_DEVICE}

--- a/app.config.ts
+++ b/app.config.ts
@@ -30,7 +30,10 @@ const config = {
   ios: {
     bundleIdentifier: "com.tifapp.FitnessApp",
     infoPlist: {
-      NSLocationAlwaysAndWhenInUseUsageDescription: "REASON_FOR_REQUEST",
+      NSLocationAlwaysAndWhenInUseUsageDescription:
+        "To be able to let others know when you've arrived at an event, tap \"Change to Always Allow\".",
+      NSLocationWhenInUseUsageDescription:
+        "To find fitness events in your current area, and to get travel estimates to upcoming events, tap \"Allow Once\" or \"Allow While Using App\".",
       UIBackgroundModes: ["location", "fetch"],
       LSApplicationQueriesSchemes: [
         "comgooglemaps",

--- a/app.config.ts
+++ b/app.config.ts
@@ -31,9 +31,9 @@ const config = {
     bundleIdentifier: "com.tifapp.FitnessApp",
     infoPlist: {
       NSLocationAlwaysAndWhenInUseUsageDescription:
-        "To be able to let others know when you've arrived at an event, tap \"Change to Always Allow\".",
+        "To inform others of your arrival, tap \"Change to Always Allow.\"",
       NSLocationWhenInUseUsageDescription:
-        "To find fitness events in your current area, and to get travel estimates to upcoming events, tap \"Allow Once\" or \"Allow While Using App\".",
+        "Discover events and receive travel estimates for events by tapping \"Allow Once\" or \"Allow While Using App.\"",
       UIBackgroundModes: ["location", "fetch"],
       LSApplicationQueriesSchemes: [
         "comgooglemaps",

--- a/hooks/UserLocation.tsx
+++ b/hooks/UserLocation.tsx
@@ -42,9 +42,26 @@ export const useRequestForegroundLocationPermissions = (
   )
 }
 
+/**
+ * A query hook to request permission for background location permissions.
+ *
+ * Background location permissions first require that foreground location permissions are accepted.
+ */
+export const useRequestBackgroundLocationsPermissions = (
+  options?: QueryHookOptions<PermissionResponse>
+) => {
+  const { requestBackgroundPermissions } = useUserLocationFunctions()
+  return useQuery(
+    ["request-location-foreground-permissions"],
+    async () => await requestBackgroundPermissions(),
+    options
+  )
+}
+
 export type UserLocationFunctions = {
   getCurrentLocation: (options: LocationOptions) => Promise<LocationObject>
   requestForegroundPermissions: () => Promise<PermissionResponse>
+  requestBackgroundPermissions: () => Promise<PermissionResponse>
 }
 
 const UserLocationFunctionsContext = createContext<


### PR DESCRIPTION
This PR adds a hook similar to `useRequestForegroundLocation` permissions called `useRequestBackgroundLocationPermissions`.

It also adds a reason description on iOS that shows up when the user receives the permissions prompt for both foreground and background location permissions.