### PR TITLE
SQLite Migration: Internal Metrics

### DIFF
--- a/event-details/arrival-tracking/Refresh.test.ts
+++ b/event-details/arrival-tracking/Refresh.test.ts
@@ -1,14 +1,11 @@
-import AsyncStorage from "@react-native-async-storage/async-storage"
 import { fakeTimers } from "@test-helpers/Timers"
-import { EventArrivalsLastRefreshDate, EventArrivalsRefresher } from "./Refresh"
+import { EventArrivalsRefresher } from "./Refresh"
+import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
+import { SQLiteInternalMetrics } from "@lib/InternalMetrics"
 
 describe("EventArrivalsRefresher tests", () => {
-  let lastRefreshDate = new EventArrivalsLastRefreshDate()
+  resetTestSQLiteBeforeEach()
   fakeTimers()
-  beforeEach(async () => {
-    lastRefreshDate = new EventArrivalsLastRefreshDate()
-    await AsyncStorage.clear()
-  })
 
   const performRefresh = jest.fn()
   beforeEach(() => performRefresh.mockReset())
@@ -87,7 +84,7 @@ describe("EventArrivalsRefresher tests", () => {
   const createRefresher = (minutesBetweenNeededRefreshes: number) => {
     return new EventArrivalsRefresher(
       performRefresh,
-      lastRefreshDate,
+      new SQLiteInternalMetrics(testSQLite),
       minutesBetweenNeededRefreshes
     )
   }

--- a/event-details/arrival-tracking/UpcomingArrivals.ts
+++ b/event-details/arrival-tracking/UpcomingArrivals.ts
@@ -88,7 +88,7 @@ export class SQLiteUpcomingEventArrivals implements UpcomingEventArrivals {
             ${region.coordinate.latitude},
             ${region.coordinate.longitude},
             ${region.arrivalRadiusMeters},
-            ${region.isArrived ? 1 : 0}
+            ${region.isArrived}
           )
           `
           await Promise.all(

--- a/lib/InternalMetrics.test.ts
+++ b/lib/InternalMetrics.test.ts
@@ -1,0 +1,72 @@
+import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
+import {
+  DEFAULT_INTERNAL_METRICS_VALUES,
+  SQLiteInternalMetrics
+} from "./InternalMetrics"
+
+describe("InternalMetrics tests", () => {
+  describe("SQLiteInternalMetrics tests", () => {
+    resetTestSQLiteBeforeEach()
+    const internalMetrics = new SQLiteInternalMetrics(testSQLite)
+
+    it("should return the default values when no values are saved", async () => {
+      const values = await internalMetrics.current()
+      expect(values).toEqual(DEFAULT_INTERNAL_METRICS_VALUES)
+    })
+
+    test("save once, then load, returns updated values", async () => {
+      await internalMetrics.update({
+        hasCompletedOnboarding: true,
+        lastEventArrivalsRefreshDate: new Date(1000)
+      })
+      const values = await internalMetrics.current()
+      expect(values).toEqual({
+        ...DEFAULT_INTERNAL_METRICS_VALUES,
+        hasCompletedOnboarding: true,
+        lastEventArrivalsRefreshDate: new Date(1000)
+      })
+    })
+
+    test("save value as undefined, then load, ignored in updated values", async () => {
+      await internalMetrics.update({
+        hasCompletedOnboarding: true,
+        lastEventArrivalsRefreshDate: undefined
+      })
+      const values = await internalMetrics.current()
+      expect(values).toEqual({
+        ...DEFAULT_INTERNAL_METRICS_VALUES,
+        hasCompletedOnboarding: true
+      })
+    })
+
+    test("save twice, then load, returns updated values", async () => {
+      await internalMetrics.update({
+        hasCompletedOnboarding: true
+      })
+      await internalMetrics.update({
+        lastEventArrivalsRefreshDate: new Date(1000)
+      })
+      const values = await internalMetrics.current()
+      expect(values).toEqual({
+        ...DEFAULT_INTERNAL_METRICS_VALUES,
+        hasCompletedOnboarding: true,
+        lastEventArrivalsRefreshDate: new Date(1000)
+      })
+    })
+
+    test("save twice, only creates 1 row in the InternalMetrics table", async () => {
+      await internalMetrics.update({
+        hasCompletedOnboarding: true
+      })
+      await internalMetrics.update({
+        lastEventArrivalsRefreshDate: new Date(1000)
+      })
+      const count = (await testSQLite.withTransaction(async (db) => {
+        return await db.queryFirst<{
+          c: number
+        }>`SELECT COUNT(*) as c FROM InternalMetrics`
+      }))!.c
+      expect(count).toEqual(1)
+    })
+  })
+})

--- a/lib/InternalMetrics.ts
+++ b/lib/InternalMetrics.ts
@@ -1,0 +1,98 @@
+import { SQLExecutable, TiFSQLite } from "./SQLite"
+import { ObjectUtils } from "./utils/Object"
+
+/**
+ * A type for modeling simple configuration values that the app needs to keep
+ * track of over time, are not directly shown/are directly configurable by the
+ * user in the through any direct means, but do effect the user experience.
+ *
+ * For example, when `hasCompletedOnboarding` is false, then we need to
+ * display the onboarding experience, and afterwards we set it to true.
+ * However, the user doesn't do this directly through a settings page, instead
+ * we do it indirectly after they have completed onboarding.
+ */
+export type InternalMetrics = {
+  hasCompletedOnboarding: boolean
+  lastEventArrivalsRefreshDate: Date | null
+}
+
+export const DEFAULT_INTERNAL_METRICS_VALUES = {
+  hasCompletedOnboarding: false,
+  lastEventArrivalsRefreshDate: null
+} as Readonly<InternalMetrics>
+
+/**
+ * An interface for storing the current {@link InternalMetrics}.
+ */
+export interface InternalMetricsStorage {
+  /**
+   * Returns the current {@link InternalMetrics} or
+   * {@link DEFAULT_INTERNAL_METRICS_VALUES} if none exist.
+   */
+  current(): Promise<InternalMetrics>
+
+  /**
+   * Updates the current {@link InternalMetrics} based on the partial
+   * `values` given.
+   *
+   * @param values A partial object of values to update.
+   */
+  update(values: Partial<InternalMetrics>): Promise<void>
+}
+
+type SQLiteInternalMetricsValues = {
+  hasCompletedOnboarding: number
+  lastEventArrivalsRefreshTime: number | null
+}
+
+/**
+ * {@link InternalMetricsStorage} implementation using SQLite.
+ */
+export class SQLiteInternalMetrics implements InternalMetricsStorage {
+  private readonly sqlite: TiFSQLite
+
+  constructor(sqlite: TiFSQLite) {
+    this.sqlite = sqlite
+  }
+
+  async current() {
+    return await this.sqlite.withTransaction(this.currentValues)
+  }
+
+  async update(values: Partial<InternalMetrics>) {
+    await this.sqlite.withTransaction(async (db) => {
+      const valuesToSave = {
+        ...(await this.currentValues(db)),
+        ...ObjectUtils.removeUndefined(values)
+      }
+      await db.run`
+      INSERT INTO InternalMetrics (
+        id,
+        hasCompletedOnboarding,
+        lastEventArrivalsRefreshTime
+      ) VALUES (
+        1,
+        ${valuesToSave.hasCompletedOnboarding},
+        ${valuesToSave.lastEventArrivalsRefreshDate?.getTime()}
+      )
+      ON CONFLICT(id)
+      DO UPDATE SET
+      hasCompletedOnboarding = ${valuesToSave.hasCompletedOnboarding},
+        lastEventArrivalsRefreshTime = ${valuesToSave.lastEventArrivalsRefreshDate?.getTime()}
+      `
+    })
+  }
+
+  private async currentValues(db: SQLExecutable) {
+    const dbValues = await db.queryFirst<SQLiteInternalMetricsValues>`
+      SELECT * FROM InternalMetrics LIMIT 1
+      `
+    if (!dbValues) return { ...DEFAULT_INTERNAL_METRICS_VALUES }
+    return {
+      hasCompletedOnboarding: dbValues.hasCompletedOnboarding === 1,
+      lastEventArrivalsRefreshDate: dbValues.lastEventArrivalsRefreshTime
+        ? new Date(dbValues.lastEventArrivalsRefreshTime)
+        : null
+    }
+  }
+}

--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -112,6 +112,13 @@ export class TiFSQLite {
         stringifiedMetadata TEXT,
         timestamp DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec'))
       )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS InternalMetrics (
+        id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,
+        hasCompletedOnboarding INT2 NOT NULL,
+        lastEventArrivalsRefreshTime DOUBLE
+      )
       `
     ])
     return db
@@ -174,7 +181,12 @@ class ExpoSQLExecutable {
   ) {
     return {
       query: statements.join("?"),
-      values: args.map((arg) => (arg === undefined ? null : arg))
+      values: args.map((arg) => {
+        if (typeof arg === "boolean") {
+          return arg ? 1 : 0
+        }
+        return arg === undefined ? null : arg
+      })
     }
   }
 }

--- a/lib/utils/Object.ts
+++ b/lib/utils/Object.ts
@@ -1,0 +1,9 @@
+export namespace ObjectUtils {
+  export const removeUndefined = <Obj extends { [key: string]: any }>(
+    obj: Obj
+  ) => {
+    return Object.fromEntries(
+      Object.entries(obj).filter(([_, v]) => v !== undefined)
+    ) as Obj
+  }
+}

--- a/test-helpers/SQLite.ts
+++ b/test-helpers/SQLite.ts
@@ -14,6 +14,7 @@ export const resetTestSQLiteBeforeEach = () => {
       await db.run`DELETE FROM LocationArrivals`
       await db.run`DELETE FROM LocationPlacemarks`
       await db.run`DELETE FROM Logs`
+      await db.run`DELETE FROM InternalMetrics`
     })
   })
 }


### PR DESCRIPTION
Introduces the concept of _Internal Metrics_, and replaces the implementation of `EventArrivalsRefresher` with this concept.

We'll define _Internal Metrics_ as a term for simple configuration values, or other simple properties, that the app adjusts over time to affect the user experience, but are not directly configurable or viewable by the end user. A good example of this is `hasCompletedOnboarding`, which is a simple boolean for whether or not the user has completed the planned onboarding experience. This value is not configured by the user directly, but rather indirectly when they complete onboarding.

To implement this, I naturally turned to SQLite again and used a [single-row table](https://swiftpackageindex.com/groue/grdb.swift/v6.24.2/documentation/grdb/singlerowtables) using the `InternalMetricsStorage` interface with an `SQLiteInternalMetricsStorage` implementation. `InternalMetricsStorage` simply has 2 methods, one to get the current set of metrics, and the other to update the metrics with a partial object. For the second method, the implementation merges the partial values with the current values when performing the update.

I also made the date previously stored by `EventArrivalsLastRefreshTime` a value on the `InternalMetrics` type which allowed me to get rid of the class, and reimplement `EventArrivalsRefresher` using the `InternalMetricsStorage` interface.