### PR TITLE
Settings: Appearance Settings

### DIFF
--- a/.storybook/components/SettingsScreen/SettingsScreen.stories.tsx
+++ b/.storybook/components/SettingsScreen/SettingsScreen.stories.tsx
@@ -2,7 +2,10 @@ import { BASE_HEADER_SCREEN_OPTIONS } from "@components/Navigation"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { SettingsScreen } from "@screens/SettingsScreen/SettingsScreen"
-import { NotificationSettingsView } from "@settings-boundary"
+import {
+  AppearanceSettingsView,
+  NotificationSettingsView
+} from "@settings-boundary"
 import { SettingsProvider } from "@settings-storage/Hooks"
 import { SQLiteLocalSettingsStorage } from "@settings-storage/LocalSettings"
 import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
@@ -27,7 +30,7 @@ export const Basic: SettingsStory = () => (
   <SafeAreaProvider>
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ ...BASE_HEADER_SCREEN_OPTIONS }}>
-        <Stack.Screen name="Notifications" component={Test} />
+        <Stack.Screen name="Appearance" component={Test} />
       </Stack.Navigator>
     </NavigationContainer>
   </SafeAreaProvider>
@@ -42,19 +45,13 @@ const userStore = PersistentSettingsStores.user(
 )
 
 const Test = () => {
-  const [isGranted, setIsGranted] = useState(false)
   return (
     <SafeAreaView edges={["bottom"]}>
       <SettingsProvider
         localSettingsStore={localStore}
         userSettingsStore={userStore}
       >
-        <NotificationSettingsView
-          notificationPermission={{
-            isGranted,
-            onToggled: async () => setIsGranted(!isGranted)
-          }}
-        />
+        <AppearanceSettingsView />
       </SettingsProvider>
     </SafeAreaView>
   )

--- a/lib/Fonts.ts
+++ b/lib/Fonts.ts
@@ -12,8 +12,8 @@ export const useAppFonts = () => {
     OpenSansSemiBold: require("../assets/fonts/OpenSans-SemiBold.ttf"),
     OpenSans: require("../assets/fonts/OpenSans-Regular.ttf"),
     OpenSansBold: require("../assets/fonts/OpenSans-Bold.ttf"),
-    OpenDyslexic: require("../assets/fonts/OpenDyslexic3-Regular.ttf"),
-    OpenDyslexicBold: require("../assets/fonts/OpenDyslexic3-Bold.ttf")
+    OpenDyslexic3: require("../assets/fonts/OpenDyslexic3-Regular.ttf"),
+    OpenDyslexic3Bold: require("../assets/fonts/OpenDyslexic3-Bold.ttf")
   })
 }
 

--- a/settings-boundary/AppearanceSettings.tsx
+++ b/settings-boundary/AppearanceSettings.tsx
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   View,
   Text,
+  TextProps,
   TextStyle,
   Pressable,
   Platform
@@ -13,7 +14,7 @@ import { SettingsSectionView } from "./components/Section"
 import { SettingsCardView } from "./components/Card"
 import { useLocalSettings } from "@settings-storage/Hooks"
 import { settingsSelector } from "@settings-storage/Settings"
-import { BodyText } from "@components/Text"
+import { BodyText, CaptionTitle } from "@components/Text"
 import { AppStyles } from "@lib/AppColorStyle"
 import { FontScaleFactors, useFontScale } from "@lib/Fonts"
 
