### PR TITLE
Shared Query Keys Folder

### DIFF
--- a/event-details/Details.tsx
+++ b/event-details/Details.tsx
@@ -2,6 +2,7 @@ import { UseQueryResult, useQuery } from "@tanstack/react-query"
 import {
   BlockedEvent,
   CurrentUserEvent,
+  EventID,
   currentUserEventFromResponse
 } from "@shared-models/Event"
 import { useIsConnectedToInternet } from "@lib/InternetConnection"
@@ -17,14 +18,7 @@ import Animated, { ZoomIn, ZoomOut } from "react-native-reanimated"
 import { TiFDefaultLayoutTransition } from "@lib/Reanimated"
 import { AppStyles } from "@lib/AppColorStyle"
 import { useAutocorrectingInterval } from "@lib/utils/UseInterval"
-
-/**
- * A result from loading a single event for the details screen.
- */
-export type EventDetailsLoadingResult =
-  | { status: "not-found" | "cancelled" }
-  | { status: "blocked"; event: BlockedEvent }
-  | { status: "success"; event: CurrentUserEvent }
+import { EventDetailsLoadingResult, useEventDetailsQuery } from "./Query"
 
 /**
  * Loads the event details from the server.
@@ -66,13 +60,10 @@ export type UseLoadEventDetailsResult =
  * A hook to load an event in the context of the details screen.
  */
 export const useLoadEventDetails = (
-  eventId: number,
-  loadEvent: (id: number) => Promise<EventDetailsLoadingResult>
+  eventId: EventID,
+  loadEvent: (id: EventID) => Promise<EventDetailsLoadingResult>
 ): UseLoadEventDetailsResult => {
-  const query = useQuery(
-    ["event", eventId],
-    async () => await loadEvent(eventId)
-  )
+  const query = useEventDetailsQuery(eventId, loadEvent)
   return loadEventDetailsResult(query, useIsConnectedToInternet())
 }
 

--- a/event-details/Query.ts
+++ b/event-details/Query.ts
@@ -1,0 +1,18 @@
+import { BlockedEvent, CurrentUserEvent, EventID } from "@shared-models/Event"
+import { eventDetailsQueryKey } from "@shared-models/query-keys/Event"
+import { useQuery } from "@tanstack/react-query"
+
+/**
+ * A result from loading a single event for the details screen.
+ */
+export type EventDetailsLoadingResult =
+  | { status: "not-found" | "cancelled" }
+  | { status: "blocked"; event: BlockedEvent }
+  | { status: "success"; event: CurrentUserEvent }
+
+export const useEventDetailsQuery = (
+  id: EventID,
+  loadEvent: (id: EventID) => Promise<EventDetailsLoadingResult>
+) => {
+  return useQuery(eventDetailsQueryKey(id), async () => await loadEvent(id))
+}

--- a/screens/ExploreEvents/useExploreEvents.ts
+++ b/screens/ExploreEvents/useExploreEvents.ts
@@ -16,6 +16,7 @@ import {
 import { Region } from "@location/index"
 import { QueryHookOptions } from "@lib/ReactQuery"
 import { LocationAccuracy, PermissionResponse } from "expo-location"
+import { eventDetailsQueryKey } from "@shared-models/query-keys/Event"
 
 export type UseExploreEventsEnvironment = {
   fetchEvents: (region: Region) => Cancellable<CurrentUserEvent[]>
@@ -91,9 +92,9 @@ const useUserRegion = (
   return !coords
     ? undefined
     : createDefaultMapRegion({
-      latitude: coords.latitude,
-      longitude: coords.longitude
-    })
+        latitude: coords.latitude,
+        longitude: coords.longitude
+      })
 }
 
 const useExploreEventsQuery = (
@@ -110,7 +111,7 @@ const useExploreEventsQuery = (
         const events = await cancelOnAborted(fetchEvents(region), signal).value
 
         events.forEach((event) => {
-          queryClient.setQueryData(["event", event.id], event)
+          queryClient.setQueryData(eventDetailsQueryKey(event.id), event)
         })
 
         return events

--- a/shared-models/Event.ts
+++ b/shared-models/Event.ts
@@ -10,6 +10,8 @@ import {
   UnblockedBidirectionalUserRelationsSchema
 } from "./User"
 
+export type EventID = number
+
 /**
  * A zod schema for {@link EventRegion}.
  */

--- a/shared-models/User.ts
+++ b/shared-models/User.ts
@@ -1,5 +1,7 @@
 import { z } from "zod"
 
+export type UserID = string
+
 export const NotFriendsStatusSchema = z.literal("not-friends")
 export const FriendRequestPendingStatusSchema = z.literal(
   "friend-request-pending"

--- a/shared-models/query-keys/Event.ts
+++ b/shared-models/query-keys/Event.ts
@@ -1,0 +1,5 @@
+import { EventID } from "@shared-models/Event"
+
+export const eventDetailsQueryKey = (eventId: EventID) => {
+  return ["event", eventId] as const
+}

--- a/tests/events/ExploreEvents.test.tsx
+++ b/tests/events/ExploreEvents.test.tsx
@@ -12,6 +12,7 @@ import {
   createInitialCenter,
   useExploreEvents
 } from "@screens/ExploreEvents"
+import { eventDetailsQueryKey } from "@shared-models/query-keys/Event"
 import { endlessCancellable, nonCancellable } from "@test-helpers/Cancellable"
 import {
   TestQueryClientProvider,
@@ -243,13 +244,13 @@ describe("ExploreEvents tests", () => {
       })
 
       await waitFor(() => {
-        expect(queryClient.getQueryData(["event", events[0].id])).toMatchObject(
-          events[0]
-        )
+        expect(
+          queryClient.getQueryData(eventDetailsQueryKey(events[0].id))
+        ).toMatchObject(events[0])
       })
-      expect(queryClient.getQueryData(["event", events[1].id])).toMatchObject(
-        events[1]
-      )
+      expect(
+        queryClient.getQueryData(eventDetailsQueryKey(events[1].id))
+      ).toMatchObject(events[1])
     })
 
     const advanceThroughRegionUpdateDebounce = () => {


### PR DESCRIPTION
Some of the query keys will need to be shared, so I made a `query-keys` folder inside `shared-models`. This doesn't cover `useQuery` instances that are shared atm, as we don't have any instances of that as of now.