### PR TITLE
Event Details: Update Query Client on successful join

### DIFF
--- a/event-details/JoinEvent.test.tsx
+++ b/event-details/JoinEvent.test.tsx
@@ -22,8 +22,11 @@ import { mswServer } from "@test-helpers/msw"
 import { http, HttpResponse } from "msw"
 import { TiFAPI } from "@api-client/TiFAPI"
 import { mockEventRegion } from "./arrival-tracking/MockData"
-import { EventMocks, mockEventChatTokenRequest } from "./MockData"
-import { CurrentUserEvent } from "@shared-models/Event"
+import {
+  EventMocks,
+  mockEventChatTokenRequest,
+  mockEventLocation
+} from "./MockData"
 import { renderSuccessfulUseLoadEventDetails } from "./TestHelpers"
 import { verifyNeverOccurs } from "@test-helpers/ExpectNeverOccurs"
 
@@ -35,19 +38,13 @@ describe("JoinEvent tests", () => {
     const env = {
       joinEvent: jest.fn(),
       monitor: TrueRegionMonitor,
-      onSuccess: jest.fn(),
       loadPermissions: jest.fn()
     }
 
     const TEST_EVENT = {
       ...EventMocks.PickupBasketball,
       id: 1,
-      location: {
-        coordinate: mockLocationCoordinate2D(),
-        arrivalRadiusMeters: 50,
-        isInArrivalTrackingPeriod: true,
-        placemark: null
-      },
+      location: mockEventLocation(),
       userAttendeeStatus: "not-participating"
     } as const
 
@@ -109,10 +106,8 @@ describe("JoinEvent tests", () => {
         })
       })
 
-      expect(env.onSuccess).not.toHaveBeenCalled()
       act(() => (result.current as any).requestButtonTapped())
       await waitFor(() => expect(result.current).toEqual({ stage: "success" }))
-      expect(env.onSuccess).toHaveBeenCalledTimes(1)
     })
 
     test("join event flow, skips false permissions", async () => {
@@ -141,7 +136,6 @@ describe("JoinEvent tests", () => {
       await waitFor(() => {
         expect(result.current).toEqual({ stage: "success" })
       })
-      expect(env.onSuccess).toHaveBeenCalledTimes(1)
     })
 
     test("join event flow, dismiss permissions", async () => {
@@ -163,10 +157,8 @@ describe("JoinEvent tests", () => {
         permissionKind: "backgroundLocation"
       })
 
-      expect(env.onSuccess).not.toHaveBeenCalled()
       act(() => (result.current as any).dismissButtonTapped())
       expect(result.current).toEqual({ stage: "success" })
-      expect(env.onSuccess).toHaveBeenCalledTimes(1)
     })
 
     test("join event flow, error alerts", async () => {

--- a/event-details/JoinEvent.tsx
+++ b/event-details/JoinEvent.tsx
@@ -167,7 +167,6 @@ export type UseJoinEventEnvironment = {
   monitor: EventRegionMonitor
   joinEvent: (request: JoinEventRequest) => Promise<JoinEventResult>
   loadPermissions: () => Promise<JoinEventPermission[]>
-  onSuccess: () => void
 }
 
 export type UseJoinEventPermissionStage = {
@@ -225,10 +224,6 @@ export const useJoinEventStages = (
   const hasJoined =
     joinEventMutation.isSuccess && joinEventMutation.data === "success"
   const isSuccess = hasJoined && currentPermission === "done"
-
-  useEffect(() => {
-    if (isSuccess) onSuccess()
-  }, [isSuccess, onSuccess])
 
   if (hasJoined && typeof currentPermission === "object") {
     return { stage: "permission", ...currentPermission }

--- a/event-details/Menu.test.tsx
+++ b/event-details/Menu.test.tsx
@@ -12,7 +12,10 @@ import {
   TestQueryClientProvider,
   createTestQueryClient
 } from "@test-helpers/ReactQuery"
-import { renderUseLoadEventDetails } from "./TestHelpers"
+import {
+  renderUseLoadEventDetails,
+  renderSuccessfulUseLoadEventDetails
+} from "./TestHelpers"
 import { TestInternetConnectionStatus } from "@test-helpers/InternetConnectionStatus"
 import { CloudDirectory } from "aws-sdk"
 import { Faker } from "@faker-js/faker"
@@ -218,12 +221,7 @@ describe("EventDetailsMenu tests", () => {
     }
 
     const renderUseEventDetails = (event: CurrentUserEvent) => {
-      return renderUseLoadEventDetails(
-        event.id,
-        new TestInternetConnectionStatus(true),
-        async () => ({ status: "success", event }),
-        queryClient
-      )
+      return renderSuccessfulUseLoadEventDetails(event, queryClient)
     }
 
     const renderUseEventDetailsMenuActions = (event: CurrentUserEvent) => {

--- a/event-details/TestHelpers.tsx
+++ b/event-details/TestHelpers.tsx
@@ -5,9 +5,10 @@ import {
 import { TestQueryClientProvider } from "@test-helpers/ReactQuery"
 import { renderHook } from "@testing-library/react-native"
 import { useLoadEventDetails } from "./Details"
-import { EventID } from "@shared-models/Event"
+import { CurrentUserEvent, EventID } from "@shared-models/Event"
 import { EventDetailsLoadingResult } from "./Query"
 import { QueryClient } from "@tanstack/react-query"
+import { TestInternetConnectionStatus } from "@test-helpers/InternetConnectionStatus"
 
 export const renderUseLoadEventDetails = (
   eventId: EventID,
@@ -27,5 +28,17 @@ export const renderUseLoadEventDetails = (
         </InternetConnectionStatusProvider>
       )
     }
+  )
+}
+
+export const renderSuccessfulUseLoadEventDetails = (
+  event: CurrentUserEvent,
+  queryClient: QueryClient
+) => {
+  return renderUseLoadEventDetails(
+    event.id,
+    new TestInternetConnectionStatus(true),
+    async () => ({ status: "success", event }),
+    queryClient
   )
 }


### PR DESCRIPTION
Ensures to update the user attendee status to `"attending"` when joining an event using the same methods as #280. I also removed the `onSuccess` handler since its original intention was to do the query client update.