### PR TITLE
Event Details: Update Event Type

### DIFF
--- a/api-client/TiFAPI.ts
+++ b/api-client/TiFAPI.ts
@@ -165,6 +165,9 @@ export class TiFAPI {
     )
   }
 
+  /**
+   * Loads an individual event by its id.
+   */
   async eventDetails (eventId: number) {
     return await this.apiFetch(
       {

--- a/event-details/EventDetailsLoading.test.tsx
+++ b/event-details/EventDetailsLoading.test.tsx
@@ -258,6 +258,7 @@ describe("EventDetailsLoading tests", () => {
           id: uuidString(),
           username: "Blob",
           handle: "blob",
+          profileImageURL: null,
           relations: {
             themToYou: "blocked",
             youToThem: "blocked"
@@ -296,6 +297,7 @@ describe("EventDetailsLoading tests", () => {
           id: uuidString(),
           username: "Blob",
           handle: "blob",
+          profileImageURL: null,
           relations: {
             themToYou: "not-friends",
             youToThem: "not-friends"
@@ -308,14 +310,15 @@ describe("EventDetailsLoading tests", () => {
         time: {
           secondsToStart: dayjs.duration(3, "hours").asSeconds(),
           todayOrTomorrow: "today",
-          timezoneIdentifier: "UTC",
           dateRange: {
             startDateTime: new Date(4000),
             endDateTime: new Date(5000)
           }
         },
+        joinDate: null,
         location: mockEventLocation(),
-        previewAttendees: [{ id: uuidString() }]
+        previewAttendees: [{ id: uuidString(), profileImageURL: null }],
+        hasEndedEarly: false
       }
       setEventResponse(200, eventResponse)
       const resp = await loadEventDetails(1, TiFAPI.testAuthenticatedInstance)

--- a/event-details/EventDetailsLoading.tsx
+++ b/event-details/EventDetailsLoading.tsx
@@ -1,5 +1,9 @@
 import { UseQueryResult, useQuery } from "@tanstack/react-query"
-import { BlockedEvent, CurrentUserEvent } from "@shared-models/Event"
+import {
+  BlockedEvent,
+  CurrentUserEvent,
+  currentUserEventFromResponse
+} from "@shared-models/Event"
 import { useIsConnectedToInternet } from "@lib/InternetConnection"
 import { useEffect } from "react"
 import { useEffectEvent } from "@lib/utils/UseEffectEvent"
@@ -33,10 +37,7 @@ export const loadEventDetails = async (
   } else {
     return {
       status: "success",
-      event: {
-        ...resp.data,
-        time: { ...resp.data.time, clientReceivedTime: new Date() }
-      }
+      event: currentUserEventFromResponse(resp.data)
     }
   }
 }

--- a/event-details/MockData.ts
+++ b/event-details/MockData.ts
@@ -11,7 +11,7 @@ import { faker } from "@faker-js/faker"
 import {
   randomBool,
   randomIntegerInRange,
-  randomlyUndefined
+  randomlyNull
 } from "@lib/utils/Random"
 import { ColorString } from "@lib/utils/Color"
 
@@ -19,7 +19,8 @@ export const mockEventLocation = (): EventLocation => ({
   coordinate: mockLocationCoordinate2D(),
   arrivalRadiusMeters: parseInt(faker.random.numeric(3)),
   isInArrivalTrackingPeriod: randomBool(),
-  placemark: randomlyUndefined(mockPlacemark())
+  timezoneIdentifier: faker.address.timeZone(),
+  placemark: randomlyNull(mockPlacemark())
 })
 
 /**
@@ -42,6 +43,7 @@ export namespace EventAttendeeMocks {
     id: uuidString(),
     username: "Blob Jr.",
     handle: UserHandle.optionalParse("SmallBlob")!,
+    profileImageURL: null,
     relations: {
       themToYou: "not-friends",
       youToThem: "not-friends"
@@ -52,6 +54,7 @@ export namespace EventAttendeeMocks {
     id: uuidString(),
     username: "Blob Sr.",
     handle: UserHandle.optionalParse("OriginalBlob")!,
+    profileImageURL: null,
     relations: {
       themToYou: "not-friends",
       youToThem: "not-friends"
@@ -66,6 +69,7 @@ export namespace EventAttendeeMocks {
     id: uuidString(),
     username: "Anna Attendee",
     handle: UserHandle.optionalParse("AnnaAttendee")!,
+    profileImageURL: null,
     relations: {
       themToYou: "not-friends",
       youToThem: "not-friends"
@@ -76,6 +80,7 @@ export namespace EventAttendeeMocks {
     id: uuidString(),
     username: "Haley Host",
     handle: UserHandle.optionalParse("HaleyHost")!,
+    profileImageURL: null,
     relations: {
       themToYou: "not-friends",
       youToThem: "not-friends"
@@ -100,7 +105,6 @@ export namespace EventMocks {
       ),
       secondsToStart: dayjs.duration(3, "hours").asSeconds(),
       todayOrTomorrow: "today",
-      timezoneIdentifier: "UTC",
       clientReceivedTime: new Date()
     },
     settings: {
@@ -112,7 +116,8 @@ export namespace EventMocks {
     userAttendeeStatus: "attending",
     hasArrived: false,
     joinDate: new Date(),
-    isChatExpired: false
+    isChatExpired: false,
+    hasEndedEarly: false
   } as CurrentUserEvent
 
   export const Multiday = {
@@ -127,7 +132,6 @@ export namespace EventMocks {
         new Date("2023-03-21T12:00:00")
       ),
       secondsToStart: dayjs.duration(2, "days").asSeconds(),
-      timezoneIdentifier: "UTC",
       clientReceivedTime: new Date()
     },
     location: mockEventLocation(),
@@ -139,7 +143,8 @@ export namespace EventMocks {
     userAttendeeStatus: "attending",
     hasArrived: false,
     joinDate: new Date(),
-    isChatExpired: false
+    isChatExpired: false,
+    hasEndedEarly: false
   } as CurrentUserEvent
 
   export const NoPlacemarkInfo = {
@@ -155,11 +160,10 @@ export namespace EventMocks {
         new Date("2023-03-18T15:00:00")
       ),
       secondsToStart: dayjs.duration(2, "days").asSeconds(),
-      timezoneIdentifier: "UTC",
       clientReceivedTime: new Date()
     },
     color: ColorString.parse("#ABCDEF")!,
-    location: { ...mockEventLocation(), placemark: undefined },
+    location: { ...mockEventLocation(), placemark: null },
     settings: {
       shouldHideAfterStartDate: false,
       isChatEnabled: true
@@ -167,6 +171,7 @@ export namespace EventMocks {
     userAttendeeStatus: "attending",
     hasArrived: false,
     joinDate: new Date(),
-    isChatExpired: false
+    isChatExpired: false,
+    hasEndedEarly: false
   } as CurrentUserEvent
 }

--- a/shared-models/Event.ts
+++ b/shared-models/Event.ts
@@ -190,6 +190,13 @@ export type CurrentUserEvent = Omit<CurrentUserEventResponse, "time"> & {
   time: CurrentUserEventResponse["time"] & { clientReceivedTime: Date }
 }
 
+export const currentUserEventFromResponse = (
+  response: CurrentUserEventResponse
+) => ({
+  ...response,
+  time: { ...response.time, clientReceivedTime: new Date() }
+})
+
 export const BlockedEventResponseSchema = CurrentUserEventResponseSchema.omit({
   host: true
 })

--- a/shared-models/Event.ts
+++ b/shared-models/Event.ts
@@ -37,7 +37,7 @@ export const UnblockedEventAttendeeSchema = z.object({
   id: z.string().uuid(),
   username: z.string(),
   handle: UserHandle.zodSchema,
-  profileImageURL: z.string().url().optional(),
+  profileImageURL: z.string().url().nullable(),
   relations: UnblockedBidirectionalUserRelationsSchema
 })
 
@@ -88,7 +88,8 @@ export type EventPreviewAttendee = Pick<EventAttendee, "id" | "profileImageURL">
 
 export const EventLocationSchema = EventRegionSchema.extend({
   isInArrivalTrackingPeriod: z.boolean(),
-  placemark: PlacemarkSchema.optional()
+  timezoneIdentifier: z.string(),
+  placemark: PlacemarkSchema.nullable()
 })
 
 /**
@@ -104,8 +105,7 @@ export type EventLocation = z.infer<typeof EventLocationSchema>
 
 export const EventTimeResponseSchema = z.object({
   secondsToStart: z.number(),
-  todayOrTomorrow: TodayOrTomorrowSchema.optional(),
-  timezoneIdentifier: z.string(),
+  todayOrTomorrow: TodayOrTomorrowSchema.nullable(),
   dateRange: StringDateRangeSchema
 })
 
@@ -125,7 +125,7 @@ export const CurrentUserEventResponseSchema = z.object({
   description: z.string(),
   color: ColorString.zodSchema,
   attendeeCount: z.number().nonnegative(),
-  joinDate: StringDateSchema.optional(),
+  joinDate: StringDateSchema.nullable(),
   createdAt: StringDateSchema,
   updatedAt: StringDateSchema,
   hasArrived: z.boolean(),
@@ -135,7 +135,8 @@ export const CurrentUserEventResponseSchema = z.object({
   time: EventTimeResponseSchema,
   location: EventLocationSchema,
   previewAttendees: z.array(EventPreviewAttendeeSchema),
-  host: UnblockedEventAttendeeSchema
+  host: UnblockedEventAttendeeSchema,
+  hasEndedEarly: z.boolean()
 })
 
 /**


### PR DESCRIPTION
- Uses `nullable` instead of `optional` on the zod schemas which requires null to be explicitly passed.
- Adds a `hasEndedEarly` property directly on `CurrentUserEventResponse` which can be used to detect when the host has cancelled the event while it was ongoing.
- Moves `timezoneIdentifer` to the `location` object as per requested by the backend.