### PR TITLE
Allow dashed object keys

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,11 @@
         ],
         "format": ["PascalCase", "camelCase"]
       },
+      {
+        "selector": "objectLiteralProperty",
+        "format": null,
+        "modifiers": ["requiresQuotes"]
+      },
       { "selector": "typeLike", "format": ["PascalCase"] },
       { "selector": "typeParameter", "format": ["PascalCase"] },
 


### PR DESCRIPTION
Allow dashed object keys to use for union types

![image](https://github.com/tifapp/FitnessProject/assets/43940015/70ec4c83-0088-4b85-9ecb-9b51293cab56)
