### PR TITLE
Arrivals: Set unsubscribe to undefined in tracker

### DIFF
--- a/event-details/arrival-tracking/Tracker.ts
+++ b/event-details/arrival-tracking/Tracker.ts
@@ -101,6 +101,7 @@ export class EventArrivalsTracker {
    */
   stopTracking () {
     this.unsubscribeFromGeofencing?.()
+    this.unsubscribeFromGeofencing = undefined
   }
 
   private async handleGeofencingUpdate (update: EventArrivalGeofencingUpdate) {


### PR DESCRIPTION
Sets the `unsubscribeFromGeofencing` to undefined in the tracker class after it is called.