### PR TITLE
Logs + Main SQLite DB separation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
     "object-curly-spacing": "error",
     "comma-spacing": "error",
     "indent": "off",
+    "brace-style": "off",
     "@typescript-eslint/naming-convention": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
     "array-bracket-spacing": "error",
     "object-curly-spacing": "error",
     "comma-spacing": "error",
-    "indent": ["error", 2],
+    "indent": "off",
     "@typescript-eslint/naming-convention": [
       "warn",
       {

--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -290,7 +290,7 @@ export namespace Migrations {
       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
       label TEXT NOT NULL,
       message TEXT NOT NULL,
-      level TEXT NOT NULL CHECK(level IN ('debug', 'info', 'warn', 'error')),
+      level TEXT NOT NULL CHECK(level IN ('debug', 'info', 'warn', 'error', 'trace')),
       stringifiedMetadata TEXT,
       timestamp DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec'))
     )

--- a/lib/SQLite.ts
+++ b/lib/SQLite.ts
@@ -32,11 +32,16 @@ export class TiFSQLite {
    */
   constructor(
     path: string,
+    migrate: (db: SQLExecutable) => Promise<void>,
     openSQLExecuatble: (
       path: string
     ) => Promise<ExpoSQLExecutable> = openExpoSQLExecutable
   ) {
-    this.sqlExecutablePromise = TiFSQLite.setup(path, openSQLExecuatble)
+    this.sqlExecutablePromise = TiFSQLite.setup(
+      path,
+      migrate,
+      openSQLExecuatble
+    )
   }
 
   /**
@@ -83,10 +88,11 @@ export class TiFSQLite {
 
   private static async setup(
     path: string,
+    migrate: (db: SQLExecutable) => Promise<void>,
     openSQLExecuatble: (path: string) => Promise<ExpoSQLExecutable>
   ) {
     const db = await TiFSQLite.openWithInMemoryFallback(path, openSQLExecuatble)
-    await TiFSQLite.migrateV1(db)
+    await migrate(db)
     return db
   }
 
@@ -107,91 +113,6 @@ export class TiFSQLite {
       )
       return await openSQLExecuatble(SQLITE_IN_MEMORY_PATH)
     }
-  }
-
-  private static async migrateV1(db: SQLExecutable) {
-    await Promise.all([
-      db.run`
-      CREATE TABLE IF NOT EXISTS LocationArrivals (
-        latitude DOUBLE,
-        longitude DOUBLE,
-        arrivalRadiusMeters DOUBLE,
-        hasArrived INT2 DEFAULT 0,
-        PRIMARY KEY(latitude, longitude, arrivalRadiusMeters)
-      )
-      `,
-      db.run`
-      CREATE TABLE IF NOT EXISTS UpcomingEventArrivals (
-        eventId BIGINT,
-        latitude DOUBLE,
-        longitude DOUBLE,
-        arrivalRadiusMeters DOUBLE,
-        PRIMARY KEY(eventId, latitude, longitude, arrivalRadiusMeters),
-        FOREIGN KEY(latitude, longitude, arrivalRadiusMeters)
-          REFERENCES LocationArrivals(latitude, longitude, arrivalRadiusMeters)
-          ON DELETE CASCADE
-      )
-      `,
-      db.run`
-      CREATE TABLE IF NOT EXISTS LocationPlacemarks (
-        latitude DOUBLE NOT NULL,
-        longitude DOUBLE NOT NULL,
-        name TEXT,
-        country TEXT,
-        postalCode TEXT,
-        street TEXT,
-        streetNumber TEXT,
-        region TEXT,
-        isoCountryCode TEXT,
-        city TEXT,
-        recentAnnotation TEXT,
-        recentUpdatedAt DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec')),
-        CHECK(
-          recentAnnotation IN (
-            'attended-event',
-            'hosted-event',
-            'joined-event'
-          )
-        ),
-        PRIMARY KEY(latitude, longitude)
-      )
-      `,
-      db.run`
-      CREATE TABLE IF NOT EXISTS Logs (
-        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-        label TEXT NOT NULL,
-        message TEXT NOT NULL,
-        level TEXT NOT NULL CHECK(level IN ('debug', 'info', 'warn', 'error')),
-        stringifiedMetadata TEXT,
-        timestamp DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec'))
-      )
-      `,
-      db.run`
-      CREATE TABLE IF NOT EXISTS LocalSettings (
-        id TEXT NOT NULL PRIMARY KEY DEFAULT 'A' CHECK (id = 'A'),
-        isHapticFeedbackEnabled INT2 NOT NULL,
-        isHapticAudioEnabled INT2 NOT NULL,
-        hasCompletedOnboarding INT2 NOT NULL,
-        lastEventArrivalsRefreshDate DOUBLE,
-        userInterfaceStyle TEXT NOT NULL,
-        preferredFontFamily TEXT NOT NULL,
-        preferredBrowserName TEXT NOT NULL,
-        isUsingSafariReaderMode INT2 NOT NULL
-      )
-      `,
-      db.run`
-      CREATE TABLE IF NOT EXISTS UserSettings (
-        id TEXT NOT NULL PRIMARY KEY DEFAULT 'A' CHECK (id = 'A'),
-        isAnalyticsEnabled INT2 NOT NULL,
-        isCrashReportingEnabled INT2 NOT NULL,
-        canShareArrivalStatus INT2 NOT NULL,
-        pushNotificationTriggerIds TEXT NOT NULL,
-        eventCalendarStartOfWeekDay TEXT NOT NULL,
-        eventCalendarDefaultLayout TEXT NOT NULL,
-        version INTEGER NOT NULL DEFAULT 0
-      )
-      `
-    ])
   }
 }
 
@@ -285,5 +206,94 @@ export class ExpoSQLExecutable implements SQLExecutable {
         return arg === undefined ? null : arg
       })
     }
+  }
+}
+
+export namespace Migrations {
+  export const main = async (db: SQLExecutable) => {
+    await Promise.all([
+      db.run`
+      CREATE TABLE IF NOT EXISTS LocationArrivals (
+        latitude DOUBLE,
+        longitude DOUBLE,
+        arrivalRadiusMeters DOUBLE,
+        hasArrived INT2 DEFAULT 0,
+        PRIMARY KEY(latitude, longitude, arrivalRadiusMeters)
+      )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS UpcomingEventArrivals (
+        eventId BIGINT,
+        latitude DOUBLE,
+        longitude DOUBLE,
+        arrivalRadiusMeters DOUBLE,
+        PRIMARY KEY(eventId, latitude, longitude, arrivalRadiusMeters),
+        FOREIGN KEY(latitude, longitude, arrivalRadiusMeters)
+          REFERENCES LocationArrivals(latitude, longitude, arrivalRadiusMeters)
+          ON DELETE CASCADE
+      )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS LocationPlacemarks (
+        latitude DOUBLE NOT NULL,
+        longitude DOUBLE NOT NULL,
+        name TEXT,
+        country TEXT,
+        postalCode TEXT,
+        street TEXT,
+        streetNumber TEXT,
+        region TEXT,
+        isoCountryCode TEXT,
+        city TEXT,
+        recentAnnotation TEXT,
+        recentUpdatedAt DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec')),
+        CHECK(
+          recentAnnotation IN (
+            'attended-event',
+            'hosted-event',
+            'joined-event'
+          )
+        ),
+        PRIMARY KEY(latitude, longitude)
+      )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS LocalSettings (
+        id TEXT NOT NULL PRIMARY KEY DEFAULT 'A' CHECK (id = 'A'),
+        isHapticFeedbackEnabled INT2 NOT NULL,
+        isHapticAudioEnabled INT2 NOT NULL,
+        hasCompletedOnboarding INT2 NOT NULL,
+        lastEventArrivalsRefreshDate DOUBLE,
+        userInterfaceStyle TEXT NOT NULL,
+        preferredFontFamily TEXT NOT NULL,
+        preferredBrowserName TEXT NOT NULL,
+        isUsingSafariReaderMode INT2 NOT NULL
+      )
+      `,
+      db.run`
+      CREATE TABLE IF NOT EXISTS UserSettings (
+        id TEXT NOT NULL PRIMARY KEY DEFAULT 'A' CHECK (id = 'A'),
+        isAnalyticsEnabled INT2 NOT NULL,
+        isCrashReportingEnabled INT2 NOT NULL,
+        canShareArrivalStatus INT2 NOT NULL,
+        pushNotificationTriggerIds TEXT NOT NULL,
+        eventCalendarStartOfWeekDay TEXT NOT NULL,
+        eventCalendarDefaultLayout TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 0
+      )
+      `
+    ])
+  }
+  export const logs = async (db: SQLExecutable) => {
+    await db.run`
+    CREATE TABLE IF NOT EXISTS Logs (
+      id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      label TEXT NOT NULL,
+      message TEXT NOT NULL,
+      level TEXT NOT NULL CHECK(level IN ('debug', 'info', 'warn', 'error')),
+      stringifiedMetadata TEXT,
+      timestamp DOUBLE NOT NULL DEFAULT (unixepoch('now', 'subsec'))
+    )
+    `
   }
 }

--- a/lib/Sqlite.test.ts
+++ b/lib/Sqlite.test.ts
@@ -78,7 +78,7 @@ describe("SQLite tests", () => {
       }
       throw new Error()
     })
-    const sqlite = new TiFSQLite("hello/world", open)
+    const sqlite = new TiFSQLite("hello/world", jest.fn(), open)
     const result = await sqlite.withTransaction(async (db) => {
       return await db.queryFirst<{ value: number }>`SELECT TRUE AS value`
     })

--- a/test-helpers/SQLite.ts
+++ b/test-helpers/SQLite.ts
@@ -1,9 +1,12 @@
-import { SQLITE_IN_MEMORY_PATH, TiFSQLite } from "@lib/SQLite"
+import { Migrations, SQLITE_IN_MEMORY_PATH, TiFSQLite } from "@lib/SQLite"
 
 /**
  * An in memory {@link TiFSQLite} instance for testing.
  */
-export const testSQLite = new TiFSQLite(SQLITE_IN_MEMORY_PATH)
+export const testSQLite = new TiFSQLite(SQLITE_IN_MEMORY_PATH, async (db) => {
+  await Migrations.main(db)
+  await Migrations.logs(db)
+})
 
 /**
  * Resets the data inside {@link testSQLite}.


### PR DESCRIPTION
## Problem/Purpose

The purpose of this PR is to separate the logs from the main tables of the SQLite database, where settings, location placemarks, etc. are stored. This is done in order to easily create a copy of them for importing purposes, or to access the current ones in a more isolated database. 

## Implementation Steps

1. In order to adjust the implementation of the database, we needed to adjust the TiFSQLite class.
2. Going there, we remove its `migrateV1` function in favour of a more generic `migrate` parameter, so that we can specify what gets run for the database.
3. We add a namespace with two functions: `main`, which makes most tables, and `logs`, which makes only the logs table. 
4. We adjust any implementations of `TiFSQLite` or `testSQLite` accordingly.
