### PR TITLE
True Dismissal

### DIFF
--- a/lib/AppState.tsx
+++ b/lib/AppState.tsx
@@ -1,0 +1,20 @@
+import { ReactNode, createContext, useContext } from "react"
+import { AppState, AppStateStatic } from "react-native"
+
+const AppStateContext = createContext(AppState)
+
+export type AppStateProviderProps = {
+  appState: AppStateStatic
+  children: ReactNode
+}
+
+export const AppStateProvider = ({
+  appState,
+  children
+}: AppStateProviderProps) => (
+  <AppStateContext.Provider value={appState}>
+    {children}
+  </AppStateContext.Provider>
+)
+
+export const useAppState = () => useContext(AppStateContext)

--- a/lib/utils/UseDismisaal.test.tsx
+++ b/lib/utils/UseDismisaal.test.tsx
@@ -14,7 +14,7 @@ describe("UseDismissal tests", () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
-  it("should run the dismissal function only when the app is not active", () => {
+  it("should run the dismissal function only when the app is in the background", () => {
     let send: ((status: AppStateStatus) => void) | undefined
     appStateSubscribe.mockImplementationOnce((_, cb) => {
       send = cb
@@ -26,8 +26,6 @@ describe("UseDismissal tests", () => {
     expect(callback).not.toHaveBeenCalled()
     act(() => send?.("background"))
     expect(callback).toHaveBeenCalledTimes(1)
-    act(() => send?.("inactive"))
-    expect(callback).toHaveBeenCalledTimes(2)
   })
 
   const renderUseDismissal = (onDismiss: () => void) => {

--- a/lib/utils/UseDismisaal.test.tsx
+++ b/lib/utils/UseDismisaal.test.tsx
@@ -1,0 +1,44 @@
+import { act, renderHook } from "@testing-library/react-native"
+import { useDismissal } from "./UseDismissal"
+import { AppStateProvider } from "@lib/AppState"
+import { AppState, AppStateStatus } from "react-native"
+
+describe("UseDismissal tests", () => {
+  const appStateSubscribe = jest.fn()
+
+  it("should run the dismissal function when the component unmounts", () => {
+    const callback = jest.fn()
+    const { unmount } = renderUseDismissal(callback)
+    expect(callback).not.toHaveBeenCalled()
+    act(() => unmount())
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it("should run the dismissal function only when the app is not active", () => {
+    let send: ((status: AppStateStatus) => void) | undefined
+    appStateSubscribe.mockImplementationOnce((_, cb) => {
+      send = cb
+      return { remove: jest.fn() }
+    })
+    const callback = jest.fn()
+    renderUseDismissal(callback)
+    act(() => send?.("active"))
+    expect(callback).not.toHaveBeenCalled()
+    act(() => send?.("background"))
+    expect(callback).toHaveBeenCalledTimes(1)
+    act(() => send?.("inactive"))
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  const renderUseDismissal = (onDismiss: () => void) => {
+    return renderHook(() => useDismissal(onDismiss), {
+      wrapper: ({ children }: any) => (
+        <AppStateProvider
+          appState={{ ...AppState, addEventListener: appStateSubscribe }}
+        >
+          {children}
+        </AppStateProvider>
+      )
+    })
+  }
+})

--- a/lib/utils/UseDismissal.ts
+++ b/lib/utils/UseDismissal.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react"
+import { useEffectEvent } from "./UseEffectEvent"
+import { useAppState } from "@lib/AppState"
+
+/**
+ * Runs the given callback when either the component unmounts, or when the app
+ * is backgrounded.
+ */
+export const useDismissal = (onDismiss: () => void) => {
+  const fn = useEffectEvent(onDismiss)
+  const appState = useAppState()
+  useEffect(() => fn, [fn])
+  useEffect(() => {
+    const subscription = appState.addEventListener("change", (status) => {
+      if (status !== "active") fn()
+    })
+    return () => subscription.remove()
+  }, [fn, appState])
+}

--- a/lib/utils/UseDismissal.ts
+++ b/lib/utils/UseDismissal.ts
@@ -12,7 +12,7 @@ export const useDismissal = (onDismiss: () => void) => {
   useEffect(() => fn, [fn])
   useEffect(() => {
     const subscription = appState.addEventListener("change", (status) => {
-      if (status !== "active") fn()
+      if (status === "background") fn()
     })
     return () => subscription.remove()
   }, [fn, appState])


### PR DESCRIPTION
Creates a hook that runs a function when either the current component unmounts, or when the app is backgrounded.

Some screens, like the block list, debounce any changes the user may make to them (eg. debouncing when unblocking users so that the backend can unblock many users at once rather than make a separate API call for unblocking each user). Debouncing relies on `setTimeout` which is paused when the app backgrounds. So when the app backgrounds, or when the user leaves that screen, we should skip the debounce wait and flush any pending changes.

This new hook, `useDismissal` allows for that. You pass it an `onDismiss` callback, and it runs that callback either on unmount, or when the `AppState` changes to `"background"`. Under the hood, the hook uses `useEffectEvent`, so there is no need to wrap the callback with `useCallback`.

Additionally, I also wrote a context around `AppState` such that it can be injected for mocking purposes.

https://trello.com/c/bHPmsdXH