@@ -99,6 +100,12 @@ const FontFamilySectionView = () => {
         <View style={styles.previewOptionRow}>
           <PreviewableOptionView
             name="Open Sans"
+            NameComponent={(props: TextProps) => (
+              <Text
+                {...props}
+                style={[props.style, styles.openSansOptionLabel]}
+              />
+            )}
             isSelected={settings.preferredFontFamily === "OpenSans"}
             onSelected={() => update({ preferredFontFamily: "OpenSans" })}
             previewStyle={styles.fontOptionPreviewContainer}
@@ -107,10 +114,16 @@ const FontFamilySectionView = () => {
           </PreviewableOptionView>
           <PreviewableOptionView
             name="Open Dyslexic"
-            nameTextStyle={[
-              styles.openDyslexicOptionLabel,
-              { marginTop: Platform.OS === "ios" ? -4 * fontScale : 0 }
-            ]}
+            NameComponent={(props: TextProps) => (
+              <Text
+                {...props}
+                style={[
+                  props.style,
+                  styles.openDyslexicOptionLabel,
+                  { marginTop: Platform.OS === "ios" ? -4 * fontScale : 0 }
+                ]}
+              />
+            )}
             isSelected={settings.preferredFontFamily === "OpenDyslexic3"}
             onSelected={() => update({ preferredFontFamily: "OpenDyslexic3" })}
             previewStyle={styles.fontOptionPreviewContainer}
@@ -139,16 +152,20 @@ const FontOptionPreviewView = ({ textStyle }: FontOptionPreviewProps) => (
 
 type PreviewableOptionProps = {
   name: string
-  nameTextStyle?: StyleProp<TextStyle>
+  NameComponent?: (props: TextProps) => JSX.Element
   previewStyle?: StyleProp<ViewStyle>
   isSelected: boolean
   onSelected: () => void
   children?: JSX.Element | JSX.Element[]
 }
 
+const DefaultPreviewOptionName = (props: TextProps) => (
+  <CaptionTitle {...props} />
+)
+
 const PreviewableOptionView = ({
   name,
-  nameTextStyle = styles.openSansOptionLabel,
+  NameComponent = DefaultPreviewOptionName,
   previewStyle,
   isSelected,
   onSelected,
@@ -180,10 +197,9 @@ const PreviewableOptionView = ({
           backgroundColor: isSelected ? AppStyles.darkColor : undefined
         }}
       >
-        <Text
+        <NameComponent
           maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
           style={[
-            nameTextStyle,
             {
               padding: 8,
               color: isSelected ? "white" : AppStyles.darkColor
@@ -191,7 +207,7 @@ const PreviewableOptionView = ({
           ]}
         >
           {name}
-        </Text>
+        </NameComponent>
       </View>
     </View>
   </Pressable>
@@ -272,13 +288,11 @@ const styles = StyleSheet.create({
     padding: 8
   },
   openDyslexicOptionLabel: {
-    fontFamily: "OpenDyslexic3",
-    fontSize: 10,
-    marginTop: Platform.OS === "ios" ? -4 : 0
+    fontFamily: "OpenDyslexic3Bold",
+    fontSize: 10
   },
   openDyslexicOptionPreview: {
-    fontFamily: "OpenDyslexic3",
-    fontSize: 18,
-    marginTop: Platform.OS === "ios" ? -4 : 0
+    fontFamily: "OpenDyslexic3Bold",
+    fontSize: 18
   }
 })

--- a/settings-boundary/AppearanceSettings.tsx
+++ b/settings-boundary/AppearanceSettings.tsx
@@ -1,0 +1,284 @@
+import {
+  StyleProp,
+  ViewStyle,
+  StyleSheet,
+  View,
+  Text,
+  TextStyle,
+  Pressable,
+  Platform
+} from "react-native"
+import { SettingsScrollView } from "./components/ScrollView"
+import { SettingsSectionView } from "./components/Section"
+import { SettingsCardView } from "./components/Card"
+import { useLocalSettings } from "@settings-storage/Hooks"
+import { settingsSelector } from "@settings-storage/Settings"
+import { BodyText } from "@components/Text"
+import { AppStyles } from "@lib/AppColorStyle"
+import { FontScaleFactors, useFontScale } from "@lib/Fonts"
+
+export type AppearanceSettingsProps = {
+  style?: StyleProp<ViewStyle>
+}
+
+export const AppearanceSettingsView = ({ style }: AppearanceSettingsProps) => (
+  <SettingsScrollView style={style}>
+    <ThemeSectionView />
+    <FontFamilySectionView />
+  </SettingsScrollView>
+)
+
+const ThemeSectionView = () => {
+  const { settings, update } = useLocalSettings(
+    settingsSelector("userInterfaceStyle")
+  )
+  return (
+    <SettingsSectionView title="Theme">
+      <SettingsCardView>
+        <View style={styles.previewOptionRow}>
+          <PreviewableOptionView
+            name="System"
+            isSelected={settings.userInterfaceStyle === "system"}
+            onSelected={() => update({ userInterfaceStyle: "system" })}
+            previewStyle={styles.userInterfaceStylePreview}
+          >
+            <View style={styles.systemUserInterfaceStylePreviewDark} />
+            <View style={styles.systemUserInterfaceStylePreviewLight} />
+          </PreviewableOptionView>
+          <PreviewableOptionView
+            name="Dark"
+            isSelected={settings.userInterfaceStyle === "dark"}
+            onSelected={() => update({ userInterfaceStyle: "dark" })}
+            previewStyle={[
+              styles.userInterfaceStylePreview,
+              styles.darkUserInterfaceStylePreview
+            ]}
+          />
+          <PreviewableOptionView
+            name="Light"
+            isSelected={settings.userInterfaceStyle === "light"}
+            onSelected={() => update({ userInterfaceStyle: "light" })}
+            previewStyle={[
+              styles.userInterfaceStylePreview,
+              styles.lightUserInterfaceStylePreview
+            ]}
+          />
+        </View>
+      </SettingsCardView>
+    </SettingsSectionView>
+  )
+}
+
+const FontFamilySectionView = () => {
+  const { settings, update } = useLocalSettings(
+    settingsSelector("preferredFontFamily")
+  )
+  const fontScale = useFontScale({
+    maximumScaleFactor: FontScaleFactors.xxxLarge
+  })
+  return (
+    <SettingsSectionView
+      title="Font"
+      subtitle={
+        <BodyText>
+          <BodyText style={styles.fontSubtitleBase}>
+            Open Dyslexic is a font that aids against common symptoms of
+            Dyslexia.{" "}
+          </BodyText>
+          <BodyText
+            style={styles.learnMore}
+            suppressHighlighting
+            // TODO: - Open web page.
+          >
+            Learn More...
+          </BodyText>
+        </BodyText>
+      }
+    >
+      <SettingsCardView>
+        <View style={styles.previewOptionRow}>
+          <PreviewableOptionView
+            name="Open Sans"
+            isSelected={settings.preferredFontFamily === "OpenSans"}
+            onSelected={() => update({ preferredFontFamily: "OpenSans" })}
+            previewStyle={styles.fontOptionPreviewContainer}
+          >
+            <FontOptionPreviewView textStyle={styles.openSansOptionPreview} />
+          </PreviewableOptionView>
+          <PreviewableOptionView
+            name="Open Dyslexic"
+            nameTextStyle={[
+              styles.openDyslexicOptionLabel,
+              { marginTop: Platform.OS === "ios" ? -4 * fontScale : 0 }
+            ]}
+            isSelected={settings.preferredFontFamily === "OpenDyslexic3"}
+            onSelected={() => update({ preferredFontFamily: "OpenDyslexic3" })}
+            previewStyle={styles.fontOptionPreviewContainer}
+          >
+            <FontOptionPreviewView
+              textStyle={styles.openDyslexicOptionPreview}
+            />
+          </PreviewableOptionView>
+        </View>
+      </SettingsCardView>
+    </SettingsSectionView>
+  )
+}
+
+type FontOptionPreviewProps = {
+  textStyle: StyleProp<TextStyle>
+}
+
+const FontOptionPreviewView = ({ textStyle }: FontOptionPreviewProps) => (
+  <View style={styles.optionLabelText}>
+    <Text allowFontScaling={false} style={textStyle}>
+      ABC 123
+    </Text>
+  </View>
+)
+
+type PreviewableOptionProps = {
+  name: string
+  nameTextStyle?: StyleProp<TextStyle>
+  previewStyle?: StyleProp<ViewStyle>
+  isSelected: boolean
+  onSelected: () => void
+  children?: JSX.Element | JSX.Element[]
+}
+
+const PreviewableOptionView = ({
+  name,
+  nameTextStyle = styles.openSansOptionLabel,
+  previewStyle,
+  isSelected,
+  onSelected,
+  children
+}: PreviewableOptionProps) => (
+  <Pressable onPress={onSelected} style={styles.previewOptionContainer}>
+    <View
+      style={[
+        previewStyle,
+        {
+          borderRadius: 12,
+          overflow: "hidden",
+          borderWidth: isSelected ? 2 : 0
+        }
+      ]}
+    >
+      {children}
+    </View>
+    <View
+      style={{
+        height:
+          32 * useFontScale({ maximumScaleFactor: FontScaleFactors.xxxLarge })
+      }}
+    >
+      <View
+        style={{
+          borderRadius: 12,
+          overflow: "hidden",
+          backgroundColor: isSelected ? AppStyles.darkColor : undefined
+        }}
+      >
+        <Text
+          maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
+          style={[
+            nameTextStyle,
+            {
+              padding: 8,
+              color: isSelected ? "white" : AppStyles.darkColor
+            }
+          ]}
+        >
+          {name}
+        </Text>
+      </View>
+    </View>
+  </Pressable>
+)
+
+const styles = StyleSheet.create({
+  fontSubtitleBase: {
+    opacity: 0.5
+  },
+  previewOptionRow: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-evenly",
+    paddingVertical: 16
+  },
+  previewOptionContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    rowGap: 8
+  },
+  previewOptionPreview: {
+    width: 128,
+    height: 48,
+    borderRadius: 12
+  },
+  previewOptionLabel: {
+    height: 32
+  },
+  learnMore: {
+    color: AppStyles.linkColor,
+    opacity: 1
+  },
+  userInterfaceStylePreview: {
+    width: 84,
+    height: 48,
+    borderRadius: 10,
+    display: "flex",
+    flexDirection: "row"
+  },
+  darkUserInterfaceStylePreview: {
+    backgroundColor: AppStyles.darkColor
+  },
+  lightUserInterfaceStylePreview: {
+    backgroundColor: "white"
+  },
+  systemUserInterfaceStylePreviewDark: {
+    backgroundColor: AppStyles.darkColor,
+    width: "50%",
+    height: "100%",
+    borderBottomLeftRadius: 10,
+    borderTopLeftRadius: 10
+  },
+  systemUserInterfaceStylePreviewLight: {
+    backgroundColor: "white",
+    width: "50%",
+    height: "100%",
+    borderTopRightRadius: 10,
+    borderBottomRightRadius: 10
+  },
+  fontOptionPreviewContainer: {
+    width: 128,
+    height: 48
+  },
+  optionLabelText: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  openSansOptionLabel: {
+    fontFamily: "OpenSansBold",
+    fontSize: 12
+  },
+  openSansOptionPreview: {
+    fontFamily: "OpenSansBold",
+    fontSize: 20,
+    padding: 8
+  },
+  openDyslexicOptionLabel: {
+    fontFamily: "OpenDyslexic3",
+    fontSize: 10,
+    marginTop: Platform.OS === "ios" ? -4 : 0
+  },
+  openDyslexicOptionPreview: {
+    fontFamily: "OpenDyslexic3",
+    fontSize: 18,
+    marginTop: Platform.OS === "ios" ? -4 : 0
+  }
+})

--- a/settings-boundary/components/ScrollView.tsx
+++ b/settings-boundary/components/ScrollView.tsx
@@ -1,4 +1,3 @@
-import { TiFDefaultLayoutTransition } from "@lib/Reanimated"
 import { ReactNode } from "react"
 import { StyleProp, ViewStyle, StyleSheet } from "react-native"
 import Animated from "react-native-reanimated"

--- a/settings-boundary/components/Section.tsx
+++ b/settings-boundary/components/Section.tsx
@@ -1,6 +1,6 @@
-import { Subtitle } from "@components/Text"
+import { BodyText, Subtitle } from "@components/Text"
 import { TiFDefaultLayoutTransition } from "@lib/Reanimated"
-import { createContext, useContext } from "react"
+import { ReactNode, createContext, useContext } from "react"
 import { ViewStyle, View, StyleProp, StyleSheet } from "react-native"
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated"
 
@@ -18,6 +18,7 @@ export const useCurrentSettingsSection = () => {
 
 export type SettingsSectionProps = {
   title?: string
+  subtitle?: ReactNode
   isDisabled?: boolean
   children: JSX.Element | JSX.Element[]
   style?: StyleProp<ViewStyle>
@@ -25,6 +26,7 @@ export type SettingsSectionProps = {
 
 export const SettingsSectionView = ({
   title,
+  subtitle,
   isDisabled = false,
   children,
   style
@@ -37,7 +39,13 @@ export const SettingsSectionView = ({
     <SettingsSectionContext.Provider value={{ isDisabled }}>
       <View style={style}>
         <View style={[styles.container, { opacity: isDisabled ? 0.5 : 1 }]}>
-          {title && <Subtitle>{title}</Subtitle>}
+          <View style={styles.textContainer}>
+            {title && <Subtitle>{title}</Subtitle>}
+            {subtitle && typeof subtitle === "string" && (
+              <BodyText style={styles.subtitle}>{subtitle}</BodyText>
+            )}
+            {subtitle && typeof subtitle !== "string" && subtitle}
+          </View>
           {children}
         </View>
       </View>
@@ -50,5 +58,11 @@ const styles = StyleSheet.create({
     display: "flex",
     flexDirection: "column",
     rowGap: 16
+  },
+  textContainer: {
+    rowGap: 4
+  },
+  subtitle: {
+    opacity: 0.5
   }
 })

--- a/settings-boundary/index.ts
+++ b/settings-boundary/index.ts
@@ -1,2 +1,3 @@
 export * from "./PrivacySettings"
 export * from "./NotificationSettings"
+export * from "./AppearanceSettings"


### PR DESCRIPTION
Implements the settings screen that allows the user to change the theme to light or dark mode and the font to Open Dyslexic. This PR does not implement dark mode or font changes in the UI, but just the screen that allows the user to do so.

On iOS the open dyslexic font seems to have an inherent top margin of 4. To level that text with Open Sans in the font picker, I needed to add a negative top margin to counteract this.

![IMG_0075](https://github.com/tifapp/FitnessProject/assets/75196016/507d49e2-7e10-4203-8362-bb9c7e79417f)

https://trello.com/c/7gsD1KkU