### PR TITLE
Event Details: Replace Edit Menu Action with Block Toggling

### DIFF
--- a/.storybook/components/EventDetails/EventDetails.stories.tsx
+++ b/.storybook/components/EventDetails/EventDetails.stories.tsx
@@ -17,7 +17,6 @@ import {
 import { mockPlacemark } from "@location/MockData"
 import { EventCountdownView, eventCountdown } from "@event-details/Countdown"
 import { dateRange, dayjs, now } from "@date-time"
-import { View } from "react-native"
 import { JoinEventStagesView } from "@event-details/JoinEvent"
 import { NavigationContainer, useFocusEffect } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
@@ -30,6 +29,8 @@ import { createTestQueryClient } from "@test-helpers/ReactQuery"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { EventDetailsMenuView } from "@event-details/Menu"
 import { View } from "react-native"
+import { NonCompliantChecksCount } from "aws-sdk/clients/iot"
+import { CurrentUserEvent } from "@shared-models/Event"
 
 const EventDetailsMeta: ComponentMeta<typeof SettingsScreen> = {
   title: "Event Details"
@@ -99,20 +100,25 @@ const Test = () => {
       }}
     >
       <EventDetailsMenuView
-        event={{
-          title: "Test Event",
-          userAttendeeStatus: "hosting",
-          host
-        }}
+        event={
+          {
+            title: "Test Event",
+            userAttendeeStatus: "attending",
+            host: {
+              ...host,
+              relations: { youToThem: "not-friends", themToYou: "not-friends" }
+            }
+          } as CurrentUserEvent
+        }
         eventShareContent={async () => ({
           title: "Test",
           url: "https://www.google.com",
           message: "Hello There"
         })}
+        onBlockHostToggled={() => console.log("Block Toggled")}
         onCopyEventTapped={() => console.log("Copy")}
         onInviteFriendsTapped={() => console.log("Invite")}
         onContactHostTapped={() => console.log("Contact Host")}
-        onEditEventTapped={() => console.log("Edit")}
         onReportEventTapped={() => console.log("Report")}
         onAssignNewHostTapped={() => console.log("Assign Host")}
       />

--- a/.storybook/components/EventDetails/EventDetails.stories.tsx
+++ b/.storybook/components/EventDetails/EventDetails.stories.tsx
@@ -29,7 +29,6 @@ import { createTestQueryClient } from "@test-helpers/ReactQuery"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { EventDetailsMenuView } from "@event-details/Menu"
 import { View } from "react-native"
-import { NonCompliantChecksCount } from "aws-sdk/clients/iot"
 import { CurrentUserEvent } from "@shared-models/Event"
 
 const EventDetailsMeta: ComponentMeta<typeof SettingsScreen> = {

--- a/event-details/Menu.test.ts
+++ b/event-details/Menu.test.ts
@@ -1,6 +1,7 @@
 import { setPlatform } from "@test-helpers/Platform"
 import { EVENT_MENU_ACTION, formatEventMenuActions } from "./Menu"
 import { EventAttendeeMocks } from "./MockData"
+import { CurrentUserEvent } from "@shared-models/Event"
 
 describe("EventDetailsMenu tests", () => {
   describe("FormatEventMenuActions tests", () => {
@@ -8,7 +9,7 @@ describe("EventDetailsMenu tests", () => {
 
     it("should format the contact-host action with the host's name", () => {
       const actions = formatEventMenuActions(
-        { host: EventAttendeeMocks.Alivs },
+        { host: EventAttendeeMocks.Alivs } as CurrentUserEvent,
         [EVENT_MENU_ACTION.copyEvent, EVENT_MENU_ACTION.contactHost]
       )
       expect(actions).toEqual([
@@ -17,14 +18,47 @@ describe("EventDetailsMenu tests", () => {
       ])
     })
 
-    it("should reverse the actions if the platform is android", () => {
-      setPlatform("android")
+    it("should format the toggle-block-host with 'Block Hostname' when user is not blocking host", () => {
       const actions = formatEventMenuActions(
-        { host: EventAttendeeMocks.Alivs },
-        [EVENT_MENU_ACTION.copyEvent, EVENT_MENU_ACTION.editEvent]
+        { host: EventAttendeeMocks.Alivs } as CurrentUserEvent,
+        [EVENT_MENU_ACTION.toggleBlockHost]
       )
       expect(actions).toEqual([
-        EVENT_MENU_ACTION.editEvent,
+        {
+          ...EVENT_MENU_ACTION.toggleBlockHost,
+          title: "Block Alvis",
+          image: "person.slash.fill"
+        }
+      ])
+    })
+
+    it("should format the toggle-block-host with 'Unblock Hostname' when user is blocking host", () => {
+      const actions = formatEventMenuActions(
+        {
+          host: {
+            ...EventAttendeeMocks.Alivs,
+            relations: { themToYou: "not-friends", youToThem: "blocked" }
+          }
+        } as CurrentUserEvent,
+        [EVENT_MENU_ACTION.toggleBlockHost]
+      )
+      expect(actions).toEqual([
+        {
+          ...EVENT_MENU_ACTION.toggleBlockHost,
+          title: "Unblock Alvis",
+          image: "person.fill.checkmark"
+        }
+      ])
+    })
+
+    it("should reverse the actions if the platform is android", () => {
+      setPlatform("android")
+      const actions = formatEventMenuActions({} as CurrentUserEvent, [
+        EVENT_MENU_ACTION.copyEvent,
+        EVENT_MENU_ACTION.shareEvent
+      ])
+      expect(actions).toEqual([
+        EVENT_MENU_ACTION.shareEvent,
         EVENT_MENU_ACTION.copyEvent
       ])
     })


### PR DESCRIPTION
Replaces the "Edit Event" menu action with a new action to block/unblock the host since we display the edit event action next to the host row on the details screen.

I made some changes to the `EVENT_MENU_ACTIONS` config object which allow the title and image to be computed from a function so that creating dynamic content was easier.