### PR TITLE
Fix Expandable Content Text

### DIFF
--- a/.storybook/components/ContentText/ContextText.stories.tsx
+++ b/.storybook/components/ContentText/ContextText.stories.tsx
@@ -3,37 +3,45 @@ import React, { useState } from "react"
 import { ContentText, ExpandableContentText } from "@content-parsing"
 import { ScrollView, TextInput } from "react-native-gesture-handler"
 import { Headline } from "@components/Text"
+import { Button } from "react-native"
+
+const text1 =
+  "Hello world, this is an @event of some kind. Please join it if you like to do !17|123/#2BC016/Pickup Basketball. \n\nNow I write this endless storybook story in the void, where \nI can test things like @hello to make sure that links are highlighting and I am not going absolutely crazy."
+const text2 = "Hello world, I am the alternate text!"
 
 const StoryText = () => {
-  const [text, setText] = useState(
-    "Hello world, this is an @event of some kind. Please join it if you like to do nothing. \n\nNow I write this endless storybook story in the void, where \nI can test things like @hello to make sure that links are highlighting and I am not going absolutely crazy."
-  )
+  const [text, setText] = useState(text1)
   return (
     <ScrollView style={{ marginTop: 64 }}>
       <Headline>Expandable Text</Headline>
       <ExpandableContentText
-        initialText={text}
+        text={text}
         collapsedLineLimit={2}
+        expandButtonText="Read More"
         onUserHandleTapped={console.log}
         onEventHandleTapped={console.log}
         expandButtonTextStyle={{ color: "red" }}
         style={{ marginBottom: 24, marginTop: 8 }}
       />
+      <Button
+        title="Toggle text"
+        onPress={() => setText((t) => (t === text1 ? text2 : text1))}
+      />
       <Headline>No Long Enought Text</Headline>
       <ExpandableContentText
-        initialText="Now, for the new event! !17|123/#2BC016/Pickup Basketball"
+        text="Now, for the new event! !17|123/#2BC016/Pickup Basketball"
         collapsedLineLimit={5}
         onUserHandleTapped={console.log}
         onEventHandleTapped={console.log}
       />
       <Headline style={{ marginTop: 24 }}>Text Input</Headline>
-      <TextInput multiline style={{ width: "100%" }} onChangeText={setText}>
+      {/* <TextInput multiline style={{ width: "100%" }} onChangeText={setText}>
         <ContentText
           onUserHandleTapped={console.log}
           onEventHandleTapped={console.log}
           text={text}
         />
-      </TextInput>
+      </TextInput> */}
     </ScrollView>
   )
 }

--- a/content-parsing/ExpandableContentText.tsx
+++ b/content-parsing/ExpandableContentText.tsx
@@ -1,5 +1,5 @@
 import { Headline } from "@components/Text"
