### PR TITLE
Eslint: Remove react in scope

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "no-use-before-define": "off",
+    "react/react-in-jsx-scope": "off",
     "spaced-comment": "warn",
     "space-in-parens": "error",
     "computed-property-spacing": "error",

--- a/event-details/arrival-tracking/ArrivalBanner.tsx
+++ b/event-details/arrival-tracking/ArrivalBanner.tsx
@@ -3,7 +3,7 @@ import { TouchableIonicon } from "@components/common/Icons"
 import { AppStyles } from "@lib/AppColorStyle"
 import { FontScaleFactors } from "@lib/Fonts"
 import { ceilDurationToUnit, dayjs } from "@date-time"
-import React, { useState } from "react"
+import { useState } from "react"
 import { View, ViewStyle, StyleSheet } from "react-native"
 import Animated, {
   AnimatedStyleProp,


### PR DESCRIPTION
We hated this rule in unison, so it shall be banished.