### PR TITLE
Arrivals: Handle Geofencing Update

### DIFF
--- a/event-details/arrival-tracking/Geofencing.ts
+++ b/event-details/arrival-tracking/Geofencing.ts
@@ -23,6 +23,27 @@ export type EventArrivalGeofencingCallback = (
   update: EventArrivalGeofencingUpdate
 ) => void
 
+export type EventArrivalGeofencingUnsubscribe = () => void
+
+/**
+ * A geofencer interface explicitly tuned for event arrivals.
+ */
+export interface EventArrivalsGeofencer {
+  /**
+   * Replaces all coordinates currently being geofenced.
+   */
+  replaceGeofencedCoordinates: (
+    coordinates: LocationCoordinate2D[]
+  ) => Promise<void>
+
+  /**
+   * Registers a callback that listens for geofencing updates.
+   */
+  onUpdate: (
+    handleUpdate: EventArrivalGeofencingCallback
+  ) => EventArrivalGeofencingUnsubscribe
+}
+
 const taskCallbacks = {
   nonUpcoming: undefined as EventArrivalGeofencingCallback | undefined,
   upcoming: undefined as EventArrivalGeofencingCallback | undefined
@@ -46,7 +67,7 @@ const taskName = (key: TaskCallbackKey) => {
  * This distance being geofenced is based on a "walking to the event from the parking lot basis",
  * ie. about 1-2 american football fields.
  */
-export class ExpoEventArrivalsGeofencer {
+export class ExpoEventArrivalsGeofencer implements EventArrivalsGeofencer {
   private readonly key: TaskCallbackKey
 
   private constructor (key: TaskCallbackKey) {

--- a/event-details/arrival-tracking/Tracker.test.ts
+++ b/event-details/arrival-tracking/Tracker.test.ts
@@ -58,7 +58,7 @@ describe("EventArrivalsTracker tests", () => {
     performArrivalOperation.mockReset()
   })
 
-  const tracker = EventArrivalsTracker.trackingUpcomingArrivals(
+  const tracker = new EventArrivalsTracker(
     upcomingArrivals,
     testGeofencer,
     performArrivalOperation
@@ -127,19 +127,21 @@ describe("EventArrivalsTracker tests", () => {
   })
 
   test("does not subscribe to geofencing updates when no tracked arrivals", async () => {
-    await waitFor(() => expect(testGeofencer.hasSubscriber).toEqual(false))
+    await tracker.startTracking()
+    expect(testGeofencer.hasSubscriber).toEqual(false)
   })
 
   test("subscribes to geofencing updates when previously tracked arrivals", async () => {
     await tracker.trackArrival(mockEventArrival())
     tracker.stopTracking()
     expect(testGeofencer.hasSubscriber).toEqual(false)
-    EventArrivalsTracker.trackingUpcomingArrivals(
+    const tracker2 = new EventArrivalsTracker(
       upcomingArrivals,
       testGeofencer,
       jest.fn()
     )
-    await waitFor(() => expect(testGeofencer.hasSubscriber).toEqual(true))
+    await tracker2.startTracking()
+    expect(testGeofencer.hasSubscriber).toEqual(true)
   })
 
   test("unsubscribes from tracker when removing all tracked arrivals", async () => {

--- a/event-details/arrival-tracking/Tracker.test.ts
+++ b/event-details/arrival-tracking/Tracker.test.ts
@@ -1,19 +1,67 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { AsyncStorageUpcomingEventArrivals } from "./UpcomingArrivals"
 import { EventArrivalsTracker } from "./Tracker"
-import { EventArrival, mockEventArrival } from "./models"
+import {
+  EventArrival,
+  EventArrivalOperationResult,
+  mockEventArrival
+} from "./models"
 import { ArrayUtils } from "@lib/Array"
+import { LocationCoordinate2D, mockLocationCoordinate2D } from "@lib/location"
+import {
+  EventArrivalGeofencingCallback,
+  EventArrivalGeofencingUpdate,
+  EventArrivalsGeofencer
+} from "./Geofencing"
+import { waitFor } from "@testing-library/react-native"
+
+class TestGeofencer implements EventArrivalsGeofencer {
+  private updateCallback?: EventArrivalGeofencingCallback
+  geofencedCoordinates = [] as LocationCoordinate2D[]
+
+  get hasSubscriber () {
+    return !!this.updateCallback
+  }
+
+  async replaceGeofencedCoordinates (coordinates: LocationCoordinate2D[]) {
+    this.geofencedCoordinates = coordinates
+  }
+
+  sendUpdate (update: EventArrivalGeofencingUpdate) {
+    this.updateCallback?.(update)
+  }
+
+  reset () {
+    this.updateCallback = undefined
+    this.geofencedCoordinates = []
+  }
+
+  onUpdate (handleUpdate: EventArrivalGeofencingCallback) {
+    this.updateCallback = handleUpdate
+    return () => {
+      this.updateCallback = undefined
+    }
+  }
+}
 
 describe("EventArrivalsTracker tests", () => {
   const upcomingArrivals = new AsyncStorageUpcomingEventArrivals()
   beforeEach(async () => await AsyncStorage.clear())
 
-  const replaceGeofencedCoordinates = jest.fn()
-  afterEach(() => replaceGeofencedCoordinates.mockReset())
+  const testGeofencer = new TestGeofencer()
 
-  const tracker = new EventArrivalsTracker(
+  const replaceGeofencedCoordinates = jest.fn()
+  const performArrivalOperation = jest.fn()
+  beforeEach(() => testGeofencer.reset())
+  afterEach(() => {
+    replaceGeofencedCoordinates.mockReset()
+    performArrivalOperation.mockReset()
+  })
+
+  const tracker = EventArrivalsTracker.trackingUpcomingArrivals(
     upcomingArrivals,
-    replaceGeofencedCoordinates
+    testGeofencer,
+    performArrivalOperation
   )
 
   test("refresh arrivals", async () => {
@@ -21,19 +69,14 @@ describe("EventArrivalsTracker tests", () => {
       return mockEventArrival()
     })
     await tracker.refreshArrivals(jest.fn().mockResolvedValueOnce(arrivals))
-    expect(replaceGeofencedCoordinates).toHaveBeenCalledWith([
-      arrivals[0].coordinate,
-      arrivals[1].coordinate
-    ])
+    expectGeofencedCoordinates([arrivals[0].coordinate, arrivals[1].coordinate])
     await expectUpcomingArrivals(arrivals)
   })
 
   test("track arrival, basic", async () => {
     const arrival = mockEventArrival()
     await tracker.trackArrival(arrival)
-    expect(replaceGeofencedCoordinates).toHaveBeenCalledWith([
-      arrival.coordinate
-    ])
+    expectGeofencedCoordinates([arrival.coordinate])
     await expectUpcomingArrivals([arrival])
   })
 
@@ -42,27 +85,20 @@ describe("EventArrivalsTracker tests", () => {
       return mockEventArrival()
     })
     await tracker.trackArrival(arrivals[0])
-    replaceGeofencedCoordinates.mockReset()
     await tracker.trackArrival(arrivals[1])
-    expect(replaceGeofencedCoordinates).toHaveBeenCalledWith([
-      arrivals[0].coordinate,
-      arrivals[1].coordinate
-    ])
+    expectGeofencedCoordinates([arrivals[0].coordinate, arrivals[1].coordinate])
     await expectUpcomingArrivals(arrivals)
   })
 
   test("track arrival, updates existing arrival with matching event id", async () => {
     const arrival = mockEventArrival()
     await tracker.trackArrival(arrival)
-    replaceGeofencedCoordinates.mockReset()
     const nextArrival = {
       ...mockEventArrival(),
       eventId: arrival.eventId
     }
     await tracker.trackArrival(nextArrival)
-    expect(replaceGeofencedCoordinates).toHaveBeenCalledWith([
-      nextArrival.coordinate
-    ])
+    expectGeofencedCoordinates([nextArrival.coordinate])
     await expectUpcomingArrivals([nextArrival])
   })
 
@@ -70,34 +106,152 @@ describe("EventArrivalsTracker tests", () => {
     const arrivals = ArrayUtils.repeatElements(3, () => {
       return mockEventArrival()
     })
-    for (const arrival of arrivals) {
-      await tracker.trackArrival(arrival)
-    }
-    replaceGeofencedCoordinates.mockReset()
+    await tracker.trackArrivals(arrivals)
     await tracker.removeArrivalByEventId(arrivals[1].eventId)
-    expect(replaceGeofencedCoordinates).toHaveBeenCalledWith([
-      arrivals[0].coordinate,
-      arrivals[2].coordinate
-    ])
+    expectGeofencedCoordinates([arrivals[0].coordinate, arrivals[2].coordinate])
     await expectUpcomingArrivals([arrivals[0], arrivals[2]])
   })
 
   test("remove arrival, does nothing when no tracked arrivals", async () => {
     await tracker.removeArrivalByEventId(1)
-    expect(replaceGeofencedCoordinates).not.toHaveBeenCalled()
+    expectGeofencedCoordinates([])
     await expectUpcomingArrivals([])
   })
 
   test("remove arrival, does nothing when given arrival not tracked", async () => {
     const trackedArrival = { ...mockEventArrival(), eventId: 2 }
     await tracker.trackArrival(trackedArrival)
-    replaceGeofencedCoordinates.mockReset()
     await tracker.removeArrivalByEventId(1)
-    expect(replaceGeofencedCoordinates).not.toHaveBeenCalled()
+    expectGeofencedCoordinates([trackedArrival.coordinate])
     await expectUpcomingArrivals([trackedArrival])
+  })
+
+  test("does not subscribe to geofencing updates when no tracked arrivals", async () => {
+    await waitFor(() => expect(testGeofencer.hasSubscriber).toEqual(false))
+  })
+
+  test("subscribes to geofencing updates when previously tracked arrivals", async () => {
+    await tracker.trackArrival(mockEventArrival())
+    tracker.stopTracking()
+    expect(testGeofencer.hasSubscriber).toEqual(false)
+    EventArrivalsTracker.trackingUpcomingArrivals(
+      upcomingArrivals,
+      testGeofencer,
+      jest.fn()
+    )
+    await waitFor(() => expect(testGeofencer.hasSubscriber).toEqual(true))
+  })
+
+  test("unsubscribes from tracker when removing all tracked arrivals", async () => {
+    const arrival = mockEventArrival()
+    await tracker.trackArrival(arrival)
+    expect(testGeofencer.hasSubscriber).toEqual(true)
+    await tracker.removeArrivalByEventId(arrival.eventId)
+    expect(testGeofencer.hasSubscriber).toEqual(false)
+  })
+
+  test("handle geofencing update, no tracked arrival at coordinate, does not perform arrival operation", async () => {
+    await tracker.trackArrival(mockEventArrival())
+    testGeofencer.sendUpdate({
+      coordinate: mockLocationCoordinate2D(),
+      status: "entered"
+    })
+    expect(performArrivalOperation).not.toHaveBeenCalled()
+  })
+
+  test("handle geofencing update, all successful operations, does \"arrived\" operation for all arrivals when entering coordinate", async () => {
+    const coordinate = mockLocationCoordinate2D()
+    const arrivals = ArrayUtils.repeatElements(3, () => {
+      return { ...mockEventArrival(), coordinate }
+    })
+    performArrivalOperation.mockResolvedValueOnce(
+      arrivals.map(successResultForArrival)
+    )
+    await tracker.trackArrivals(arrivals)
+    testGeofencer.sendUpdate({ coordinate, status: "entered" })
+    await waitFor(() => {
+      expect(performArrivalOperation).toHaveBeenCalledWith(arrivals, "arrived")
+    })
+  })
+
+  test("handle geofencing update, all successful operations, does \"departed\" operation for all arrivals when exiting coordinate", async () => {
+    const coordinate = mockLocationCoordinate2D()
+    const arrivals = ArrayUtils.repeatElements(3, () => {
+      return { ...mockEventArrival(), coordinate }
+    })
+    performArrivalOperation.mockResolvedValueOnce(
+      arrivals.map(successResultForArrival)
+    )
+    await tracker.trackArrivals(arrivals)
+    testGeofencer.sendUpdate({ coordinate, status: "exited" })
+    await waitFor(() => {
+      expect(performArrivalOperation).toHaveBeenCalledWith(arrivals, "departed")
+    })
+  })
+
+  test("handle geofencing update, removes arrivals with a \"non-upcoming\" operation result status", async () => {
+    const coordinate = mockLocationCoordinate2D()
+    const arrivals = ArrayUtils.repeatElements(3, () => {
+      return { ...mockEventArrival(), coordinate }
+    })
+    const operationResults = arrivals.map(successResultForArrival)
+    operationResults[1] = {
+      eventId: operationResults[1].eventId,
+      status: "non-upcoming"
+    }
+    performArrivalOperation.mockResolvedValueOnce(operationResults)
+    await tracker.trackArrivals(arrivals)
+    testGeofencer.sendUpdate({ coordinate, status: "entered" })
+    await waitFor(() => {
+      expectGeofencedCoordinates([
+        arrivals[0].coordinate,
+        arrivals[2].coordinate
+      ])
+    })
+    await expectUpcomingArrivals([arrivals[0], arrivals[2]])
+  })
+
+  test("handle geofencing update, updates arrivals with an \"outdated-coordinate\" operation result status", async () => {
+    const coordinate = mockLocationCoordinate2D()
+    const arrivals = ArrayUtils.repeatElements(3, () => {
+      return { ...mockEventArrival(), coordinate }
+    })
+    const operationResults = arrivals.map(successResultForArrival)
+    const updatedCoordinate = mockLocationCoordinate2D()
+    operationResults[1] = {
+      eventId: operationResults[1].eventId,
+      status: "outdated-coordinate",
+      updatedCoordinate
+    }
+    performArrivalOperation.mockResolvedValueOnce(operationResults)
+    await tracker.trackArrivals(arrivals)
+    testGeofencer.sendUpdate({ coordinate, status: "entered" })
+    await waitFor(() => {
+      expectGeofencedCoordinates([
+        arrivals[0].coordinate,
+        updatedCoordinate,
+        arrivals[2].coordinate
+      ])
+    })
+    await expectUpcomingArrivals([
+      arrivals[0],
+      { ...arrivals[1], coordinate: updatedCoordinate },
+      arrivals[2]
+    ])
+  })
+
+  const successResultForArrival = (
+    arrival: EventArrival
+  ): EventArrivalOperationResult => ({
+    eventId: arrival.eventId,
+    status: "success"
   })
 
   const expectUpcomingArrivals = async (expected: EventArrival[]) => {
     expect(await upcomingArrivals.all()).toEqual(expected)
+  }
+
+  const expectGeofencedCoordinates = (expected: LocationCoordinate2D[]) => {
+    expect(testGeofencer.geofencedCoordinates).toEqual(expected)
   }
 })

--- a/event-details/arrival-tracking/Tracker.ts
+++ b/event-details/arrival-tracking/Tracker.ts
@@ -31,7 +31,7 @@ export class EventArrivalsTracker {
 
   private unsubscribeFromGeofencing?: EventArrivalGeofencingUnsubscribe
 
-  private constructor (
+  constructor (
     upcomingArrivals: UpcomingEventArrivals,
     geofencer: EventArrivalsGeofencer,
     performArrivalsOperation: PerformArrivalsOperation
@@ -39,29 +39,6 @@ export class EventArrivalsTracker {
     this.upcomingArrivals = upcomingArrivals
     this.geofencer = geofencer
     this.performArrivalsOperation = performArrivalsOperation
-  }
-
-  /**
-   * Constructs an {@link EventArrivalsTracker} instance and immediately begins tracking
-   * arrival updates for all upcoming event arrivals.
-   */
-  static trackingUpcomingArrivals (
-    upcomingArrivals: UpcomingEventArrivals,
-    geofencer: EventArrivalsGeofencer,
-    performArrivalsOperation: PerformArrivalsOperation
-  ) {
-    const tracker = new EventArrivalsTracker(
-      upcomingArrivals,
-      geofencer,
-      performArrivalsOperation
-    )
-    tracker.tryStartTracking()
-    return tracker
-  }
-
-  private async tryStartTracking () {
-    const arrivals = await this.upcomingArrivals.all()
-    this.updateGeofencingSubscription(arrivals)
   }
 
   /**
@@ -108,6 +85,14 @@ export class EventArrivalsTracker {
     })
     if (trackedArrivals.length === filteredArrivals.length) return
     await this.syncArrivals(filteredArrivals)
+  }
+
+  /**
+   * Starts tracking if there is at least 1 upcoming event arrival.
+   */
+  async startTracking () {
+    const arrivals = await this.upcomingArrivals.all()
+    this.updateGeofencingSubscription(arrivals)
   }
 
   /**

--- a/event-details/arrival-tracking/models.ts
+++ b/event-details/arrival-tracking/models.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker"
 import {
+  LocationCoordinate2D,
   LocationCoordinates2DSchema,
   mockLocationCoordinate2D
 } from "@lib/location"
@@ -19,7 +20,7 @@ export const EventArrivalSchema = z.object({
 export const EventArrivalsSchema = z.array(EventArrivalSchema)
 
 /**
- * Event arrivala are sent as notifications when the user enters the area of an event,
+ * Event arrivals are sent as notifications when the user enters the area of an event,
  * so that other participants are aware of their arrival.
  *
  * The scheduling/sending of the push notifications is handled server-side.
@@ -30,3 +31,16 @@ export const mockEventArrival = (): EventArrival => ({
   eventId: parseInt(faker.random.numeric(3)),
   coordinate: mockLocationCoordinate2D()
 })
+
+export type EventArrivalOperationKind = "arrived" | "departed"
+
+/**
+ * The result of trying to post an arrival or departure from an event.
+ */
+export type EventArrivalOperationResult = {
+  eventId: number
+} & (
+  | { status: "success" }
+  | { status: "outdated-coordinate"; updatedCoordinate: LocationCoordinate2D }
+  | { status: "non-upcoming" }
+)

--- a/lib/location/Location.ts
+++ b/lib/location/Location.ts
@@ -24,17 +24,18 @@ export type LocationCoordinate2D = Readonly<
   z.infer<typeof LocationCoordinates2DSchema>
 >
 
+const COORDINATE_EPSILON = 0.0000000000001
+
 /**
- * Checks for equality on two sets of coordinates.
+ * Checks for equality on two sets of coordinates based on an epsilon = 0.0000000000001.
  */
 export const checkIfCoordsAreEqual = (
-  coordsA: LocationCoordinate2D,
-  coordsB: LocationCoordinate2D
+  a: LocationCoordinate2D,
+  b: LocationCoordinate2D
 ) => {
-  return (
-    coordsA.longitude === coordsB.longitude &&
-    coordsA.latitude === coordsB.latitude
-  )
+  const isLatEqual = Math.abs(a.latitude - b.latitude) <= COORDINATE_EPSILON
+  const isLngEqual = Math.abs(a.longitude - b.longitude) <= COORDINATE_EPSILON
+  return isLatEqual && isLngEqual
 }
 
 /**


### PR DESCRIPTION
This PR makes the tracker class observe geofencing updates, and post an arrival or departure respectively. It does so by grabbing all upcoming event arrivals near a particular coordinate, then doing the respective `"arrived"` or `"departed"` operation on all the arrivals. In some cases, we may not have had a refresh yet, and the `EventArrivalOperationResult` type contains cases for what happens when we try to arrive/depart from an outdated arrival. The tracker uses these results and updates the upcoming arrivals and geofenced coordinates accordingly.

I also had to make some modifications to the `checkIfCoordsAreEqual` method to compare against an epsilon, as coordinates may lose precision when they are persisted.

There's also some trickery to ensure that we're only subscribed to geofencing updates when we actually have upcoming arrivals.