### PR TITLE
Event Details: Join Flow UI

### DIFF
--- a/.storybook/components/ContentText/ContextText.stories.tsx
+++ b/.storybook/components/ContentText/ContextText.stories.tsx
@@ -3,37 +3,45 @@ import React, { useState } from "react"
 import { ContentText, ExpandableContentText } from "@content-parsing"
 import { ScrollView, TextInput } from "react-native-gesture-handler"
 import { Headline } from "@components/Text"
+import { Button } from "react-native"
+
+const text1 =
+  "Hello world, this is an @event of some kind. Please join it if you like to do !17|123/#2BC016/Pickup Basketball. \n\nNow I write this endless storybook story in the void, where \nI can test things like @hello to make sure that links are highlighting and I am not going absolutely crazy."
+const text2 = "Hello world, I am the alternate text!"
 
 const StoryText = () => {
-  const [text, setText] = useState(
-    "Hello world, this is an @event of some kind. Please join it if you like to do nothing. \n\nNow I write this endless storybook story in the void, where \nI can test things like @hello to make sure that links are highlighting and I am not going absolutely crazy."
-  )
+  const [text, setText] = useState(text1)
   return (
     <ScrollView style={{ marginTop: 64 }}>
       <Headline>Expandable Text</Headline>
       <ExpandableContentText
-        initialText={text}
+        text={text}
         collapsedLineLimit={2}
+        expandButtonText="Read More"
         onUserHandleTapped={console.log}
         onEventHandleTapped={console.log}
         expandButtonTextStyle={{ color: "red" }}
         style={{ marginBottom: 24, marginTop: 8 }}
       />
+      <Button
+        title="Toggle text"
+        onPress={() => setText((t) => (t === text1 ? text2 : text1))}
+      />
       <Headline>No Long Enought Text</Headline>
       <ExpandableContentText
-        initialText="Now, for the new event! !17|123/#2BC016/Pickup Basketball"
+        text="Now, for the new event! !17|123/#2BC016/Pickup Basketball"
         collapsedLineLimit={5}
         onUserHandleTapped={console.log}
         onEventHandleTapped={console.log}
       />
       <Headline style={{ marginTop: 24 }}>Text Input</Headline>
-      <TextInput multiline style={{ width: "100%" }} onChangeText={setText}>
+      {/* <TextInput multiline style={{ width: "100%" }} onChangeText={setText}>
         <ContentText
           onUserHandleTapped={console.log}
           onEventHandleTapped={console.log}
           text={text}
         />
-      </TextInput>
+      </TextInput> */}
     </ScrollView>
   )
 }

--- a/.storybook/components/EventDetails/EventDetails.stories.tsx
+++ b/.storybook/components/EventDetails/EventDetails.stories.tsx
@@ -1,10 +1,14 @@
 import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
 import { ComponentMeta, ComponentStory } from "@storybook/react-native"
-import React, { useState } from "react"
+import React from "react"
 import { SafeAreaProvider } from "react-native-safe-area-context"
-import { EventArrivalBannerView } from "@event-details/arrival-tracking"
-import { Button, View } from "react-native"
-import Animated, { Layout } from "react-native-reanimated"
+import { View } from "react-native"
+import { EventMocks } from "@event-details/MockData"
+import { JoinEventStagesView, useJoinEventStages } from "@event-details"
+import { delayData } from "@lib/utils/DelayData"
+import { TrueRegionMonitor } from "@event-details/arrival-tracking/region-monitoring/MockRegionMonitors"
+import { TiFQueryClientProvider } from "@lib/ReactQuery"
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
 
 const EventDetailsMeta: ComponentMeta<typeof SettingsScreen> = {
   title: "Event Details"
@@ -14,8 +18,9 @@ export default EventDetailsMeta
 
 type EventDetailsStory = ComponentStory<typeof SettingsScreen>
 
+const event = EventMocks.PickupBasketball
+
 export const Basic: EventDetailsStory = () => {
-  const [isClosed, setIsClosed] = useState(false)
   return (
     <SafeAreaProvider>
       <View
@@ -26,19 +31,39 @@ export const Basic: EventDetailsStory = () => {
           alignItems: "center"
         }}
       >
-        {!isClosed && (
-          <EventArrivalBannerView
-            hasJoinedEvent
-            countdown={{ secondsToStart: 0 }}
-            canShareArrivalStatus={false}
-            onClose={() => setIsClosed(true)}
-            style={{ padding: 16, width: "100%" }}
-          />
-        )}
-        <Animated.View layout={Layout}>
-          <Button onPress={() => setIsClosed(false)} title="Show" />
-        </Animated.View>
+        <TiFQueryClientProvider>
+          <BottomSheetModalProvider>
+            <Test />
+          </BottomSheetModalProvider>
+        </TiFQueryClientProvider>
       </View>
     </SafeAreaProvider>
   )
+}
+
+const Test = () => {
+  const stage = useJoinEventStages(event, {
+    joinEvent: async () => {
+      return await delayData("success", 2000)
+    },
+    loadPermissions: async () => [
+      {
+        id: "notifications",
+        canRequestPermission: true,
+        requestPermission: async () => {
+          // await sleep(3000)
+        }
+      },
+      {
+        id: "backgroundLocation",
+        canRequestPermission: true,
+        requestPermission: async () => {
+          // await sleep(3000)
+        }
+      }
+    ],
+    monitor: TrueRegionMonitor,
+    onSuccess: () => console.log("success")
+  })
+  return <JoinEventStagesView stage={stage} />
 }

