### PR TITLE
Add leaveEvent function to tifAPI

### DIFF
--- a/api-client/TiFAPI.ts
+++ b/api-client/TiFAPI.ts
@@ -7,11 +7,11 @@ import {
   EventRegion
 } from "@shared-models/Event"
 
+import { EventChatTokenRequestSchema } from "@shared-models/ChatToken"
 import { EventArrivalRegionsSchema } from "@shared-models/EventArrivals"
 import { z } from "zod"
 import { createAWSTiFAPIFetch } from "./aws"
 import { TiFAPIFetch, createTiFAPIFetch } from "./client"
-import { EventChatTokenRequestSchema } from "@shared-models/ChatToken"
 
 export type UpdateCurrentUserProfileRequest = Partial<{
   name: string
@@ -221,6 +221,25 @@ export class TiFAPI {
         status403: literalErrorSchema("user-is-blocked", "event-has-ended"),
         status201: JoinResponseSchema,
         status200: JoinResponseSchema
+      }
+    )
+  }
+
+  /**
+   * Leaves the event with the given id.
+   *
+   * @param eventId The id of the event to leave.
+   */
+  async leaveEvent (eventId: number) {
+    return await this.apiFetch(
+      {
+        method: "POST",
+        endpoint: `/event/leave/${eventId}`
+      },
+      {
+        status403: literalErrorSchema("event-has-been-cancelled", "event-has-ended"),
+        status400: literalErrorSchema("co-host-not-found", "already-left-event"),
+        status204: "no-content"
       }
     )
   }


### PR DESCRIPTION
* Adds a leaveEvent function to the TiFAPI class, to allow for the leaveEvent flow to utilise TiFAPI.

Response codes: 

- 204: Success case, no-content

- 400: Host trying to leave, user already left event (counts as success case to hook)

- 403: Event already been cancelled, or otherwise ended