### PR TITLE
Automatically link PR to trello when the PR is opened

### DIFF
--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -1,0 +1,62 @@
+name: Attach PR to Trello Ticket
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - development
+
+jobs:
+  link-ticket:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Link PR and Trello Ticket
+      env:
+        TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
+        TRELLO_API_TOKEN: ${{ secrets.TRELLO_API_TOKEN }}
+        USER_GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        TRELLO_CARD_ID=$(echo $PR_TITLE | grep -oEi 'task_[0-9a-zA-Z]+' | cut -d'_' -f2)
+
+        echo "Found Card ID: $TRELLO_CARD_ID"
+
+        if [[ -z "$TRELLO_CARD_ID" ]]; then
+          echo "No card ID found in PR title."
+          exit 0
+        fi
+
+        # Define Card URL
+        TRELLO_CARD_URL="https://trello.com/c/$TRELLO_CARD_ID"
+
+        # URL of the Pull Request
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_NAME="Pull Request #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+
+        # Attach PR to Trello Card
+        TRELLO_RESPONSE=$(curl -s -o response.json -w "%{http_code}" -X POST "https://api.trello.com/1/cards/$TRELLO_CARD_ID/attachments" \
+        -d "key=${TRELLO_API_KEY}" \
+        -d "token=${TRELLO_API_TOKEN}" \
+        -d "url=${PR_URL}" \
+        -d "name=${PR_NAME}")
+        echo "Trello API Response Code: $TRELLO_RESPONSE"
+        echo "Trello API Response Body:"
+        cat response.json
+
+        if [[ "$TRELLO_RESPONSE" -ne 200 ]]; then
+          echo "Failed to attach PR to card. Response code: $TRELLO_RESPONSE"
+          cat response.json
+          exit 1
+        else
+          echo "PR successfully attached to Trello card."
+        fi
+
+        # Comment on the GitHub PR with the card link
+        COMMENT_BODY="Linked Ticket: $TRELLO_CARD_URL"
+        curl -s -H "Authorization: token $USER_GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -d "{\"body\": \"$COMMENT_BODY\"}" \
+        "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -9,30 +9,28 @@ on:
 jobs:
   link-ticket:
     runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Extract Trello Card ID from Branch Name or PR Body
-      id: card_id
+    steps:    
+    - name: Safe Handling of PR Body
       run: |
+        ENCODED_BODY=$(echo "${{ github.event.pull_request.body }}" | base64 -w 0)
+        echo "ENCODED_BODY=$ENCODED_BODY" >> $GITHUB_ENV
+
+    - name: Extract Trello Card ID from Encoded Branch Name or PR Body
+      run: |
+        # Decoding for usage here is safer, and only decode when necessary
+        PR_BODY=$(echo "$ENCODED_BODY" | base64 --decode)
         BRANCH_NAME="${{ github.head_ref }}"
-        PR_BODY="${{ github.event.pull_request.body }}"
-        # Extract ID from branch name, assuming format includes 'task_XXXX'
         TRELLO_CARD_ID=$(echo "$BRANCH_NAME" | grep -oP 'task_\K[A-Za-z0-9]+' || echo "")
-        
-        # If not found in branch name, try PR body
+
         if [[ -z "$TRELLO_CARD_ID" ]]; then
           TRELLO_CARD_ID=$(echo "$PR_BODY" | grep -oP 'task_\K[A-Za-z0-9]+' || echo "")
-          if [[ -z "$TRELLO_CARD_ID" ]]; then
-            echo "No card ID found in branch name or PR body."
-            exit 0
-          else
-            echo "Found Card ID: $TRELLO_CARD_ID in PR Body"
-            echo "::set-output name=card_id::$TRELLO_CARD_ID"
-          fi
+        fi
+
+        if [[ -z "$TRELLO_CARD_ID" ]]; then
+          echo "No card ID found in branch name or PR body."
+          exit 0
         else
-          echo "Found Card ID: $TRELLO_CARD_ID in Branch Name"
+          echo "Found Card ID: $TRELLO_CARD_ID"
           echo "::set-output name=card_id::$TRELLO_CARD_ID"
         fi
 

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -13,19 +13,39 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Extract Trello Card ID from Branch Name or PR Body
+      id: card_id
+      run: |
+        BRANCH_NAME="${{ github.head_ref }}"
+        PR_BODY="${{ github.event.pull_request.body }}"
+        # Extract ID from branch name, assuming format includes 'task_XXXX'
+        TRELLO_CARD_ID=$(echo "$BRANCH_NAME" | grep -oP 'task_\K[A-Za-z0-9]+' || echo "")
+        
+        # If not found in branch name, try PR body
+        if [[ -z "$TRELLO_CARD_ID" ]]; then
+          TRELLO_CARD_ID=$(echo "$PR_BODY" | grep -oP 'task_\K[A-Za-z0-9]+' || echo "")
+          if [[ -z "$TRELLO_CARD_ID" ]]; then
+            echo "No card ID found in branch name or PR body."
+            exit 0
+          else
+            echo "Found Card ID: $TRELLO_CARD_ID in PR Body"
+            echo "::set-output name=card_id::$TRELLO_CARD_ID"
+          fi
+        else
+          echo "Found Card ID: $TRELLO_CARD_ID in Branch Name"
+          echo "::set-output name=card_id::$TRELLO_CARD_ID"
+        fi
+
     - name: Link PR and Trello Ticket
       env:
         TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
         TRELLO_API_TOKEN: ${{ secrets.TRELLO_API_TOKEN }}
         USER_GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
       run: |
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        TRELLO_CARD_ID=$(echo $PR_TITLE | grep -oEi 'task_[0-9a-zA-Z]+' | cut -d'_' -f2)
-
-        echo "Found Card ID: $TRELLO_CARD_ID"
+        TRELLO_CARD_ID="${{ steps.card_id.outputs.card_id }}"
 
         if [[ -z "$TRELLO_CARD_ID" ]]; then
-          echo "No card ID found in PR title."
+          echo "No card ID found from previous step."
           exit 0
         fi
 
@@ -53,7 +73,7 @@ jobs:
         else
           echo "PR successfully attached to Trello card."
         fi
-
+        
         # Comment on the GitHub PR with the card link
         COMMENT_BODY="Linked Ticket: $TRELLO_CARD_URL"
         curl -s -H "Authorization: token $USER_GITHUB_TOKEN" \

--- a/autopr.mjs
+++ b/autopr.mjs
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import { exec } from "child_process"
+import dotenv from "dotenv"
+import fetch from "node-fetch"
+import open from "open"
+import { promisify } from "util"
+import { z } from "zod"
+
+dotenv.config({ path: ".env.infra" })
+
+const envVars = z
+  .object({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    TRELLO_API_KEY: z.string(),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    TRELLO_API_TOKEN: z.string()
+  })
+  .passthrough()
+  .parse(process.env)
+
+const getCardDetails = async (cardId) => {
+  const url = `https://api.trello.com/1/cards/${cardId.replace(/^TASK_/i, "")}?key=${envVars.TRELLO_API_KEY}&token=${envVars.TRELLO_API_TOKEN}`
+
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(response.statusText || "Failed to fetch task details.")
+    }
+    const data = await response.json()
+    console.log("Found task details.")
+    return { title: data.name, description: data.desc }
+  } catch (error) {
+    console.error(error.message)
+    return { title: "", description: "" }
+  }
+}
+
+const execAsync = promisify(exec)
+
+let givenCardId = process.argv.slice(2)[0]
+
+if (givenCardId) {
+  if (/^TASK_\w+$/i.test(givenCardId)) {
+    console.log("Card ID found in args")
+  } else {
+    console.error("Invalid card ID format. Expected format is 'TASK_xxx'.")
+    process.exit(1)
+  }
+}
+
+const getGitRemoteUrl = async () => {
+  try {
+    const { stdout } = await execAsync("git config --get remote.origin.url")
+    return stdout.trim()
+  } catch (error) {
+    console.error("Error getting Git remote URL:", error)
+    return null
+  }
+}
+
+const getCurrentBranch = async () => {
+  try {
+    const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD")
+    return stdout.trim()
+  } catch (error) {
+    console.error("Error getting current git branch:", error)
+    return null
+  }
+}
+
+const openPR = async () => {
+  const remoteUrl = await getGitRemoteUrl()
+  const currentBranch = await getCurrentBranch()
+
+  if (!currentBranch) {
+    console.log("Could not determine the current branch.")
+    return
+  }
+
+  if (!givenCardId) {
+    const match = currentBranch.match(/task_\w+/i)
+    if (match) {
+      givenCardId = match[0].replace(/^task_/i, "")
+      console.log("Card ID found in branch name")
+    }
+  }
+
+  let prTitle = currentBranch
+  let prBody = ""
+
+  if (givenCardId) {
+    const details = await getCardDetails(givenCardId)
+    prTitle = encodeURIComponent(`${givenCardId} ${details.title}`)
+    prBody = encodeURIComponent(
+      `${details.description}\n\nTrello Card ID: ${givenCardId}`
+    )
+  } else {
+    console.log("No linked card ID found.")
+  }
+
+  const prUrl = `${remoteUrl}/compare/development...${currentBranch}?expand=1&title=${prTitle}&body=${prBody}`
+  console.log("Opening PR form...")
+  open(prUrl)
+}
+
+openPR()

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "root",
   "main": "AppEntry.js",
   "scripts": {
+    "pr": "node autopr.mjs",
     "start": "node enableStorybook.js false && node checkEnv.js && npx expo start --dev-client --clear",
     "sb_start": "node enableStorybook.js true && sb-rn-get-stories --config-path .storybook/.ondevice && npx expo start --dev-client --clear",
     "sb_watcher": "sb-rn-watcher --config-path .storybook/.ondevice",


### PR DESCRIPTION
Problem: It was too inconvenient linking trello tickets to github PR's. We can make the process more convenient, giving devs an easier time keeping the trello board up to date (which will in turn keep the daily summary up to date).

Previous workflow:
1. Open trello
2. Write ticket
3. Make a new branch
4. Push the branch
5. Open github
6. Create PR
7. Copy PR link
8. Open trello
9. Find corresponding ticket
10. Attach PR to ticket

-----------------------------------
Solution:
* Add the trello card id in the branch name or PR description. Then add scripts to the pull request process to automatically link the PR to trello and vice versa when the PR is opened.

Implementation:
* Add script "npm run pr" to open pr form and fill in title/description based on card id from the branch name or params.
* Add github action to attach the newly opened pr to the trello card.

Notes: Trello api key and Trello api token are needed in the .env.infra in order for the "npm run pr" script to work. These are in the slack channel.

Now when opening a PR, the corresponding trello ticket gets linked in one fell swoop.

-----------------------------------

New standard workflow:
1. Open trello
2. Write ticket
3. Copy ticket ID
4. Make a new branch with the ticket ID in the branch name
5. Push the branch
6. Run "npm run pr"
7. Create PR

Alternative workflow (making PR first):
1. Make a new branch
2. Push the branch
3. Open trello
4. Write ticket/Find matching ticket
5. Copy ticket ID
6. Run "npm run pr [ticketID]"
7. Create PR

TASK_y6zY4kQW 