### PR TITLE
Event Details: Automatically refetch when the internet comes back up

### DIFF
--- a/.storybook/components/AttendeesList/AttendeesList.stories.tsx
+++ b/.storybook/components/AttendeesList/AttendeesList.stories.tsx
@@ -1,17 +1,18 @@
+import { Headline } from "@components/Text"
 import { TiFQueryClientProvider } from "@lib/ReactQuery"
-import { AttendeesListScreen } from "@screens/EventAttendeesList/AttendeesListScreen"
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
 
-const AttendeesListMeta: ComponentMeta<typeof AttendeesListScreen> = {
-  title: "Attendees List",
-  component: AttendeesListScreen
+const SomeComponent = (props: any) => <></>
+
+const AttendeesListMeta: ComponentMeta<typeof SomeComponent> = {
+  title: "Attendees List"
 }
 export default AttendeesListMeta
 
-type AttendeesListStory = ComponentStory<typeof AttendeesListScreen>
+type AttendeesListStory = ComponentStory<typeof SomeComponent>
 
 export const Basic: AttendeesListStory = () => (
   <TiFQueryClientProvider>
-    <AttendeesListScreen />
+    <Headline>Hello world</Headline>
   </TiFQueryClientProvider>
 )

--- a/App.tsx
+++ b/App.tsx
@@ -16,7 +16,7 @@ import { RootSiblingParent } from "react-native-root-siblings"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 
 import { Geo } from "@aws-amplify/geo"
-import { defineEventArrivalsGeofencingTasks } from "@event-details/arrival-tracking"
+import { defineEventArrivalsGeofencingTasks } from "@event-details/arrival-tracking/geofencing"
 import { AnalyticsProvider, MixpanelAnalytics } from "@lib/Analytics"
 import {
   addLogHandler,

--- a/event-details/EventDetailsLoading.test.tsx
+++ b/event-details/EventDetailsLoading.test.tsx
@@ -201,7 +201,6 @@ describe("EventDetailsLoading tests", () => {
       await verifyNeverOccurs(() => {
         expect((result.current as any).refreshStatus).toEqual("error")
       })
-      console.log(result.current)
       expect(loadEvent).toHaveBeenCalledTimes(1)
     })
 

--- a/event-details/EventDetailsLoading.test.tsx
+++ b/event-details/EventDetailsLoading.test.tsx
@@ -2,11 +2,17 @@ import { act, renderHook, waitFor } from "@testing-library/react-native"
 import { useLoadEventDetails } from "./EventDetailsLoading"
 import { TestQueryClientProvider } from "@test-helpers/ReactQuery"
 import { EventMocks } from "./MockData"
+import { TestInternetConnectionStatus } from "@test-helpers/InternetConnectionStatus"
+import { InternetConnectionStatusProvider } from "@lib/InternetConnection"
 
 describe("EventDetailsLoading tests", () => {
   const loadEvent = jest.fn()
+  let testConnectionStatus = new TestInternetConnectionStatus(true)
 
-  beforeEach(() => jest.resetAllMocks())
+  beforeEach(() => {
+    jest.resetAllMocks()
+    testConnectionStatus = new TestInternetConnectionStatus(true)
+  })
 
   describe("UseLoadEventDetails tests", () => {
     test("basic loading flow", async () => {
@@ -148,9 +154,29 @@ describe("EventDetailsLoading tests", () => {
       const { result } = renderUseLoadEvent(1)
       expect(result.current).toEqual({ status: "loading" })
       await waitFor(() => expect(result.current.status).toEqual("error"))
+      expect((result.current as any).isConnectedToInternet).toEqual(true)
       act(() => (result.current as any).retry())
       await waitFor(() => expect(result.current.status).toEqual("loading"))
       act(() => resolveRetry?.())
+      await waitFor(() => expect(result.current.status).toEqual("success"))
+      expect(result.current).toMatchObject({
+        event: EventMocks.Multiday,
+        refreshStatus: "idle"
+      })
+      expect(loadEvent).toHaveBeenNthCalledWith(2, 1)
+      expect(loadEvent).toHaveBeenCalledTimes(2)
+    })
+
+    test("load failure with bad internet, retries successfully when internet comes back online", async () => {
+      testConnectionStatus.publishIsConnected(false)
+      loadEvent.mockRejectedValueOnce(new Error()).mockResolvedValueOnce({
+        status: "success",
+        event: EventMocks.Multiday
+      })
+      const { result } = renderUseLoadEvent(1)
+      await waitFor(() => expect(result.current.status).toEqual("error"))
+      expect((result.current as any).isConnectedToInternet).toEqual(false)
+      act(() => testConnectionStatus.publishIsConnected(true))
       await waitFor(() => expect(result.current.status).toEqual("success"))
       expect(result.current).toMatchObject({
         event: EventMocks.Multiday,
@@ -166,7 +192,9 @@ describe("EventDetailsLoading tests", () => {
         {
           initialProps: eventId,
           wrapper: ({ children }: any) => (
-            <TestQueryClientProvider>{children}</TestQueryClientProvider>
+            <InternetConnectionStatusProvider status={testConnectionStatus}>
+              <TestQueryClientProvider>{children}</TestQueryClientProvider>
+            </InternetConnectionStatusProvider>
           )
         }
       )

--- a/lib/InternetConnection.tsx
+++ b/lib/InternetConnection.tsx
@@ -1,0 +1,70 @@
+import React, {
+  ReactNode,
+  createContext,
+  useContext,
+  useSyncExternalStore
+} from "react"
+import { addEventListener } from "@react-native-community/netinfo"
+
+export type InternetConnectionStatusUnsubscribe = () => void
+
+/**
+ * An interface for observing whether or not the user is connected to the internet.
+ */
+export interface InternetConnectionStatus {
+  subscribe(
+    callback: (isConnected: boolean) => void
+  ): InternetConnectionStatusUnsubscribe
+
+  get isConnected(): boolean
+}
+
+/**
+ * An {@link InternetConnectionStatus} using netinfo.
+ */
+export class NetInfoInternetConnectionStatus
+implements InternetConnectionStatus {
+  private _isConnected = true
+
+  subscribe (
+    callback: (isConnected: boolean) => void
+  ): InternetConnectionStatusUnsubscribe {
+    return addEventListener((state) => {
+      this._isConnected = state.isConnected ?? false
+      callback(this._isConnected)
+    })
+  }
+
+  get isConnected () {
+    return this._isConnected
+  }
+}
+
+const InternetConnectionContext = createContext<InternetConnectionStatus>(
+  new NetInfoInternetConnectionStatus()
+)
+
+export type InternetConnectionStatusProviderProps = {
+  status: InternetConnectionStatus
+  children: ReactNode
+}
+
+export const InternetConnectionStatusProvider = ({
+  status,
+  children
+}: InternetConnectionStatusProviderProps) => (
+  <InternetConnectionContext.Provider value={status}>
+    {children}
+  </InternetConnectionContext.Provider>
+)
+
+/**
+ * Subscribes to the current {@link InternetConnectionStatus} provided by {@link InternetConnectionStatusProvider}.
+ */
+export const useIsConnectedToInternet = () => {
+  const status = useContext(InternetConnectionContext)
+  return useSyncExternalStore(
+    (callback) => status.subscribe(callback),
+    () => status.isConnected
+  )
+}

--- a/lib/InternetConnection.tsx
+++ b/lib/InternetConnection.tsx
@@ -30,7 +30,7 @@ implements InternetConnectionStatus {
     callback: (isConnected: boolean) => void
   ): InternetConnectionStatusUnsubscribe {
     return addEventListener((state) => {
-      this._isConnected = state.isConnected ?? false
+      this._isConnected = state.isInternetReachable ?? false
       callback(this._isConnected)
     })
   }

--- a/lib/utils/UseEffectEvent.ts
+++ b/lib/utils/UseEffectEvent.ts
@@ -1,0 +1,37 @@
+import { useRef, useInsertionEffect, useCallback } from "react"
+
+/**
+ * A pollyfill of the upcoming `useEffectEvent` in a future react version.
+ *
+ * `useEffectEvent` allows `useEffect` to call a function without needing it as a dependency key.
+ *
+ * **Notice 🟡**: Since this is just a pollyfill, the returned function will still need to be added as a dependency key.
+ * However, the returned behavior is exactly the same as the hook itself.
+ *
+ * Ex.
+ * ```ts
+ * const onVisit = useEffectEvent(() => {
+ *  logVisit(url, numberOfItems)
+ * })
+ *
+ * useEffect(() => {
+ *   onVisit()
+ * }, [url]) // ✅ onVisit isn't needed as a dependency key
+ * ```
+ *
+ * See: https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event
+ * See: https://stackoverflow.com/questions/76335194/is-this-an-accurate-polyfill-of-reacts-useeffectevent#answer-76514983
+ *
+ * @param fn A function to run.
+ * @returns A stable reference to the given function.
+ */
+export const useEffectEvent = <F extends Function>(fn: F) => {
+  const ref = useRef(fn)
+  useInsertionEffect(() => {
+    ref.current = fn
+  }, [fn])
+  return useCallback((...args: any[]) => {
+    const f = ref.current
+    return f(...args)
+  }, []) as unknown as F
+}

--- a/test-helpers/ExpectNeverOccurs.ts
+++ b/test-helpers/ExpectNeverOccurs.ts
@@ -1,0 +1,15 @@
+import { waitFor } from "@testing-library/react-native"
+
+/**
+ * Expects that an assertion always fails asynchronously.
+ *
+ * From: https://stackoverflow.com/questions/68118941/how-to-wait-for-something-not-to-happen-in-testing-library
+ */
+export const verifyNeverOccurs = async (
+  expectation: () => unknown,
+  timeoutMillis: number = 100
+) => {
+  await expect(
+    waitFor(expectation, { timeout: timeoutMillis })
+  ).rejects.toThrow()
+}

--- a/test-helpers/InternetConnectionStatus.ts
+++ b/test-helpers/InternetConnectionStatus.ts
@@ -1,0 +1,20 @@
+import { InternetConnectionStatus } from "@lib/InternetConnection"
+
+export class TestInternetConnectionStatus implements InternetConnectionStatus {
+  isConnected: boolean
+  private callback?: (isConnected: boolean) => void
+
+  constructor (isConnected: boolean) {
+    this.isConnected = isConnected
+  }
+
+  subscribe (callback: (isConnected: boolean) => void) {
+    this.callback = callback
+    return () => (this.callback = undefined)
+  }
+
+  publishIsConnected (isConnected: boolean) {
+    this.isConnected = isConnected
+    this.callback?.(isConnected)
+  }
+}


### PR DESCRIPTION
The internet is flaky, and it would be very convenient for the user to know about that. This PR makes it so that the event details (and in the near future other major screens like explore) are automatically refetched when the internet comes back online after it has been down for some time.

First and foremost, I made an `InternetConnection` file in the `lib` folder and created an interface (`InternetConnectionStatus`) that can be injected through a context provider (`InternetConnectionStatusProvider`) for testing and storybook purposes. It turns out that it would be pretty hard to preview any future connection status UI without that context provider as turning off your wifi means losing connection to the expo dev server. This context is used by a `useIsConnectedToInternet` hook which uses `useSyncExternalStore` (think of this as a more convenient `useEffect`) under the hood. 

Next, I'm now calling this hook in `useLoadEventDetails`, and returning a new `isConnectedToInternet` property when the status is `"error"`. Furthermore, I make sure to only do the refetch when `status` is indeed `"error"` since we don't need to refetch successful cases.

Lastly, I did need to add some new utils to make some of this possible. Notably, a pollyfill of `useEffectEvent` which prevents overfiring of the `useEffect` needed to do the refetch when the internet comes back online. `useEffectEvent` is a proposed hook which can be found in the (react docs)[https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event] that makes it so that you can omit dependency values from `useEffect` by explicitly stating that a function is _non-reactive_. Without this pollyfill, the event details would be refetched every time the `useQuery` status changed even if the connection has been up the whole time. 

The other utility is simply a test utility to assert that something asynchronously _doesn't_ happen. It's called `verifyNeverOccurs` and can be found in `test-helpers`.