### PR TITLE
SQLite Migration: Recents Storage

### DIFF
--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -84,6 +84,24 @@ export class TiFSQLite {
           REFERENCES LocationArrivals(latitude, longitude, arrivalRadiusMeters)
           ON DELETE CASCADE
       )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS LocationPlacemarks (
+        latitude DOUBLE NOT NULL,
+        longitude DOUBLE NOT NULL,
+        name TEXT,
+        country TEXT,
+        postalCode TEXT,
+        street TEXT,
+        streetNumber TEXT,
+        region TEXT,
+        isoCountryCode TEXT,
+        city TEXT,
+        recentAnnotation TEXT,
+        recentUpdatedAt DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec')),
+        CHECK(recentAnnotation IN ('attended-event', 'hosted-event')),
+        PRIMARY KEY(latitude, longitude)
+      )
       `
     ])
     return db

--- a/lib/utils/Array.ts
+++ b/lib/utils/Array.ts
@@ -1,12 +1,5 @@
 export namespace ArrayUtils {
   /**
-   * A typesafe way for removing all null/undefined values from an array.
-   */
-  export const removeOptionals = <T>(arr: (T | null | undefined)[]) => {
-    return arr.reduce((acc, curr) => (curr ? [...acc, curr] : acc), [])
-  }
-
-  /**
    * Returns a random element from an array which has at least one element.
    */
   export const randomElement = <T>(arr: T[]) => {

--- a/lib/utils/DeepNullable.ts
+++ b/lib/utils/DeepNullable.ts
@@ -1,0 +1,6 @@
+/**
+ * Unions all properties of a given object with `null`.
+ */
+export type DeepNullable<T> = {
+  [K in keyof T]: DeepNullable<T[K]> | null
+}

--- a/location/MockData.ts
+++ b/location/MockData.ts
@@ -71,7 +71,7 @@ export const mockLocationCoordinate2D = (): LocationCoordinate2D => ({
 export const mockTiFLocation = (
   coordinates?: LocationCoordinate2D
 ): TiFLocation => ({
-  coordinates: coordinates ?? mockLocationCoordinate2D(),
+  coordinate: coordinates ?? mockLocationCoordinate2D(),
   placemark: mockPlacemark()
 })
 

--- a/location/search/MockData.ts
+++ b/location/search/MockData.ts
@@ -1,11 +1,7 @@
-import { ArrayUtils } from "@lib/utils/Array"
 import { randomBool } from "@lib/utils/Random"
-import { LocationCoordinate2D, TiFLocation } from "@location"
-import {
-  RecentLocationAnnotation,
-  asyncStorageLoadRecentLocations
-} from "./RecentsStorage"
-import { LocationSearchResult, LocationsSearchQuery } from "./Models"
+import { LocationCoordinate2D } from "@location"
+import { RecentLocationAnnotation } from "./RecentsStorage"
+import { LocationSearchResult } from "./Models"
 import { mockTiFLocation } from "@location/MockData"
 
 /**
@@ -28,41 +24,4 @@ export const mockLocationSearchResult = (
     annotation: isRecent ? mockLocationSearchAnnotation() : undefined,
     isRecentLocation: isRecent
   } as LocationSearchResult
-}
-
-/**
- *
- * @param coordinates
- * @returns A promise for a mocked array of LocationSearchResults.
- */
-export const mockLocationSearchResultArray = async (
-  coordinates?: LocationCoordinate2D[]
-) => {
-  return coordinates?.map((point) => mockLocationSearchResult(point))
-}
-
-/**
- *
- * @param coordinates
- * @returns A promise for a mocked array of TiFLocations.
- */
-export const mockTiFLocationArray = async (
-  coordinates?: LocationCoordinate2D[]
-) => {
-  return coordinates?.map((point) => mockTiFLocation(point))
-}
-
-export const mockLocationSearchFunction = async (
-  query: LocationsSearchQuery
-): Promise<TiFLocation[]> => {
-  return ArrayUtils.compactMap(
-    await asyncStorageLoadRecentLocations(10),
-    (recentLocation) =>
-      recentLocation.location.placemark.name?.includes(query.toString())
-        ? {
-          coordinates: recentLocation.location.coordinates,
-          placemark: recentLocation.location.placemark
-        }
-        : undefined
-  )
 }

--- a/location/search/Models.ts
+++ b/location/search/Models.ts
@@ -51,7 +51,7 @@ export class LocationsSearchQuery {
 
   private readonly rawValue: string
 
-  constructor (rawValue: string) {
+  constructor(rawValue: string) {
     this.rawValue = rawValue
   }
 
@@ -59,11 +59,11 @@ export class LocationsSearchQuery {
    * The data source type of this query. An empty string means loading from
    * the user's recent locations.
    */
-  get sourceType (): LocationsSearchSourceType {
+  get sourceType(): LocationsSearchSourceType {
     return this.rawValue.length === 0 ? "user-recents" : "remote-search"
   }
 
-  toString () {
+  toString() {
     return this.rawValue
   }
 }

--- a/location/search/RecentsStorage.test.ts
+++ b/location/search/RecentsStorage.test.ts
@@ -88,5 +88,30 @@ describe("RecentLocationStorage tests", () => {
         })
       ])
     })
+
+    test("load locations by coordinates with first longitude value equal to second latitude value", async () => {
+      await storage.save(
+        mockTiFLocation({ latitude: -50.123, longitude: -50.123 })
+      )
+      const results = await storage.locationsForCoordinates([
+        { latitude: 45.123, longitude: -50.123 },
+        { latitude: -50.123, longitude: 45.123 }
+      ])
+      expect(results).toEqual([])
+    })
+
+    test("load locations by coordinates using duplicate coordinates", async () => {
+      const locations = ArrayUtils.repeatElements(2, () => mockTiFLocation())
+      await storage.save(locations[0], "attended-event")
+      await storage.save(locations[1])
+      const results = await storage.locationsForCoordinates([
+        locations[0].coordinate,
+        locations[0].coordinate
+      ])
+      expect(results).toEqual([{
+        location: locations[0],
+        annotation: "attended-event"
+      }])
+    })
   })
 })

--- a/location/search/RecentsStorage.test.ts
+++ b/location/search/RecentsStorage.test.ts
@@ -1,78 +1,57 @@
-import { mockTiFLocation } from "@location/MockData"
-import {
-  asyncStorageLoadRecentLocations,
-  asyncStorageLoadSpecificRecentLocations,
-  asyncStorageSaveRecentLocation
-} from "./RecentsStorage"
-import AsyncStorage from "@react-native-async-storage/async-storage"
-import { clearAsyncStorageBeforeEach } from "@test-helpers/AsyncStorage"
-
-const TEST_COORDINATES = { latitude: 41.1234, longitude: -121.1234 }
-const TEST_COORDINATES_STORAGE_KEY = "@location_9r3cgy29h"
+import { mockLocationCoordinate2D, mockTiFLocation } from "@location/MockData"
+import { SQLiteRecentLocationsStorage } from "./RecentsStorage"
+import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
+import { ArrayUtils } from "@lib/utils/Array"
+import { sleep } from "@lib/utils/DelayData"
 
 describe("RecentLocationStorage tests", () => {
-  clearAsyncStorageBeforeEach()
+  describe("SQLiteRecentLocations tests", () => {
+    resetTestSQLiteBeforeEach()
+    const storage = new SQLiteRecentLocationsStorage(testSQLite)
 
-  describe("AsyncStorageSaveRecentLocation tests", () => {
-    it("should save the location in async storage", async () => {
-      const location = mockTiFLocation(TEST_COORDINATES)
+    it("should return no recent locations when no locations are saved", async () => {
+      const recents = await storage.recent(10)
+      expect(recents).toEqual([])
+    })
 
-      await asyncStorageSaveRecentLocation(location, "attended-event")
-      const savedLocation = JSON.parse(
-        (await AsyncStorage.getItem(TEST_COORDINATES_STORAGE_KEY))!
-      )
-      expect(savedLocation).toMatchObject({
-        location,
-        annotation: "attended-event"
+    it("should return no locations for coordinates when no locations are saved", async () => {
+      const coordinates = ArrayUtils.repeatElements(3, () => {
+        return mockLocationCoordinate2D()
       })
+      const locations = await storage.locationsForCoordinates(coordinates)
+      expect(locations).toEqual([])
     })
-  })
 
-  describe("AsyncStorageLoadSpecificRecentLocations tests", () => {
-    it("should be able to retrieve multiple saved locations", async () => {
-      const location1 = mockTiFLocation()
-      const location2 = mockTiFLocation()
-      const location3 = mockTiFLocation()
-      await asyncStorageSaveRecentLocation(location1, "attended-event")
-      await asyncStorageSaveRecentLocation(location2, "hosted-event")
+    test("save then load single location from recents", async () => {
+      const location = mockTiFLocation()
+      await storage.save(location, "attended-event")
+      const recents = await storage.recent(10)
+      expect(recents).toEqual([{ location, annotation: "attended-event" }])
+    })
 
-      const results = await asyncStorageLoadSpecificRecentLocations([
-        location1.coordinates,
-        location2.coordinates,
-        location3.coordinates
+    test("save then load single location by its coordinates", async () => {
+      const location = mockTiFLocation()
+      await storage.save(location, "attended-event")
+      const recents = await storage.locationsForCoordinates([
+        location.coordinate
       ])
-      expect(results).toEqual([
-        expect.objectContaining({
-          location: location1,
-          annotation: "attended-event"
-        }),
-        expect.objectContaining({
-          location: location2,
-          annotation: "hosted-event"
-        })
-      ])
+      expect(recents).toEqual([{ location, annotation: "attended-event" }])
     })
 
-    it("filters invalidly persisted locations", async () => {
-      await AsyncStorage.setItem(TEST_COORDINATES_STORAGE_KEY, "sdkjcudsb")
-      expect(
-        await asyncStorageLoadSpecificRecentLocations([TEST_COORDINATES])
-      ).toHaveLength(0)
-    })
-  })
-
-  describe("AsyncStorageLoadRecentLocations tests", () => {
-    it("should load recent locations ordered by most recently saved", async () => {
-      const location1 = mockTiFLocation()
+    test("loads multiple recent locations ordered by most recently saved", async () => {
+      const location1 = { ...mockTiFLocation(), placemark: { name: "hello" } }
       const location2 = mockTiFLocation()
       const location3 = mockTiFLocation()
 
-      await asyncStorageSaveRecentLocation(location1)
-      await asyncStorageSaveRecentLocation(location2, "hosted-event")
-      await asyncStorageSaveRecentLocation(location3, "attended-event")
-      await asyncStorageSaveRecentLocation(location1)
+      await storage.save(location1)
+      await sleep(10)
+      await storage.save(location2, "hosted-event")
+      await sleep(10)
+      await storage.save(location3, "attended-event")
+      await sleep(10)
+      await storage.save(location1)
 
-      const results = await asyncStorageLoadRecentLocations(2)
+      const results = await storage.recent(2)
       expect(results).toEqual([
         {
           location: location1,
@@ -85,15 +64,29 @@ describe("RecentLocationStorage tests", () => {
       ])
     })
 
-    it("is empty when no recent locations", async () => {
-      expect(await asyncStorageLoadRecentLocations(100)).toHaveLength(0)
-    })
+    test("loading multiple recent locations by their coordinates", async () => {
+      const location1 = mockTiFLocation()
+      const location2 = mockTiFLocation()
+      const location3 = mockTiFLocation()
+      await storage.save(location1, "attended-event")
+      await sleep(10)
+      await storage.save(location2, "hosted-event")
 
-    it("filters invalidly persisted locations", async () => {
-      // NB: Ensure this location appears in the keylist.
-      await asyncStorageSaveRecentLocation(mockTiFLocation(TEST_COORDINATES))
-      await AsyncStorage.setItem(TEST_COORDINATES_STORAGE_KEY, "sdkjcudsb")
-      expect(await asyncStorageLoadRecentLocations(10)).toHaveLength(0)
+      const results = await storage.locationsForCoordinates([
+        location1.coordinate,
+        location2.coordinate,
+        location3.coordinate
+      ])
+      expect(results).toEqual([
+        expect.objectContaining({
+          location: location2,
+          annotation: "hosted-event"
+        }),
+        expect.objectContaining({
+          location: location1,
+          annotation: "attended-event"
+        })
+      ])
     })
   })
 })

--- a/location/search/RecentsStorage.ts
+++ b/location/search/RecentsStorage.ts
@@ -61,7 +61,7 @@ export class SQLiteRecentLocationsStorage implements RecentLocationsStorage {
       const results = await db.queryAll<SQLiteLocationPlacemark>`
       SELECT * FROM LocationPlacemarks
       WHERE ${stringifiedCoordinates} 
