### PR TITLE
Settings: Help and Support Email Templates Language

### DIFF
--- a/.storybook/components/SettingsScreen/SettingsScreen.stories.tsx
+++ b/.storybook/components/SettingsScreen/SettingsScreen.stories.tsx
@@ -49,7 +49,7 @@ const userStore = PersistentSettingsStores.user(
 
 const Test = () => {
   const state = useHelpAndSupportSettings({
-    isShowingContactSection: isAvailableAsync,
+    isMailComposerAvailable: isAvailableAsync,
     composeEmail: presentEmailComposer,
     compileLogs: async () => "Test"
   })

--- a/lib/EmailComposition.ts
+++ b/lib/EmailComposition.ts
@@ -12,6 +12,8 @@ export type EmailCompositionResult =
 
 export type EmailTemplate = MailComposerOptions
 
+export const TIF_SUPPORT_EMAIL = "tifapp@doesnotexistyet.com"
+
 /**
  * Presents the device's email composer with the specified {@link EmailTemplate}, and returns
  * whether or not the user sent an email through the composer's UI.

--- a/settings-boundary/HelpAndSupport.test.tsx
+++ b/settings-boundary/HelpAndSupport.test.tsx
@@ -34,9 +34,8 @@ describe("HelpAndSupportSettings tests", () => {
       act(() => result.current.feedbackSubmitted())
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitFeedbackSuccess.title,
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitFeedbackSuccess
-            .description
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitFeedback.title,
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitFeedback.description
         )
       )
       expect(composeEmail).toHaveBeenCalledWith(
@@ -49,8 +48,8 @@ describe("HelpAndSupportSettings tests", () => {
       act(() => result.current.feedbackSubmitted())
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitFeedbackError.title,
-          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitFeedbackError.description
+          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitFeedback.title,
+          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitFeedback.description
         )
       )
     })
@@ -62,8 +61,8 @@ describe("HelpAndSupportSettings tests", () => {
       await reportWithoutLogs()
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.title,
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.description
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.title,
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.description
         )
       )
       expect(composeEmail).toHaveBeenCalledWith(
@@ -78,8 +77,8 @@ describe("HelpAndSupportSettings tests", () => {
       await reportWithLogs()
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.title,
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.description
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.title,
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.description
         )
       )
       expect(composeEmail).toHaveBeenCalledWith(
@@ -102,8 +101,8 @@ describe("HelpAndSupportSettings tests", () => {
       await reportWithoutLogsAfterFailure()
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.title,
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBugSuccess.description
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.title,
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.reportBug.description
         )
       )
       expect(composeEmail).toHaveBeenCalledWith(
@@ -116,9 +115,8 @@ describe("HelpAndSupportSettings tests", () => {
       act(() => result.current.questionSubmitted())
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitQuestionSuccess.title,
-          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitQuestionSuccess
-            .description
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitQuestion.title,
+          HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS.submitQuestion.description
         )
       )
 
@@ -136,8 +134,8 @@ describe("HelpAndSupportSettings tests", () => {
       act(() => result.current.questionSubmitted())
       await waitFor(async () =>
         expect(alertPresentationSpy).toHaveBeenCalledWith(
-          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitQuestionError.title,
-          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitQuestionError.description
+          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitQuestion.title,
+          HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS.submitQuestion.description
         )
       )
     })
@@ -164,7 +162,7 @@ describe("HelpAndSupportSettings tests", () => {
       return renderHook(
         () =>
           useHelpAndSupportSettings({
-            isShowingContactSection,
+            isMailComposerAvailable: isShowingContactSection,
             compileLogs,
             composeEmail
           }),

--- a/settings-boundary/HelpAndSupport.tsx
+++ b/settings-boundary/HelpAndSupport.tsx
@@ -1,5 +1,9 @@
 import { AppStyles } from "@lib/AppColorStyle"
-import { EmailCompositionResult, EmailTemplate } from "@lib/EmailComposition"
+import {
+  EmailCompositionResult,
+  EmailTemplate,
+  TIF_SUPPORT_EMAIL
+} from "@lib/EmailComposition"
 import { useOpenWeblink } from "@modules/tif-weblinks"
 import { useQuery } from "@tanstack/react-query"
 import React from "react"
@@ -10,73 +14,68 @@ import { SettingsCardSectionView } from "./components/Section"
 
 export const COMPILING_LOGS_INFO_URL = "https://logs.com"
 
+type EmailSection = string & { _tag: "help-and-support-email-section" }
+
+const email = (
+  subject: string,
+  attachments: string[],
+  ...sections: EmailSection[]
+) => ({
+  recipients: [TIF_SUPPORT_EMAIL],
+  subject,
+  body: sections.join("\n"),
+  attachments,
+  isHtml: true
+})
+
+const emailSection = (name: string) => {
+  return `<strong>${name}</strong><br><br><br>` as EmailSection
+}
+
 export const HELP_AND_SUPPORT_EMAILS = {
-  feedbackSubmitted: {
-    recipients: ["TIF@myspace.com"],
-    subject: "App Feedback",
-    body: `\
-<strong>📝 1. Select one or more feedback topics below and provide the necessary details. (Required)</strong>
-<br>
-<br>
-<br>
-<strong>a. App functionality (How can the app help you?)</strong>
-<br>
-<br>
-<br>
-<strong>b. Creative synergy (Are the features of the app helping you progress?)</strong>
-<br>
-<br>
-<br>
-<strong>c. Other feedback (Any other general feedback you have)</strong>
-<br>
-<br>
-<br>
-<strong>📸 2. Provide any supplementary information or files related to the feedback above. (Optional)</strong>
-<br>
-<br>
-<br>
-    `,
-    isHtml: true
+  feedbackSubmitted: email(
+    "App Feedback",
+    [],
+    emailSection(
+      "📝 1. Select one or more feedback topics below and provide the necessary details. (Required)"
+    ),
+    emailSection("a. App functionality (How can the app help you?)"),
+    emailSection(
+      "b. Creative synergy (Are the features of the app helping you progress?)"
+    ),
+    emailSection("c. Other feedback (Any other general feedback you have)"),
+    emailSection(
+      "📸 2. Provide any supplementary information or files related to the feedback above. (Optional)"
+    )
+  ),
+  bugReported: (compileLogsURI?: string) => {
+    return email(
+      "App Bug Report",
+      compileLogsURI ? [compileLogsURI] : [],
+      emailSection(
+        "🐞 1. Briefly describe the bug and the issues it is causing in the app. (Required)"
+      ),
+      emailSection(
+        "a. Specify the steps that it took for you to get to the bug. (Required)"
+      ),
+      emailSection(
+        "b. What was the expected result supposed to be? (Required)"
+      ),
+      emailSection(
+        "📸 2. Provide any supplementary information or files related to this bug (Optional)."
+      )
+    )
   },
-  bugReported: (compileLogsURI?: string) => ({
-    recipients: ["TIF@myspace.com"],
-    subject: "App Bug Report",
-    body: `\
-<strong>🐞 1. Briefly describe the bug and the issues it is causing in the app. (Required)</strong>
-<br>
-<br>
-<br>
-<strong>a. Specify the steps that it took for you to get to the bug. (Required)</strong>
-<br>
-<br>
-<br>
-<strong>b. What was the expected result supposed to be? (Required)</strong>
-<br>
-<br>
-<br>
-<strong>📸 2. Provide any supplementary information or files related to this bug (Optional).</strong>
-<br>
-<br>
-<br>
-    `,
-    attachments: compileLogsURI ? [compileLogsURI] : undefined,
-    isHtml: true
-  }),
-  questionSubmitted: {
-    recipients: ["TIF@myspace.com"],
-    subject: "App Question",
-    body: `\
-<strong>❓ 1. List your question(s) and provide all relevant details. (Required)</strong>
-<br>
-<br>
-<br>
-<strong>📸 2. Provide any supplementary information or files related to this question. (Optional)</strong>
-<br>
-<br>
-<br>
-    `,
-    isHtml: true
-  }
+  questionSubmitted: email(
+    "App Question",
+    [],
+    emailSection(
+      "❓ 1. List your question(s) and provide all relevant details. (Required)"
+    ),
+    emailSection(
+      "📸 2. Provide any supplementary information or files related to this question. (Optional)"
+    )
+  )
 }
 
 export const HELP_AND_SUPPORT_ALERTS = {

--- a/settings-boundary/HelpAndSupport.tsx
+++ b/settings-boundary/HelpAndSupport.tsx
@@ -127,17 +127,17 @@ export const HELP_AND_SUPPORT_ALERTS = {
 }
 
 export const HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS = {
-  submitFeedbackSuccess: {
+  submitFeedback: {
     title: "Received!",
     description:
       "Thank you for submitting your feedback and helping us improve the app. We appreciate your input."
   },
-  reportBugSuccess: {
+  reportBug: {
     title: "Received!",
     description:
       "Thank you for reporting this bug and helping us improve the app. We appreciate your input."
   },
-  submitQuestionSuccess: {
+  submitQuestion: {
     title: "Received!",
     description:
       "Thank you for submitting your question. We’ll get back to you shortly. In the meantime, please visit our Help Center for FAQ’s and additional resources."
@@ -145,17 +145,17 @@ export const HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS = {
 }
 
 export const HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS = {
-  submitFeedbackError: {
+  submitFeedback: {
     title: "Oops!",
     description:
       "Something went wrong while submitting your feedback. Please try again."
   },
-  reportBugError: {
+  reportBug: {
     title: "Oops!",
     description:
       "Something went wrong while reporting this bug. Please try again."
   },
-  submitQuestionError: {
+  submitQuestion: {
     title: "Oops!",
     description:
       "Something went wrong while submitting your question. Please try again."
@@ -174,7 +174,7 @@ export const HelpAndSupportView = ({ style, state }: EventSettingsProps) => (
 )
 
 export type UseHelpAndSupportSettingsEnvironment = {
-  isShowingContactSection: () => Promise<boolean>
+  isMailComposerAvailable: () => Promise<boolean>
   compileLogs: () => Promise<string>
   composeEmail: (email: EmailTemplate) => Promise<EmailCompositionResult>
 }
@@ -184,7 +184,7 @@ export const useHelpAndSupportSettings = (
 ) => {
   const { data: isShowingContactSection } = useQuery(
     ["isMailComposerAvailable"],
-    async () => await env.isShowingContactSection(),
+    async () => await env.isMailComposerAvailable(),
     { initialData: true }
   )
   const open = useOpenWeblink()
@@ -192,11 +192,10 @@ export const useHelpAndSupportSettings = (
   return {
     isShowingContactSection,
     feedbackSubmitted: () => {
-      createEmail(
+      tryComposeEmail(
         env.composeEmail,
         HELP_AND_SUPPORT_EMAILS.feedbackSubmitted,
-        "submitFeedbackSuccess",
-        "submitFeedbackError"
+        "submitFeedback"
       )
     },
     bugReported: () => {
@@ -206,69 +205,63 @@ export const useHelpAndSupportSettings = (
         HELP_AND_SUPPORT_ALERTS.reportBugTapped.buttons(
           async () => {
             try {
-              const URI = await env.compileLogs()
-              createEmail(
+              await tryComposeBugReportEmail(
                 env.composeEmail,
-                HELP_AND_SUPPORT_EMAILS.bugReported(URI),
-                "reportBugSuccess",
-                "reportBugError"
+                await env.compileLogs()
               )
             } catch {
               Alert.alert(
                 HELP_AND_SUPPORT_ALERTS.compileLogError.title,
                 HELP_AND_SUPPORT_ALERTS.compileLogError.description,
-                HELP_AND_SUPPORT_ALERTS.compileLogError.buttons(() =>
-                  createEmail(
-                    env.composeEmail,
-                    HELP_AND_SUPPORT_EMAILS.bugReported(undefined),
-                    "reportBugSuccess",
-                    "reportBugError"
-                  )
-                )
+                HELP_AND_SUPPORT_ALERTS.compileLogError.buttons(() => {
+                  tryComposeBugReportEmail(env.composeEmail)
+                })
               )
             }
           },
-          async () => {
-            await createEmail(
-              env.composeEmail,
-              HELP_AND_SUPPORT_EMAILS.bugReported(undefined),
-              "reportBugSuccess",
-              "reportBugError"
-            )
-          },
+          async () => await tryComposeBugReportEmail(env.composeEmail),
           () => open(COMPILING_LOGS_INFO_URL)
         )
       )
     },
     questionSubmitted: () => {
-      createEmail(
+      tryComposeEmail(
         env.composeEmail,
         HELP_AND_SUPPORT_EMAILS.questionSubmitted,
-        "submitQuestionSuccess",
-        "submitQuestionError"
+        "submitQuestion"
       )
     }
   }
 }
 
-export const createEmail = async (
+const tryComposeBugReportEmail = async (
+  composeEmail: (email: EmailTemplate) => Promise<EmailCompositionResult>,
+  uri?: string
+) => {
+  await tryComposeEmail(
+    composeEmail,
+    HELP_AND_SUPPORT_EMAILS.bugReported(uri),
+    "reportBug"
+  )
+}
+
+const tryComposeEmail = async (
   composeEmail: (email: EmailTemplate) => Promise<EmailCompositionResult>,
   emailTemplate: EmailTemplate,
-  successAlerts: keyof typeof HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS,
-  failureAlerts: keyof typeof HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS
+  alertsKey: keyof typeof HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS
 ) => {
   try {
     const status = await composeEmail(emailTemplate)
     if (status === "success") {
       Alert.alert(
-        HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS[successAlerts].title,
-        HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS[successAlerts].description
+        HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS[alertsKey].title,
+        HELP_AND_SUPPORT_EMAIL_SUCCESS_ALERTS[alertsKey].description
       )
     }
   } catch {
     Alert.alert(
-      HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS[failureAlerts].title,
-      HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS[failureAlerts].description
+      HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS[alertsKey].title,
+      HELP_AND_SUPPORT_EMAIL_ERROR_ALERTS[alertsKey].description
     )
   }
 }

--- a/settings-boundary/HelpAndSupport.tsx
+++ b/settings-boundary/HelpAndSupport.tsx
@@ -39,7 +39,7 @@ export const HELP_AND_SUPPORT_EMAILS = {
     emailSection(
       "📝 1. Select one or more feedback topics below and provide the necessary details. (Required)"
     ),
-    emailSection("a. App functionality (How can the app help you?)"),
+    emailSection("a. App functionality (How could the app help you?)"),
     emailSection(
       "b. Creative synergy (Are the features of the app helping you progress?)"
     ),
@@ -58,11 +58,9 @@ export const HELP_AND_SUPPORT_EMAILS = {
       emailSection(
         "a. Specify the steps that it took for you to get to the bug. (Required)"
       ),
+      emailSection("b. What did you expect to happen? (Required)"),
       emailSection(
-        "b. What was the expected result supposed to be? (Required)"
-      ),
-      emailSection(
-        "📸 2. Provide any supplementary information or files related to this bug (Optional)."
+        "📸 2. Provide any supplementary information or screenshots related to the feedback above. (Optional)"
       )
     )
   },
@@ -73,7 +71,7 @@ export const HELP_AND_SUPPORT_EMAILS = {
       "❓ 1. List your question(s) and provide all relevant details. (Required)"
     ),
     emailSection(
-      "📸 2. Provide any supplementary information or files related to this question. (Optional)"
+      "📸 2. Provide any supplementary information or screenshots related to these question(s). (Optional)"
     )
   )
 }

--- a/settings-boundary/HelpAndSupport.tsx
+++ b/settings-boundary/HelpAndSupport.tsx
@@ -14,18 +14,68 @@ export const HELP_AND_SUPPORT_EMAILS = {
   feedbackSubmitted: {
     recipients: ["TIF@myspace.com"],
     subject: "App Feedback",
-    body: "Please provide detailed feedback on the app below, including suggestions for app improvements or any other feedback you have."
+    body: `\
+<strong>📝 1. Select one or more feedback topics below and provide the necessary details. (Required)</strong>
+<br>
+<br>
+<br>
+<strong>a. App functionality (How can the app help you?)</strong>
+<br>
+<br>
+<br>
+<strong>b. Creative synergy (Are the features of the app helping you progress?)</strong>
+<br>
+<br>
+<br>
+<strong>c. Other feedback (Any other general feedback you have)</strong>
+<br>
+<br>
+<br>
+<strong>📸 2. Provide any supplementary information or files related to the feedback above. (Optional)</strong>
+<br>
+<br>
+<br>
+    `,
+    isHtml: true
   },
   bugReported: (compileLogsURI?: string) => ({
     recipients: ["TIF@myspace.com"],
     subject: "App Bug Report",
-    body: "Please provide a detailed explanation of the bug below, including all relevant information pertaining to it",
-    attachments: compileLogsURI ? [compileLogsURI] : undefined
+    body: `\
+<strong>🐞 1. Briefly describe the bug and the issues it is causing in the app. (Required)</strong>
+<br>
+<br>
+<br>
+<strong>a. Specify the steps that it took for you to get to the bug. (Required)</strong>
+<br>
+<br>
+<br>
+<strong>b. What was the expected result supposed to be? (Required)</strong>
+<br>
+<br>
+<br>
+<strong>📸 2. Provide any supplementary information or files related to this bug (Optional).</strong>
+<br>
+<br>
+<br>
+    `,
+    attachments: compileLogsURI ? [compileLogsURI] : undefined,
+    isHtml: true
   }),
   questionSubmitted: {
     recipients: ["TIF@myspace.com"],
     subject: "App Question",
-    body: "Please list your question below and include all necessary details so that we can respond effectively."
+    body: `\
+<strong>❓ 1. List your question(s) and provide all relevant details. (Required)</strong>
+<br>
+<br>
+<br>
+<strong>📸 2. Provide any supplementary information or files related to this question. (Optional)</strong>
+<br>
+<br>
+<br>
+    `,
+    isHtml: true
   }
 }
 
@@ -239,7 +289,7 @@ export const HelpSectionView = ({ state }: PresetSectionProps) => {
         <SettingsNavigationLinkView
           title={"View Help Center"}
           onTapped={() => open("https://www.google.com")}
-          iconName={"information-circle"}
+          iconName="information-circle"
           iconBackgroundColor={AppStyles.black}
         />
       </SettingsCardSectionView>
@@ -249,21 +299,21 @@ export const HelpSectionView = ({ state }: PresetSectionProps) => {
           subtitle="Submit your requests below."
         >
           <SettingsNavigationLinkView
-            title={"Report a Bug"}
+            title="Report a Bug"
             onTapped={state.bugReported}
-            iconName={"bug"}
+            iconName="bug"
             iconBackgroundColor={AppStyles.black}
           />
           <SettingsNavigationLinkView
-            title={"Submit Feedback"}
+            title="Submit Feedback"
             onTapped={state.feedbackSubmitted}
-            iconName={"build"}
+            iconName="build"
             iconBackgroundColor={AppStyles.black}
           />
           <SettingsNavigationLinkView
-            title={"Submit Feedback"}
+            title="Ask Question"
             onTapped={state.questionSubmitted}
-            iconName={"help-circle"}
+            iconName="help-circle"
             iconBackgroundColor={AppStyles.black}
           />
         </SettingsCardSectionView>


### PR DESCRIPTION
Updates the emails in the help and support settings screen with formal language. For the emails, I added a little bit of HTML to make all the sections bolded.

I also did some minor cleanup on the hook code.

## Tickets

https://trello.com/c/uouGSTlN