### PR TITLE
Mail Composer Wrapper

### DIFF
--- a/lib/EmailComposition.ts
+++ b/lib/EmailComposition.ts
@@ -1,0 +1,34 @@
+import {
+  MailComposerOptions,
+  MailComposerStatus,
+  composeAsync
+} from "expo-mail-composer"
+import { Platform } from "react-native"
+
+export type EmailCompositionResult =
+  | "success"
+  | "cancelled"
+  | "non-determinable"
+
+export type EmailTemplate = MailComposerOptions
+
+/**
+ * Presents the device's email composer with the specified {@link EmailTemplate}, and returns
+ * whether or not the user sent an email through the composer's UI.
+ *
+ * On Android, this always returns `"non-determinable"`.
+ */
+export const presentEmailComposer = async (
+  template: EmailTemplate
+): Promise<EmailCompositionResult> => {
+  const result = await composeAsync(template)
+  if (Platform.OS === "android") return "non-determinable"
+  return COMPOSITION_RESULT_MAP[result.status]
+}
+
+const COMPOSITION_RESULT_MAP = {
+  [MailComposerStatus.SENT]: "success",
+  [MailComposerStatus.SAVED]: "cancelled",
+  [MailComposerStatus.CANCELLED]: "cancelled",
+  [MailComposerStatus.UNDETERMINED]: "non-determinable"
+} as const

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "expo-image-picker": "~14.7.1",
         "expo-linking": "~6.2.2",
         "expo-location": "~16.5.3",
+        "expo-mail-composer": "~12.7.1",
         "expo-media-library": "~15.9.1",
         "expo-notifications": "~0.27.6",
         "expo-secure-store": "~12.8.1",
@@ -33483,6 +33484,14 @@
       "version": "16.5.5",
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-16.5.5.tgz",
       "integrity": "sha512-dXEd1HaZgdi6yHVF8R+SMnGlKDYrD+Hkkzd/b9edjMSUBLxF2y824AFSSNUf6BVOM53tJBOFEELneXkU1uj9nA==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-mail-composer": {
+      "version": "12.7.1",
+      "resolved": "https://registry.npmjs.org/expo-mail-composer/-/expo-mail-composer-12.7.1.tgz",
+      "integrity": "sha512-NjJCufkaQwVq58MJQM6aoT4KIKt24KDYjWt7T1g5SLB4gqcXMV+HLT7K5q3mQpD5FIXAj8E/VrwzN6cTkaeU3A==",
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "type-detect": "4.0.8",
     "use-sync-external-store": "^1.2.2",
     "uuid": "^9.0.0",
-    "zod": "^3.20.6"
+    "zod": "^3.20.6",
+    "expo-mail-composer": "~12.7.1"
   },
   "devDependencies": {
     "@aws-amplify/cli": "^10.8.1",


### PR DESCRIPTION
The help and support screen (and possibly future screens) present a success alert when the user sends an email successfully through the mail composer. Unfortunately, Android does not give access to this information, but expo still decides it's a good idea to return `MailComposerStatus.SENT` even if the user did not send an email. Due to this, it's possible for a "We received your feedback!" alert to be presented even when no email was sent on Android.

There are 2 possible fixes for this:
1. Check that both the status is `MailComposerStatus.SENT` and that `Platform.OS === "android"` every time we need to evaluate the result of a mail composition session.
2. Wrap `expo-mail-composer`'s `composeAsync` function and return a custom `EmailCompositionResult` union type based on the check from fix 1.

I went with fix 2.

## Tickets

https://trello.com/c/IGbGWAuV