### PR TITLE
Roswaal: Upload Format Update

### DIFF
--- a/roswaal/Client.test.ts
+++ b/roswaal/Client.test.ts
@@ -37,13 +37,13 @@ describe("RoswaalClient tests", () => {
     await client.uploadTestResultsIfAble()
     expect(uploadedResults).toEqual([
       {
-        name: "Hello",
-        actionResults: [{ didPass: true }, { didPass: true }],
+        testName: "Hello",
+        commandFailureOrdinal: null,
         error: null
       },
       {
-        name: "World",
-        actionResults: [{ didPass: true }, { didPass: true }],
+        testName: "World",
+        commandFailureOrdinal: null,
         error: null
       }
     ])
@@ -63,8 +63,8 @@ describe("RoswaalClient tests", () => {
     expect(uploadedResults).toEqual(
       expect.arrayContaining([
         {
-          name: "Hello",
-          actionResults: [{ didPass: true }, { didPass: false }],
+          testName: "Hello",
+          commandFailureOrdinal: 1,
           error: {
             message: "I died",
             stackTrace: expect.any(String)

--- a/roswaal/TestCase.test.ts
+++ b/roswaal/TestCase.test.ts
@@ -10,8 +10,8 @@ describe("RoswaalTestCases tests", () => {
     testCase.appendAction(jest.fn())
     const result = await testCase.run(jest.fn())
     expect(result).toEqual({
-      name: "Test",
-      actionResults: [{ didPass: true }, { didPass: true }, { didPass: true }],
+      testName: "Test",
+      commandFailureOrdinal: null,
       error: null
     })
   })
@@ -26,13 +26,8 @@ describe("RoswaalTestCases tests", () => {
     testCase.appendAction(jest.fn())
     const result = await testCase.run(jest.fn())
     expect(result).toEqual({
-      name: "Test",
-      actionResults: [
-        { didPass: true },
-        { didPass: true },
-        { didPass: false },
-        { didPass: false }
-      ],
+      testName: "Test",
+      commandFailureOrdinal: 2,
       error: new Error("I died")
     })
   })
@@ -46,12 +41,8 @@ describe("RoswaalTestCases tests", () => {
     testCase.appendAction(jest.fn())
     const result = await testCase.run(jest.fn())
     expect(result).toEqual({
-      name: "Test",
-      actionResults: [
-        { didPass: false },
-        { didPass: false },
-        { didPass: false }
-      ],
+      testName: "Test",
+      commandFailureOrdinal: 0,
       error: new Error("I died")
     })
   })

--- a/roswaal/TestCase.ts
+++ b/roswaal/TestCase.ts
@@ -2,8 +2,8 @@ import { repeatElements } from "TiFShared/lib/Array"
 import { TestAppLaunchConfig, launchApp } from "./Launch"
 
 export type RoswaalTestCaseResult = {
-  name: string
-  actionResults: RoswaalTestCaseActionResult[]
+  testName: string
+  commandFailureOrdinal: number | null
   error: Error | null
 }
 
@@ -58,33 +58,27 @@ export class RoswaalTestCase {
     const beforeLaunchResult = await this.runBeforeLaunch()
     if (beforeLaunchResult instanceof Error || beforeLaunchResult === null) {
       return {
-        name: this.name,
-        actionResults: repeatElements(this.actions.length + 1, {
-          didPass: false
-        }),
+        testName: this.name,
+        commandFailureOrdinal: 0,
         error: beforeLaunchResult
       }
     }
     await launch(beforeLaunchResult)
-    const actionResults = [{ didPass: true }]
     for (const [index, action] of this.actions.entries()) {
       try {
         await action()
-        actionResults.push({ didPass: true })
       } catch (e) {
         const error = e instanceof Error ? e : null
         return {
-          name: this.name,
-          actionResults: actionResults.concat(
-            repeatElements(this.actions.length - index, { didPass: false })
-          ),
+          testName: this.name,
+          commandFailureOrdinal: index + 1,
           error
         }
       }
     }
     return {
-      name: this.name,
-      actionResults,
+      testName: this.name,
+      commandFailureOrdinal: null,
       error: null
     }
   }


### PR DESCRIPTION
Updates the shape of the upload request to match the latest fields from the roswaal tool. The biggest change is how we're now using a failure index (`commandFailureOrdinal`) instead of having a `didPass` field for every step.

## Tickets

https://trello.com/c/UH6YeaPS