### PR TITLE
SQLite: Add Warn Log Message on Open Failure

### DIFF
--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -101,6 +101,7 @@ export class TiFSQLite {
         "Failed to open SQLite at the specified path, falling back to an in memory instance.",
         {
           message: e.message,
+          code: e.code,
           path
         }
       )

--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -1,3 +1,4 @@
+import { logger } from "TiFShared/logging"
 import {
   SQLiteDatabase as ExpoSQLiteDatabase,
   SQLiteBindValue,
@@ -5,6 +6,8 @@ import {
 } from "expo-sqlite/next"
 
 export const SQLITE_IN_MEMORY_PATH = ":memory:"
+
+const log = logger("tif.sqlite")
 
 /**
  * A class that manages the SQLite database for the app.
@@ -93,7 +96,14 @@ export class TiFSQLite {
   ) {
     try {
       return await openSQLExecuatble(path)
-    } catch {
+    } catch (e) {
+      log.warn(
+        "Failed to open SQLite at the specified path, falling back to an in memory instance.",
+        {
+          message: e.message,
+          path
+        }
+      )
       return await openSQLExecuatble(SQLITE_IN_MEMORY_PATH)
     }
   }


### PR DESCRIPTION
Adds a `warn` level log message when SQLite fails to open for any reason. I made sure to put the error message, expo error code, and path in the metadata.