-        LIKE '%' || cast(latitude AS TEXT) || ',' || cast(longitude as TEXT) || '%'
+        LIKE '%' || latitude || ',' || longitude || '%'
       ORDER BY recentUpdatedAt DESC
       `
       return results.map(recentLocationFromSQLite)

--- a/location/search/RecentsStorage.ts
+++ b/location/search/RecentsStorage.ts
@@ -1,13 +1,141 @@
-import { ArrayUtils } from "@lib/utils/Array"
-import { AsyncStorageUtils } from "@lib/utils/AsyncStorage"
-import AsyncStorage from "@react-native-async-storage/async-storage"
 import { z } from "zod"
-import {
-  LocationCoordinate2D,
-  TiFLocation,
-  TiFLocationSchema,
-  hashLocationCoordinate
-} from "@shared-models/Location"
+import { LocationCoordinate2D, TiFLocation } from "@shared-models/Location"
+import { TiFSQLite } from "@lib/SQLite"
+import { Placemark } from "@shared-models/Placemark"
+import { DeepNullable } from "@lib/utils/DeepNullable"
+
+/**
+ * An interface for storing locations that the user has interacted with
+ * previously.
+ */
+export interface RecentLocationsStorage {
+  /**
+   * Loads the `amount` most recent locations ordered by the time each location
+   * was last saved.
+   */
+  recent(amount: number): Promise<RecentLocation[]>
+
+  /**
+   * Loads recent locations which contain matching coordinates as any of the
+   * coordinates in the given array.
+   */
+  locationsForCoordinates(
+    coordinates: LocationCoordinate2D[]
+  ): Promise<RecentLocation[]>
+
+  /**
+   * Saves a location to the recents storage with the given annotation.
+   */
+  save(
+    location: TiFLocation,
+    annotation?: RecentLocationAnnotation
+  ): Promise<void>
+}
+
+/**
+ * {@link RecentLocationsStorage} implemented with SQLite.
+ */
+export class SQLiteRecentLocationsStorage implements RecentLocationsStorage {
+  private readonly sqlite: TiFSQLite
+
+  constructor(sqlite: TiFSQLite) {
+    this.sqlite = sqlite
+  }
+
+  async recent(amount: number) {
+    return await this.sqlite.withTransaction(async (db) => {
+      const results = await db.queryAll<SQLiteLocationPlacemark>`
+      SELECT * FROM LocationPlacemarks
+      ORDER BY recentUpdatedAt DESC
+      LIMIT ${amount}
+      `
+      return results.map(recentLocationFromSQLite)
+    })
+  }
+
+  async locationsForCoordinates(coordinates: LocationCoordinate2D[]) {
+    const stringifiedCoordinates = coordinates
+      .map((coordinate) => `${coordinate.latitude},${coordinate.longitude}`)
+      .join(",")
+    return await this.sqlite.withTransaction(async (db) => {
+      const results = await db.queryAll<SQLiteLocationPlacemark>`
+      SELECT * FROM LocationPlacemarks
+      WHERE ${stringifiedCoordinates} 
+        LIKE '%' || cast(latitude AS TEXT) || ',' || cast(longitude as TEXT) || '%'
+      ORDER BY recentUpdatedAt DESC
+      `
+      return results.map(recentLocationFromSQLite)
+    })
+  }
+
+  async save(location: TiFLocation, annotation?: RecentLocationAnnotation) {
+    await this.sqlite.withTransaction(async (db) => {
+      await db.run`
+      INSERT INTO LocationPlacemarks (
+        latitude,
+        longitude,
+        name,
+        country,
+        postalCode,
+        street,
+        streetNumber,
+        region,
+        isoCountryCode,
+        city,
+        recentAnnotation
+      ) VALUES (
+        ${location.coordinate.latitude},
+        ${location.coordinate.longitude},
+        ${location.placemark.name},
+        ${location.placemark.country},
+        ${location.placemark.postalCode},
+        ${location.placemark.street},
+        ${location.placemark.streetNumber},
+        ${location.placemark.region},
+        ${location.placemark.isoCountryCode},
+        ${location.placemark.city},
+        ${annotation}
+      ) 
+      ON CONFLICT(latitude, longitude)
+      DO UPDATE SET
+        name = ${location.placemark.name},
+        country = ${location.placemark.country},
+        postalCode = ${location.placemark.postalCode},
+        street = ${location.placemark.street},
+        streetNumber = ${location.placemark.streetNumber},
+        isoCountryCode = ${location.placemark.isoCountryCode},
+        city = ${location.placemark.city},
+        recentAnnotation = ${annotation},
+        recentUpdatedAt = unixepoch('now', 'subsec')
+      `
+    })
+  }
+}
+
+type SQLiteLocationPlacemark = LocationCoordinate2D &
+  DeepNullable<Placemark> & {
+    recentAnnotation: RecentLocationAnnotation | null
+  }
+
+const recentLocationFromSQLite = (location: SQLiteLocationPlacemark) => ({
+  location: {
+    coordinate: {
+      latitude: location.latitude,
+      longitude: location.longitude
+    },
+    placemark: {
+      name: location.name ?? undefined,
+      country: location.country ?? undefined,
+      postalCode: location.postalCode ?? undefined,
+      street: location.street ?? undefined,
+      streetNumber: location.streetNumber ?? undefined,
+      region: location.region ?? undefined,
+      isoCountryCode: location.isoCountryCode ?? undefined,
+      city: location.city ?? undefined
+    }
+  },
+  annotation: location.recentAnnotation ?? undefined
+})
 
 /**
  * A zod schema for {@link RecentLocationAnnotationSchema}.
@@ -30,90 +158,12 @@ export const RecentLocationAnnotationSchema = z.enum([
  * - `"hosted-event"`
  *    - Use this when the user creates an event
  */
-export type RecentLocationAnnotation = z.infer<
-  typeof RecentLocationAnnotationSchema
->
-
-/**
- * A zod schema for {@link RecentLocation}.
- */
-export const RecentLocationSchema = z.object({
-  location: TiFLocationSchema,
-  annotation: RecentLocationAnnotationSchema.optional()
-})
+export type RecentLocationAnnotation = "attended-event" | "hosted-event"
 
 /**
  * A type that contains recency data around a particular location.
  */
-export type RecentLocation = z.infer<typeof RecentLocationSchema>
-
-/**
- * Loads the specified amount of recent locations ordered by recency date descending.
- */
-export const asyncStorageLoadRecentLocations = async (amount: number) => {
-  const keylist = await loadRecentLocationsKeylist()
-  return await recentLocationsWithKeys(keylist.slice(0, amount))
-}
-
-/**
- * Loads specific recent locations from async storage based on the given coordinates.
- */
-export const asyncStorageLoadSpecificRecentLocations = async (
-  coordinates: LocationCoordinate2D[]
-) => {
-  return await recentLocationsWithKeys(
-    coordinates.map(recentLocationAsyncStorageKey)
-  )
-}
-
-const recentLocationsWithKeys = async (keys: string[]) => {
-  return await AsyncStorageUtils.parseJSONItems(
-    RecentLocationSchema,
-    keys
-  ).then((results) => {
-    return ArrayUtils.removeOptionals(results.map(([_, value]) => value))
-  })
-}
-
-/**
- * Saves a location to async storage with the given reason.
- */
-export const asyncStorageSaveRecentLocation = async (
-  location: TiFLocation,
+export type RecentLocation = {
+  location: TiFLocation
   annotation?: RecentLocationAnnotation
-) => {
-  const key = recentLocationAsyncStorageKey(location.coordinates)
-  const keylist = await loadRecentLocationsKeylist().then((keylist) =>
-    keylist.filter((keylistKey) => keylistKey !== key)
-  )
-
-  // NB: Time only moves forward, so we can keep the list sorted by simply just
-  // inserting at the start.
-  keylist.unshift(key)
-
-  await AsyncStorage.multiSet([
-    [RECENT_LOCATIONS_KEYLIST_KEY, JSON.stringify(keylist)],
-    [
-      key,
-      JSON.stringify({
-        location,
-        annotation
-      })
-    ]
-  ])
-}
-
-const RECENT_LOCATIONS_KEYLIST_KEY = "@recent_locations_keys"
-
-const RecentLocationsKeylistSchema = z.array(z.string())
-
-const loadRecentLocationsKeylist = async () => {
-  return await AsyncStorageUtils.parseJSONItem(
-    RecentLocationsKeylistSchema,
-    RECENT_LOCATIONS_KEYLIST_KEY
-  ).then((result) => result ?? [])
-}
-
-const recentLocationAsyncStorageKey = (coordinate: LocationCoordinate2D) => {
-  return `@location_${hashLocationCoordinate(coordinate)}`
 }

--- a/location/search/RecentsStorage.ts
+++ b/location/search/RecentsStorage.ts
@@ -113,7 +113,7 @@ export class SQLiteRecentLocationsStorage implements RecentLocationsStorage {
 }
 
 type SQLiteLocationPlacemark = LocationCoordinate2D &
-  DeepNullable<Placemark> & {
+  DeepNullable<Required<Placemark>> & {
     recentAnnotation: RecentLocationAnnotation | null
   }
 

--- a/location/search/RecentsStorage.ts
+++ b/location/search/RecentsStorage.ts
@@ -56,12 +56,12 @@ export class SQLiteRecentLocationsStorage implements RecentLocationsStorage {
   async locationsForCoordinates(coordinates: LocationCoordinate2D[]) {
     const stringifiedCoordinates = coordinates
       .map((coordinate) => `${coordinate.latitude},${coordinate.longitude}`)
-      .join(",")
+      .join("|")
     return await this.sqlite.withTransaction(async (db) => {
       const results = await db.queryAll<SQLiteLocationPlacemark>`
       SELECT * FROM LocationPlacemarks
