### PR TITLE
Settings: Support Simple Arrays

### DIFF
--- a/settings-storage/Settings.test.ts
+++ b/settings-storage/Settings.test.ts
@@ -3,13 +3,20 @@ import { areSettingsEqual } from "./Settings"
 describe("Settings tests", () => {
   describe("AreSettingsEqual tests", () => {
     it("should be equal when the keys and values are the same", () => {
+      const now = new Date()
       const settings1 = {
         hello: "world",
         isOn: true,
         count: 3,
-        currentDate: new Date()
+        currentDate: now,
+        someSet: [1, 2, now]
       }
-      expect(areSettingsEqual(settings1, { ...settings1 })).toEqual(true)
+      expect(
+        areSettingsEqual(settings1, {
+          ...settings1,
+          someSet: [1, 2, now]
+        })
+      ).toEqual(true)
     })
 
     it("should not be equal when values are not the same", () => {
@@ -17,7 +24,8 @@ describe("Settings tests", () => {
         hello: "hello",
         isOn: false,
         count: 2,
-        currentDate: new Date()
+        currentDate: new Date(),
+        someSet: [1, 2, new Date()]
       }
       expect(
         areSettingsEqual(settings, { ...settings, hello: "world" })
@@ -30,6 +38,15 @@ describe("Settings tests", () => {
       )
       expect(
         areSettingsEqual(settings, { ...settings, currentDate: new Date(0) })
+      ).toEqual(false)
+      expect(areSettingsEqual(settings, { ...settings, someSet: [1] })).toEqual(
+        false
+      )
+      expect(
+        areSettingsEqual(settings, {
+          ...settings,
+          someSet: [1, new Date(1000), 3]
+        })
       ).toEqual(false)
     })
   })

--- a/settings-storage/Settings.ts
+++ b/settings-storage/Settings.ts
@@ -1,6 +1,12 @@
 export type SettingsStoreUnsubscribe = () => void
 
-export type SettingValue = string | boolean | number | Date | null
+export type SettingValue =
+  | string
+  | boolean
+  | number
+  | SettingValue[]
+  | Date
+  | null
 
 export type AnySettings = Record<string, SettingValue>
 
@@ -32,11 +38,17 @@ export const areSettingsEqual = <Settings extends AnySettings>(
   s1: Settings,
   s2: Settings
 ) => {
-  return Object.keys(s1).every((key) => {
-    const [v1, v2] = [s1[key], s2[key]]
-    if (v1 instanceof Date && v2 instanceof Date) {
-      return v1.getTime() === v2.getTime()
-    }
-    return v1 === v2
-  })
+  return Object.keys(s1).every((key) => isEqualSettingValue(s1[key], s2[key]))
+}
+
+const isEqualSettingValue = (v1: SettingValue, v2: SettingValue): boolean => {
+  if (v1 instanceof Date && v2 instanceof Date) {
+    return v1.getTime() === v2.getTime()
+  }
+  if (Array.isArray(v1) && Array.isArray(v2)) {
+    return v1.every((setting, index) => {
+      return index <= v2.length - 1 && isEqualSettingValue(setting, v2[index])
+    })
+  }
+  return v1 === v2
 }


### PR DESCRIPTION
Some settings values like event duration presets and notification triggers are best represented by arrays of primitive JS values. So this adds another union case to the `SettingValue` type to include support for a `SettingValue[]`. I also updated `areSettingsEqual` to ensure that arrays are compared for equality by value and not by reference.

TASK_UVOItWdN