--- a/content-parsing/ExpandableContentText.tsx
+++ b/content-parsing/ExpandableContentText.tsx
@@ -1,5 +1,5 @@
 import { Headline } from "@components/Text"
-import React, { useState, useRef } from "react"
+import React, { useEffect, useState } from "react"
 import {
   StyleProp,
   TextStyle,
@@ -8,12 +8,14 @@ import {
   TouchableOpacity,
   StyleSheet
 } from "react-native"
-import Animated, { FadeIn, Layout } from "react-native-reanimated"
+import Animated, { FadeIn, FadeOut, Layout } from "react-native-reanimated"
 import { ContentTextProps, ContentText } from "./ContentText"
+import { useEffectEvent } from "@lib/utils/UseEffectEvent"
 
 export type ExpandableContentTextProps = {
   collapsedLineLimit: number
-  initialText: string
+  text: string
+  expandButtonText?: string
   contentTextStyle?: StyleProp<TextStyle>
   expandButtonTextStyle?: StyleProp<TextStyle>
   style?: StyleProp<ViewStyle>
@@ -21,71 +23,85 @@ export type ExpandableContentTextProps = {
 
 /**
  * Content text that expands when the user presses a "Read More" button.
- *
- * At the moment, this only renders the initial text given to it correctly, it does not
- * render any changes to the input text.
  */
 export const ExpandableContentText = ({
   collapsedLineLimit,
   onTextLayout,
-  initialText,
+  text,
   contentTextStyle,
   expandButtonTextStyle,
+  expandButtonText = "Read More",
   style,
   ...props
 }: ExpandableContentTextProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
-  const [expansionStatus, setExpansionStatus] = useState<
-    "expandable" | "unexpandable" | undefined
-  >()
-  const textSplitsRef = useRef({ collapsedText: "", expandedText: "" })
-  const numberOfLines = expansionStatus
+  const [textState, setTextState] = useState({
+    text,
+    lineLimit: collapsedLineLimit,
+    expansionStatus: undefined as "expandable" | "unexpandable" | undefined
+  })
+  const resetTextStateIfNeeded = useEffectEvent(
+    (text: string, lineLimit: number) => {
+      if (text !== textState.text || lineLimit !== textState.lineLimit) {
+        setTextState({ text, lineLimit, expansionStatus: undefined })
+      }
+    }
+  )
+  useEffect(() => {
+    resetTextStateIfNeeded(text, collapsedLineLimit)
+  }, [text, collapsedLineLimit, resetTextStateIfNeeded])
+  const numberOfLines = textState.expansionStatus
     ? collapsedLineLimit
     : collapsedLineLimit + 1
   return (
     <View style={style}>
-      <ContentText
-        {...props}
-        text={isExpanded ? textSplitsRef.current.collapsedText : initialText}
-        numberOfLines={isExpanded ? undefined : numberOfLines}
-        onTextLayout={(e) => {
-          if (expansionStatus) {
-            onTextLayout?.(e)
-            return
-          }
-          const textBlocks = e.nativeEvent.lines.map((line) => line.text)
-          const visibleText = textBlocks
-            .slice(0, textBlocks.length - 1)
-            .join("")
-          textSplitsRef.current.collapsedText = visibleText.endsWith("\n")
-            ? visibleText.slice(0, visibleText.length - 1)
-            : visibleText
-          textSplitsRef.current.expandedText = initialText.slice(
-            visibleText.length
-          )
-          setExpansionStatus(
-            textBlocks.length !== collapsedLineLimit + 1
-              ? "unexpandable"
-              : "expandable"
-          )
-          onTextLayout?.(e)
-        }}
-        style={[contentTextStyle, { opacity: expansionStatus ? 1 : 0 }]}
-      />
-      {isExpanded && (
-        <Animated.View entering={FadeIn.duration(300)}>
-          <ContentText {...props} text={textSplitsRef.current.expandedText} />
+      {!isExpanded && (
+        // NB: By having a long fade out on this text, it creates a cross-fade
+        // effect involving the uncollapsed text such that the user can't tell
+        // that the uncollapsed text is fading out thus preventing a flicker in
+        // the ui.
+        <Animated.View exiting={FadeOut.duration(1000)}>
+          <ContentText
+            {...props}
+            text={textState.text}
+            numberOfLines={isExpanded ? undefined : numberOfLines}
+            onTextLayout={(e) => {
+              if (textState.expansionStatus) {
+                onTextLayout?.(e)
+                return
+              }
+              const textBlocks = e.nativeEvent.lines.map((line) => line.text)
+              setTextState((state) => ({
+                ...state,
+                expansionStatus:
+                  textBlocks.length <= collapsedLineLimit
+                    ? "unexpandable"
+                    : "expandable"
+              }))
+              onTextLayout?.(e)
+            }}
+            style={[contentTextStyle]}
+          />
         </Animated.View>
       )}
-      {expansionStatus === "expandable" && (
-        <Animated.View layout={Layout.duration(300)}>
+      {isExpanded && (
+        <Animated.View entering={FadeIn.duration(500)}>
+          <ContentText {...props} text={textState.text} />
+        </Animated.View>
+      )}
+      {textState.expansionStatus === "expandable" && !isExpanded && (
+        <Animated.View
+          layout={Layout.duration(300)}
+          exiting={FadeOut.duration(300)}
+          style={styles.container}
+        >
           <TouchableOpacity
-            onPress={() => setIsExpanded((expanded) => !expanded)}
+            onPress={() => setIsExpanded(true)}
             style={styles.readMore}
             hitSlop={44}
           >
             <Headline style={expandButtonTextStyle}>
-              {isExpanded ? "Read Less" : "Read More"}
+              {expandButtonText}
             </Headline>
           </TouchableOpacity>
         </Animated.View>
@@ -95,6 +111,10 @@ export const ExpandableContentText = ({
 }
 
 const styles = StyleSheet.create({
+  container: {
+    display: "flex",
+    flexDirection: "row"
+  },
   readMore: {
     marginTop: 8
   }

--- a/event-details/arrival-tracking/region-monitoring/MockRegionMonitors.ts
+++ b/event-details/arrival-tracking/region-monitoring/MockRegionMonitors.ts
@@ -1,0 +1,13 @@
+import { EventRegionMonitor } from "./RegionMonitoring"
+
+/**
+ * An {@link EventRegionMonitor} that always emits true.
+ */
+export const TrueRegionMonitor: EventRegionMonitor = {
+  monitorRegion: (_, callback) => {
+    // eslint-disable-next-line n/no-callback-literal
+    callback(true)
+    return () => {}
+  },
+  hasArrivedAtRegion: () => true
+}

--- a/event-details/index.ts
+++ b/event-details/index.ts
@@ -1,1 +1,2 @@
 export * from "./Event"
+export * from "./JoinEvent"


### PR DESCRIPTION
The initial join flow UI that follows up on #242. Though, this code does make a few naming changes with regards to the hook, but the functionality remains exactly the same.

I'm going to keep this PR in draft for 2 reasons:
1. I need to hear back on what exact messages to use for the permission modals.
2. The code to control the presentation of the bottom sheet modal is really hacky.

With regards to point 2, the main reason for the hacks was to ensure that the modals present sequentially 1 after the other in a graceful way. I originally implemented it using 2 separate `BottomSheetModal` components, but this created a quite nasty and abrupt animation when switching between the 2 sheets after enabling notification permissions. Essentially, the trick is to wait for the first one to dismiss fully before presenting the next which can be done with the `onDismiss` prop.

However, this is naturally where all hell breaks loose. First of all, the `onDismiss` prop is also called for things like swiping down the bottom sheet manually, or tapping the backdrop. Therefore, I needed some way to distinguish those events from programatic dismissals so I could call `dismissButtonTapped`, and therefore making sure `useJoinEventStage` gets the create state update on dismissal. Furthermore, when the sheet is in its dismissing animation it needs to display the same contents as when it was presented. Both of these reasons led me to creating a state variable which I had to keep manually in sync with both the state from the hook, and the actual presentation state. This is definitely not ideal, but it gets things working for now. I may be able to refactor the hook to make this less hacky, but I think just by relying on the `onDismiss` prop there are already issues.