### PR TITLE
Sqlite: Fallback to in-memory database when opening fails

### DIFF
--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -73,8 +73,7 @@ export class TiFSQLite {
 
   private async runQueueUntilEmpty() {
     while (!this.isQueueEmpty) {
-      const transaction = this.queuedTransactions[0]
-      await transaction()
+      await this.queuedTransactions[0]()
       this.queuedTransactions.shift()
     }
   }

--- a/test-helpers/SQLite.ts
+++ b/test-helpers/SQLite.ts
@@ -1,9 +1,9 @@
-import { TiFSQLite } from "@lib/SQLite"
+import { SQLITE_IN_MEMORY_PATH, TiFSQLite } from "@lib/SQLite"
 
 /**
  * An in memory {@link TiFSQLite} instance for testing.
  */
-export const testSQLite = new TiFSQLite(":memory:")
+export const testSQLite = new TiFSQLite(SQLITE_IN_MEMORY_PATH)
 
 /**
  * Resets the data inside {@link testSQLite}.


### PR DESCRIPTION
Opening a SQLite database can fail for a variety of reasons. Some include:
- Permissions issues
- Lack of disk space
- Path not found
- etc.

In our case, we use SQLite mainly for storing client-side data. Since that data is not necessarily integral to the app it wouldn't make sense to alert the user about any of the above opening failure cases. Therefore, the best approach is to fail silently. For this, I've made it so that if the call to `openDatabaseAsync` fails for any reason, I fallback to calling `openDatabaseAsync` with an _in memory_ path. This way, sqlite operations can proceed somewhat normally without being a deterrence to the user experience.

`TiFSQLite` now accepts a new argument in its constructor which performs the opening logic to which the constructor calls with the provided `path` argument. If opening the `path` argument fails, it recalls the new open argument with `SQLITE_IN_MEMORY_PATH` which should succeed nearly always.

Alongside this, I also made some minor refactorings to the internals of the `TiFSQLite` class.