-import React, { useState, useRef } from "react"
+import React, { useEffect, useState } from "react"
 import {
   StyleProp,
   TextStyle,
@@ -8,12 +8,14 @@ import {
   TouchableOpacity,
   StyleSheet
 } from "react-native"
-import Animated, { FadeIn, Layout } from "react-native-reanimated"
+import Animated, { FadeIn, FadeOut, Layout } from "react-native-reanimated"
 import { ContentTextProps, ContentText } from "./ContentText"
+import { useEffectEvent } from "@lib/utils/UseEffectEvent"
 
 export type ExpandableContentTextProps = {
   collapsedLineLimit: number
-  initialText: string
+  text: string
+  expandButtonText?: string
   contentTextStyle?: StyleProp<TextStyle>
   expandButtonTextStyle?: StyleProp<TextStyle>
   style?: StyleProp<ViewStyle>
@@ -21,71 +23,85 @@ export type ExpandableContentTextProps = {
 
 /**
  * Content text that expands when the user presses a "Read More" button.
- *
- * At the moment, this only renders the initial text given to it correctly, it does not
- * render any changes to the input text.
  */
 export const ExpandableContentText = ({
   collapsedLineLimit,
   onTextLayout,
-  initialText,
+  text,
   contentTextStyle,
   expandButtonTextStyle,
+  expandButtonText = "Read More",
   style,
   ...props
 }: ExpandableContentTextProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
-  const [expansionStatus, setExpansionStatus] = useState<
-    "expandable" | "unexpandable" | undefined
-  >()
-  const textSplitsRef = useRef({ collapsedText: "", expandedText: "" })
-  const numberOfLines = expansionStatus
+  const [textState, setTextState] = useState({
+    text,
+    lineLimit: collapsedLineLimit,
+    expansionStatus: undefined as "expandable" | "unexpandable" | undefined
+  })
+  const resetTextStateIfNeeded = useEffectEvent(
+    (text: string, lineLimit: number) => {
+      if (text !== textState.text || lineLimit !== textState.lineLimit) {
+        setTextState({ text, lineLimit, expansionStatus: undefined })
+      }
+    }
+  )
+  useEffect(() => {
+    resetTextStateIfNeeded(text, collapsedLineLimit)
+  }, [text, collapsedLineLimit, resetTextStateIfNeeded])
+  const numberOfLines = textState.expansionStatus
     ? collapsedLineLimit
     : collapsedLineLimit + 1
   return (
     <View style={style}>
-      <ContentText
-        {...props}
-        text={isExpanded ? textSplitsRef.current.collapsedText : initialText}
-        numberOfLines={isExpanded ? undefined : numberOfLines}
-        onTextLayout={(e) => {
-          if (expansionStatus) {
-            onTextLayout?.(e)
-            return
-          }
-          const textBlocks = e.nativeEvent.lines.map((line) => line.text)
-          const visibleText = textBlocks
-            .slice(0, textBlocks.length - 1)
-            .join("")
-          textSplitsRef.current.collapsedText = visibleText.endsWith("\n")
-            ? visibleText.slice(0, visibleText.length - 1)
-            : visibleText
-          textSplitsRef.current.expandedText = initialText.slice(
-            visibleText.length
-          )
-          setExpansionStatus(
-            textBlocks.length !== collapsedLineLimit + 1
-              ? "unexpandable"
-              : "expandable"
-          )
-          onTextLayout?.(e)
-        }}
-        style={[contentTextStyle, { opacity: expansionStatus ? 1 : 0 }]}
-      />
-      {isExpanded && (
-        <Animated.View entering={FadeIn.duration(300)}>
-          <ContentText {...props} text={textSplitsRef.current.expandedText} />
+      {!isExpanded && (
+        // NB: By having a long fade out on this text, it creates a cross-fade
+        // effect involving the uncollapsed text such that the user can't tell
+        // that the uncollapsed text is fading out thus preventing a flicker in
+        // the ui.
+        <Animated.View exiting={FadeOut.duration(1000)}>
+          <ContentText
+            {...props}
+            text={textState.text}
+            numberOfLines={isExpanded ? undefined : numberOfLines}
+            onTextLayout={(e) => {
+              if (textState.expansionStatus) {
+                onTextLayout?.(e)
+                return
+              }
+              const textBlocks = e.nativeEvent.lines.map((line) => line.text)
+              setTextState((state) => ({
+                ...state,
+                expansionStatus:
+                  textBlocks.length <= collapsedLineLimit
+                    ? "unexpandable"
+                    : "expandable"
+              }))
+              onTextLayout?.(e)
+            }}
+            style={[contentTextStyle]}
+          />
         </Animated.View>
       )}
-      {expansionStatus === "expandable" && (
-        <Animated.View layout={Layout.duration(300)}>
+      {isExpanded && (
+        <Animated.View entering={FadeIn.duration(500)}>
+          <ContentText {...props} text={textState.text} />
+        </Animated.View>
+      )}
+      {textState.expansionStatus === "expandable" && !isExpanded && (
+        <Animated.View
+          layout={Layout.duration(300)}
+          exiting={FadeOut.duration(300)}
+          style={styles.container}
+        >
           <TouchableOpacity
-            onPress={() => setIsExpanded((expanded) => !expanded)}
+            onPress={() => setIsExpanded(true)}
             style={styles.readMore}
             hitSlop={44}
           >
             <Headline style={expandButtonTextStyle}>
-              {isExpanded ? "Read Less" : "Read More"}
+              {expandButtonText}
             </Headline>
           </TouchableOpacity>
         </Animated.View>
@@ -95,6 +111,10 @@ export const ExpandableContentText = ({
 }
 
 const styles = StyleSheet.create({
+  container: {
+    display: "flex",
+    flexDirection: "row"
+  },
   readMore: {
     marginTop: 8
   }


### PR DESCRIPTION
The previous component had 2 flaws:
1. It didn't update when the text changed.
2. It didn't render event handles properly.

This PR fixes both of those problems. First of all, the reason event handles weren't rendered properly was because we were combining the raw text from the text lines rendered by `ContentText`, which would strip any metadata characters needed to render event handles. This was convenient before, since we could easily separate the collapsed text from the expanded text, and then gracefully animate in just the text that needed to be expanded. 

However, in order to fix this we cannot rely on the raw text lines anymore, and instead must rely on rendering everything within `ContentText` itself. Thankfully, we can recreate the animation bits by applying a sneaky cross-fade between the collapsed and expanded text such that it doesn't look like the collapsed text is disappearing when expanded.

For the second issue, we can only calculate the proper expansion status in `onTextLayout` which only fires when the text changes. In order to detect whether or not the text is expandable we must render 1 extra line than the `collapsedLineLimit`, and then check to see if the number of lines is greater than `collapsedLineLimit` before re-rendering with the correct number of collapsed lines. We have to take this round-about approach because react-native will put all truncated text on the final line with no way to tell which text is actually on screen. This is why we have the guard clause at the top of `onTextLayout`, it's so that we don't accidentally recalculate incorrectly.

However, this would also prevent the text changing from the outside the component as we would simply never perform the required layout calculations. To fix this, I utilized that `useEffectEvent` hook to detect when the current text changed, and invalidated the layout state when that occurred. I should note that the use of `useEffectEvent` was necessary since we compare against the current text state and change it, but we don't want to re-fire the `useEffect` when we actually need to perform the change.

So all in all, typical UI code.