### PR TITLE
Event Details: Join Endpoint

### DIFF
--- a/shared-models/ChatToken.test.ts
+++ b/shared-models/ChatToken.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { EventChatTokenChannelsCapabilitySchema } from "./ChatToken"
+
+describe("ChatToken tests", () => {
+  describe("EventChatTokenChannelsCapabilitySchema tests", () => {
+    it("should accept an object with both pinned and normal channels", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event": ["history", "publish", "subscribe"],
+            "5878-event-pinned": ["history", "subscribe"]
+          })
+        )
+      expect(result.success).toEqual(true)
+    })
+
+    it("should reject an object with event but no pinned channel", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event": ["history", "publish", "subscribe"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object with event pinned channel but no normal channel", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event-pinned": ["history", "subscribe"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object with extraneous channel names", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-toothbrush": ["history", "publish", "subscribe"],
+            "2468-who-do-we-appreciate": ["history", "subscribe"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object without both history and subscribe permissions", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event": ["history", "publish"],
+            "5878-event-pinned": ["subscribe"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object with invalid permissions", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event": ["history", "presence", "subscribe"],
+            "5878-event-pinned": ["history", "subscribe", "channel-metadata"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object with duplicate permissions", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({
+            "5678-event": ["history", "history"],
+            "5878-event-pinned": ["subscribe", "subscribe"]
+          })
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an object with no channels", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          JSON.stringify({})
+        )
+      expect(result.success).toEqual(false)
+    })
+
+    it("should reject an invalid JSON string", async () => {
+      const result =
+        await EventChatTokenChannelsCapabilitySchema.safeParseAsync(
+          "hello world"
+        )
+      expect(result.success).toEqual(false)
+    })
+  })
+})

--- a/shared-models/ChatToken.ts
+++ b/shared-models/ChatToken.ts
@@ -1,0 +1,48 @@
+import { z } from "zod"
+
+export const EventChatChannelCapabilitySchema = z.union([
+  z.literal("history"),
+  z.literal("subscribe"),
+  z.literal("publish")
+])
+
+const ChannelsCapabilityObjectSchema = z
+  .record(
+    z.string().regex(/^\d+-event(-pinned)?$/),
+    z.array(EventChatChannelCapabilitySchema)
+  )
+  .refine((channelsWithCapabilities) => {
+    if (Object.keys(channelsWithCapabilities).length < 2) return false
+    return Object.values(channelsWithCapabilities).every((permissions) => {
+      const permissionsSet = new Set(permissions)
+      const includesRequiredPermissions =
+        permissionsSet.has("history") && permissionsSet.has("subscribe")
+      const hasDuplicates = permissionsSet.size !== permissions.length
+      return includesRequiredPermissions && !hasDuplicates
+    })
+  })
+
+export const EventChatTokenChannelsCapabilitySchema = z
+  .string()
+  .refine(async (str) => {
+    try {
+      await ChannelsCapabilityObjectSchema.parseAsync(JSON.parse(str))
+      return true
+    } catch {
+      return false
+    }
+  })
+
+export const EventChatTokenRequestSchema = z.object({
+  capability: EventChatTokenChannelsCapabilitySchema,
+  clientId: z.string().uuid(),
+  keyName: z.string(),
+  mac: z.string(),
+  timestamp: z.number(),
+  nonce: z.string().min(16)
+})
+
+/**
+ * A request for a token to access the group chat for an event.
+ */
+export type EventChatTokenRequest = z.infer<typeof EventChatTokenRequestSchema>


### PR DESCRIPTION
Adds zod schemas and method on `TiFAPI` for the join endpoint. The schema for the chat token request was a little non-trivial, so I added some simple tests for it even if they don't handle every possible case. Additionally, I also added a `literalErrorSchema` function which creates zod schemas that match the errors returned from the api.