### PR TITLE
API Client: Add Optional Query Parameter Support

### DIFF
--- a/api-client/client.test.ts
+++ b/api-client/client.test.ts
@@ -64,6 +64,12 @@ describe("CreateAPIFetch tests", () => {
       rest.get("http://localhost:8080/test7", async (_, res, ctx) => {
         await neverPromise()
         return res(ctx.status(500))
+      }),
+      rest.get("http://localhost:8080/test8", async (req, res, ctx) => {
+        if (req.url.searchParams.has("hello")) {
+          return res(ctx.status(500))
+        }
+        return res(ctx.status(200), ctx.json({ a: 1 }))
       })
     )
   })
@@ -75,6 +81,22 @@ describe("CreateAPIFetch tests", () => {
         endpoint: "/test",
         query: { hello: "world", a: 1 },
         body: { a: 1, b: "hello" }
+      },
+      TestResponseSchema
+    )
+
+    expect(resp).toMatchObject({
+      status: 200,
+      data: { a: 1 }
+    })
+  })
+
+  test("api client fetch, undefined query", async () => {
+    const resp = await apiFetch(
+      {
+        method: "GET",
+        endpoint: "/test8",
+        query: { hello: undefined }
       },
       TestResponseSchema
     )

--- a/api-client/client.ts
+++ b/api-client/client.ts
@@ -5,10 +5,14 @@ import { AnyZodObject, ZodType, z } from "zod"
 
 export type TiFHTTPMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 
-type BaseTiFAPIRequest<Method extends TiFHTTPMethod> = {
+export type TiFAPIRequestQueryParameters = {
+  [key: string]: ToStringable | undefined
+}
+
+export type BaseTiFAPIRequest<Method extends TiFHTTPMethod> = {
   method: Method
   endpoint: `/${string}`
-  query?: { [key: string]: ToStringable }
+  query?: TiFAPIRequestQueryParameters
 }
 
 /**
@@ -199,9 +203,10 @@ const loadResponseBody = async (resp: Response) => {
   }
 }
 
-const queryToSearchParams = (query: { [key: string]: ToStringable }) => {
+const queryToSearchParams = (query: TiFAPIRequestQueryParameters) => {
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {
+    if (!value) continue
     params.set(key, value.toString())
   }
   return params


### PR DESCRIPTION
This PR adds the ability to pass in `undefined` in the `query` property when using `TiFAPIFetch` since some endpoints needed it.