-      WHERE ${stringifiedCoordinates} 
-        LIKE '%' || latitude || ',' || longitude || '%'
+      WHERE '|' || ${stringifiedCoordinates} || '|'
+        LIKE '%|' || latitude || ',' || longitude || '|%'
       ORDER BY recentUpdatedAt DESC
       `
       return results.map(recentLocationFromSQLite)
@@ -95,7 +95,7 @@ export class SQLiteRecentLocationsStorage implements RecentLocationsStorage {
         ${location.placemark.isoCountryCode},
         ${location.placemark.city},
         ${annotation}
-      ) 
+      )
       ON CONFLICT(latitude, longitude)
       DO UPDATE SET
         name = ${location.placemark.name},

--- a/location/search/SearchResultsList.tsx
+++ b/location/search/SearchResultsList.tsx
@@ -69,7 +69,7 @@ export const LocationSearchResultsListView = ({
           result={item}
           distanceMiles={
             center
-              ? milesBetweenLocations(center, item.location.coordinates)
+              ? milesBetweenLocations(center, item.location.coordinate)
               : undefined
           }
           style={styles.horizontalPadding}
@@ -88,7 +88,7 @@ export const LocationSearchResultsListView = ({
 }
 
 const keyExtractor = (result: LocationSearchResult) => {
-  return hashLocationCoordinate(result.location.coordinates)
+  return hashLocationCoordinate(result.location.coordinate)
 }
 
 type EmptyResultsProps = {

--- a/shared-models/Location.ts
+++ b/shared-models/Location.ts
@@ -38,7 +38,7 @@ export const checkIfCoordsAreEqual = (
  * A zod schema for {@link TiFLocation}.
  */
 export const TiFLocationSchema = z.object({
-  coordinates: LocationCoordinates2DSchema,
+  coordinate: LocationCoordinates2DSchema,
   placemark: PlacemarkSchema
 })
 

--- a/test-helpers/SQLite.ts
+++ b/test-helpers/SQLite.ts
@@ -12,6 +12,7 @@ export const resetTestSQLiteBeforeEach = () => {
   beforeEach(async () => {
     await testSQLite.withTransaction(async (db) => {
       await db.run`DELETE FROM LocationArrivals`
+      await db.run`DELETE FROM LocationPlacemarks`
     })
   })
 }


### PR DESCRIPTION
Migrates the functions to load the user's recent locations from AsyncStorage to SQLite. Since now the functions depend on the `TiFSQLite` class, I decided to make an interface called `RecentLocationsStorage` with an accompanying `SQLiteRecentLocationsStorage` implementation class. Due to the creation of this new interface, I had to modify the functions in `SearchClient.ts` to accept an instance of the interface as a parameter. Additionally, I took this as an opportunity to clean up the tests a little where I fixed a bug that was previously there in the process. The bug simply only counted a location as a recent location if it had an annotation, even though no annotation is required for it to be considered a recent location.

For the recent locations themselves, I simply created a table called `LocationPlacemarks` which is almost a mirror of the backend `location` table, but with 2 additional columns and no `timeZone` column:
- `recentAnnotation` which is an annotation like, "attended event here recently", or "hosted event here recently".
- `recentUpdatedAt` which is an annotation for when the recent locations storage last updated the location.

Querying this table required some nice tricks for the `locationsForCoordinates` (previously `asyncStorageLoadSpecificRecentLocations`) method. From what I can tell, I wasn't able to interpolate an array properly in the query using `expo-sqlite`, so I simply did a pattern match on a long string containing all the coordinates. Additionally, I did have to do some conversions between null and undefined which was a bit annoying. 

Lastly, for testing, I did have to introduce some very short `sleep` calls between saving mock locations. This would ensure that there was significant time between saves since the recent locations are sorted by the `recentUpdatedAt` column.