### PR TITLE
Add watchmanconfig to try and improve expo startup time

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["node_modules"]
+}


### PR DESCRIPTION
Ignoring "node_modules" should reduce the amount of files being tracked when expo starts up
https://facebook.github.io/watchman/docs/config

TASK_UNTRACKED