### PR TITLE
Event Arrivals: Prevent arrivals from being tracked when background location permissions are disabled

### DIFF
--- a/event-details/arrival-tracking/Tracker.test.ts
+++ b/event-details/arrival-tracking/Tracker.test.ts
@@ -342,7 +342,7 @@ describe("EventArrivalsTracker tests", () => {
     await verifyNeverOccurs(() => expect(callback).toHaveBeenCalledTimes(2))
   })
 
-  it("should not publish an update when failing to replace arrivals on geofencer", async () => {
+  it("should publish an empty update when failing to replace arrivals on geofencer", async () => {
     const arrival = mockEventArrival()
     const tracker = new EventArrivalsTracker(
       upcomingArrivals,
@@ -361,7 +361,8 @@ describe("EventArrivalsTracker tests", () => {
     await subscription.waitForInitialRegionsToLoad()
     callback.mockReset()
     await tracker.trackArrival(arrival)
-    await verifyNeverOccurs(() => expect(callback).toHaveBeenCalled())
+    await waitFor(() => expect(callback).toHaveBeenCalledWith([]))
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
   const expectTrackedRegions = async (regions: EventArrivalRegion[]) => {

--- a/event-details/arrival-tracking/Tracker.ts
+++ b/event-details/arrival-tracking/Tracker.ts
@@ -11,6 +11,9 @@ import { PerformArrivalsOperation } from "./ArrivalsOperation"
 import { EventArrival, arrivalRegion, removeDuplicateArrivals } from "./Models"
 import { areEventRegionsEqual } from "@shared-models/Event"
 import { uuidString } from "@lib/utils/UUID"
+import { createLogFunction } from "@lib/Logging"
+
+const log = createLogFunction("event.arrivals.tracker")
 
 export interface EventArrivalsTrackerSubscription {
   waitForInitialRegionsToLoad(): Promise<void>
@@ -149,12 +152,16 @@ export class EventArrivalsTracker {
   }
 
   private async syncRegions (regions: EventArrivalRegion[]) {
-    await Promise.all([
-      this.geofencer.replaceGeofencedRegions(regions),
-      this.upcomingArrivals.replaceAll(regions)
-    ])
-    this.updateGeofencingSubscription(regions)
-    this.subscriptions.forEach((callback) => callback(regions))
+    try {
+      await Promise.all([
+        this.geofencer.replaceGeofencedRegions(regions),
+        this.upcomingArrivals.replaceAll(regions)
+      ])
+      this.updateGeofencingSubscription(regions)
+      this.subscriptions.forEach((callback) => callback(regions))
+    } catch (e) {
+      log("error", "Failed to sync regions", { message: e.message })
+    }
   }
 
   private updateGeofencingSubscription (arrivals: EventArrivalRegion[]) {

--- a/event-details/arrival-tracking/Tracker.ts
+++ b/event-details/arrival-tracking/Tracker.ts
@@ -161,6 +161,8 @@ export class EventArrivalsTracker {
       this.subscriptions.forEach((callback) => callback(regions))
     } catch (e) {
       log("error", "Failed to sync regions", { message: e.message })
+      // eslint-disable-next-line n/no-callback-literal
+      this.subscriptions.forEach((callback) => callback([]))
     }
   }
 

--- a/event-details/arrival-tracking/UpcomingArrivals.test.ts
+++ b/event-details/arrival-tracking/UpcomingArrivals.test.ts
@@ -1,0 +1,42 @@
+import { clearAsyncStorageBeforeEach } from "@test-helpers/AsyncStorage"
+import {
+  AsyncStorageUpcomingEventArrivals,
+  requireBackgroundLocationPermissions
+} from "./UpcomingArrivals"
+import { mockEventArrivalRegion } from "./MockData"
+
+describe("UpcomingArrivals tests", () => {
+  describe("RequireBackgroundLocationPermissions tests", () => {
+    clearAsyncStorageBeforeEach()
+    const baseUpcomingArrivals = new AsyncStorageUpcomingEventArrivals()
+
+    it("should not be able to query all arrivals when background location permissions are disabled", async () => {
+      baseUpcomingArrivals.replaceAll([mockEventArrivalRegion()])
+      const upcomingArrivals = requireBackgroundLocationPermissions(
+        baseUpcomingArrivals,
+        jest.fn().mockResolvedValueOnce(false)
+      )
+      expect(await upcomingArrivals.all()).toEqual([])
+    })
+
+    it("should not be able to save arrivals when background location permissions are disabled", async () => {
+      const upcomingArrivals = requireBackgroundLocationPermissions(
+        baseUpcomingArrivals,
+        jest.fn().mockResolvedValueOnce(false)
+      )
+      await upcomingArrivals.replaceAll([mockEventArrivalRegion()])
+      expect(await baseUpcomingArrivals.all()).toEqual([])
+    })
+
+    it("should work normally when background location permissions are enabled", async () => {
+      const upcomingArrivals = requireBackgroundLocationPermissions(
+        baseUpcomingArrivals,
+        jest.fn().mockResolvedValue(true)
+      )
+      const arrivalRegions = [mockEventArrivalRegion()]
+      await upcomingArrivals.replaceAll(arrivalRegions)
+      expect(await upcomingArrivals.all()).toEqual(arrivalRegions)
+      expect(await baseUpcomingArrivals.all()).toEqual(arrivalRegions)
+    })
+  })
+})

--- a/event-details/arrival-tracking/UpcomingArrivals.ts
+++ b/event-details/arrival-tracking/UpcomingArrivals.ts
@@ -4,6 +4,7 @@ import {
   EventArrivalRegion,
   EventArrivalRegionsSchema
 } from "@shared-models/EventArrivals"
+import { getBackgroundPermissionsAsync } from "expo-location"
 
 /**
  * An interface for storing client-side details on upcoming event arrivals.
@@ -40,3 +41,24 @@ implements UpcomingEventArrivals {
     )
   }
 }
+
+/**
+ * Given a base {@link UpcomingEventArrivals} instance, it prevents arrivals
+ * from being read and written if the user has background location permissions
+ * disabled.
+ */
+export const requireBackgroundLocationPermissions = (
+  base: UpcomingEventArrivals,
+  loadPermissions: () => Promise<boolean> = async () => {
+    return (await getBackgroundPermissionsAsync()).granted
+  }
+): UpcomingEventArrivals => ({
+  all: async () => {
+    return (await loadPermissions()) ? await base.all() : []
+  },
+  replaceAll: async (arrivalRegions) => {
+    if (await loadPermissions()) {
+      await base.replaceAll(arrivalRegions)
+    }
+  }
+})


### PR DESCRIPTION
In light of region monitoring for the UI, when the user disabled background location permissions we won't be able to geofence any locations in the background. Therefore, we aren't really tracking them, and we shouldn't even consider them as being a part of the tracker.

So I added 2 things to make this happen:
1. A `requireBackgroundLocationPermissions` function that takes in a `UpcomingEventArrivals` instance, and returns a new `UpcomingEventArrivals` instance that blocks reads and writes if the user has the permissions disabled.
2. I made sure that the tracker publishes an empty update to the `subscribe` method when the given `EventArrivalsGeofencer` throws after calling `replaceAllGeofencedRegions`.

The first needs to be done because the user may retroactively disable background permissions in settings, and thus we would already have stored arrivals. So in order to prevent them from being counted as tracked, it made more sense to create another conformance to `UpcomingEventArrivals` to prevent any lingering stored arrivals from being queried.

For the second, I make sure to publish an empty update since at that point we're no longer tracking any events, so it only makes sense to do that as it would ensure that `EventArrivalsTrackerRegionMonitor` would now monitor all regions on the fallback monitor.