### PR TITLE
Edit Event: Pragma Quotes

### DIFF
--- a/edit-event/PragmaQuotes.test.ts
+++ b/edit-event/PragmaQuotes.test.ts
@@ -1,0 +1,52 @@
+import { createEventQuoteType } from "./PragmaQuotes"
+
+describe("PragmaQuotes tests", () => {
+  it.each([
+    new Date("2024-08-13T16:47:59"),
+    new Date("2024-08-12T12:12:52"),
+    new Date("2024-08-11T01:22:35"),
+    new Date("2024-08-21T21:38:30")
+  ])("Should Return Weekday Quote Type when Current Date is '%s'", (date) => {
+    expect(createEventQuoteType(date)).toEqual({ key: "weekday" })
+  })
+
+  it.each([
+    new Date("2024-08-15T16:47:59"),
+    new Date("2024-08-16T12:12:52"),
+    new Date("2024-08-17T01:22:35"),
+    new Date("2024-08-23T21:38:30")
+  ])("Should Return Weekend Quote Type when Current Date is '%s'", (date) => {
+    expect(createEventQuoteType(date)).toEqual({ key: "weekend" })
+  })
+
+  it.each([
+    [new Date("2024-12-22T16:47:59"), "Christmas"],
+    [new Date("2024-12-24T12:48:17"), "Christmas"],
+    [new Date("2023-12-29T23:28:19"), "New Year's Day"],
+    [new Date("2025-02-15T23:28:19"), "Presidents Day"],
+    [new Date("2024-02-18T23:28:19"), "Presidents Day"],
+    [new Date("2025-05-24T01:22:35"), "Memorial Day"],
+    [new Date("2023-05-28T01:22:35"), "Memorial Day"]
+  ])(
+    "Should Return an Upcoming Holiday Name when Current Date is '%s'",
+    (date, holidayName) => {
+      expect(createEventQuoteType(date)).toEqual({
+        key: "upcomingHoliday",
+        name: holidayName
+      })
+    }
+  )
+
+  it.each([
+    [new Date("2024-12-25T16:47:59"), "Merry Christmas!"],
+    [new Date("2024-01-01T12:48:17"), "Happy New Year!"]
+  ])(
+    "Should Return a Holiday Greeting when Current Date is '%s'",
+    (date, holidayGreeting) => {
+      expect(createEventQuoteType(date)).toEqual({
+        key: "holiday",
+        greeting: holidayGreeting
+      })
+    }
+  )
+})

--- a/edit-event/PragmaQuotes.ts
+++ b/edit-event/PragmaQuotes.ts
@@ -1,4 +1,5 @@
 import { dayjs } from "TiFShared/lib/Dayjs"
+import { Dayjs } from "dayjs"
 
 /**
  * Returns Pragma's Quote when the user is editing an existing event through the edit form.
@@ -106,7 +107,7 @@ const datedHolidays = (year: number) => {
   return US_HOLIDAYS.map((holiday) => {
     if ("weekdayIndex" in holiday.dayOfYear) {
       return {
-        date: relativeHolidayDate(year, holiday.dayOfYear),
+        date: recurrencePatternDate(year, holiday.dayOfYear),
         ...holiday
       }
     } else {
@@ -120,7 +121,7 @@ const datedHolidays = (year: number) => {
   }).concat(upcomingNewYearsDay)
 }
 
-const relativeHolidayDate = (
+const recurrencePatternDate = (
   year: number,
   dayOfYear: {
     month: number
@@ -128,17 +129,16 @@ const relativeHolidayDate = (
     weekdayOccurence: number
   }
 ) => {
+  const isFindingNthLastOccurence = dayOfYear.weekdayOccurence < 0
   let date = dayjs(`${year}-${dayOfYear.month}-01`)
-  if (dayOfYear.weekdayOccurence < 0) {
+  if (isFindingNthLastOccurence) {
     date = date.endOf("month")
   }
+  const dateMovementOffset = isFindingNthLastOccurence ? -1 : 1
   while (date.day() !== dayOfYear.weekdayIndex) {
-    date = date.add(dayOfYear.weekdayOccurence < 0 ? -1 : 1, "day")
+    date = date.add(dateMovementOffset, "day")
   }
-  const weeksToAdd =
-    dayOfYear.weekdayOccurence +
-    -dayOfYear.weekdayOccurence / Math.abs(dayOfYear.weekdayOccurence)
-  return date.add(weeksToAdd, "week")
+  return date.add(dayOfYear.weekdayOccurence - dateMovementOffset, "week")
 }
 
 const NEW_YEARS_DAY_HOLIDAY = {
@@ -202,12 +202,17 @@ const US_HOLIDAYS = [
       weekdayOccurence: 2
     },
     name: "Indigenous Peoples' Day",
-    reeting: "Happy Indigenous Peoples' Day!"
+    greeting: "Happy Indigenous Peoples' Day!"
+  },
+  {
+    dayOfYear: { month: 10, dayOfMonth: 31 },
+    name: "Halloween",
+    greeting: "Happy Halloween!"
   },
   {
     dayOfYear: { month: 11, dayOfMonth: 11 },
     name: "Veterans Day",
-    greeting: "Veterans Day!"
+    greeting: "Happy Veterans Day!"
   },
   {
     dayOfYear: {

--- a/edit-event/PragmaQuotes.ts
+++ b/edit-event/PragmaQuotes.ts
@@ -156,7 +156,7 @@ const US_HOLIDAYS = [
       weekdayOccurence: 3
     },
     name: "Martin Luther King, Jr. Day",
-    greeting: "Happy MLK Jr. Day!"
+    greeting: "Happy Martin Luther King, Jr Day!"
   },
   {
     dayOfYear: {
@@ -166,6 +166,21 @@ const US_HOLIDAYS = [
     },
     name: "Presidents Day",
     greeting: "Happy Presidents Day!"
+  },
+  {
+    dayOfYear: { month: 2, dayOfMonth: 14 },
+    name: "Valentine's Day",
+    greeting: "Happy Valentine's Day!"
+  },
+  {
+    dayOfYear: { month: 3, dayOfMonth: 17 },
+    name: "St. Patrick's Day",
+    greeting: "Happy St. Patrick's Day!"
+  },
+  {
+    dayOfYear: { month: 5, dayOfMonth: 5 },
+    name: "Cinco de Mayo",
+    greeting: "Happy Cinco de Mayo!"
   },
   {
     dayOfYear: {

--- a/edit-event/PragmaQuotes.ts
+++ b/edit-event/PragmaQuotes.ts
@@ -101,9 +101,7 @@ type USHoliday = {
 const datedHolidays = (year: number) => {
   const upcomingNewYearsDay = {
     date: dayjs(`${year + 1}-01-01`),
-    name: "New Year's Day",
-    dayOfYear: { month: 1, dayOfMonth: 1 },
-    greeting: "Happy New Year!"
+    ...NEW_YEARS_DAY_HOLIDAY
   }
   return US_HOLIDAYS.map((holiday) => {
     if ("weekdayIndex" in holiday.dayOfYear) {
@@ -143,12 +141,14 @@ const relativeHolidayDate = (
   return date.add(weeksToAdd, "week")
 }
 
+const NEW_YEARS_DAY_HOLIDAY = {
+  dayOfYear: { month: 1, dayOfMonth: 1 },
+  name: "New Year's Day",
+  greeting: "Happy New Year!"
+}
+
 const US_HOLIDAYS = [
-  {
-    dayOfYear: { month: 1, dayOfMonth: 1 },
-    name: "New Year's Day",
-    greeting: "Happy New Year!"
-  },
+  NEW_YEARS_DAY_HOLIDAY,
   {
     dayOfYear: {
       month: 1,

--- a/edit-event/PragmaQuotes.ts
+++ b/edit-event/PragmaQuotes.ts
@@ -77,7 +77,7 @@ export const createEventQuoteType = (
   if (upcomingHoliday) {
     return { key: "upcomingHoliday", name: upcomingHoliday.name }
   }
-  return { key: date.day() < 4 ? "weekday" : "weekend" }
+  return { key: date.day() < WeekDayIndex.Thursday ? "weekday" : "weekend" }
 }
 
 enum WeekDayIndex {
@@ -137,10 +137,10 @@ const relativeHolidayDate = (
   while (date.day() !== dayOfYear.weekdayIndex) {
     date = date.add(dayOfYear.weekdayOccurence < 0 ? -1 : 1, "day")
   }
-  const zeroIndexedOccurence =
+  const weeksToAdd =
     dayOfYear.weekdayOccurence +
     -dayOfYear.weekdayOccurence / Math.abs(dayOfYear.weekdayOccurence)
-  return date.add(zeroIndexedOccurence, "week")
+  return date.add(weeksToAdd, "week")
 }
 
 const US_HOLIDAYS = [


### PR DESCRIPTION
We've talked about adding a bit of personality on the edit event screen in the form of Pragma (accompanying character) asking a question (eg. "What event do you want to create?") instead of saying a generic "Create Event".

This PR implements a random generation of quotes that they can say depending on whether you're creating a new event or editing an existing event.

## Editing

For editing, I decided to keep it simple and only return a random quote in a list of 3 quotes. When a user is editing an event, it usually occurs due to some change in external circumstances, and their not likely to care much that Christmas is coming up, so I don't think they need to be too encouraging.

## Creating

There are 4 kinds of quotes that Pragma can say when creating an event.
1. Start of the week motivation.
2. Weekend motivation.
3. Upcoming Holiday motivation.
4. Holiday motivation.

The 3rd case occurs when a holiday is less than 3 days away, but not on the actual holiday date. The 4th case occurs on the day of the holiday, and will greet the user as such (eg. "Merry Christmas!"). I've tried to remove holidays deemed controversial, or that have too complex of a recurrence pattern. All holidays are US holidays.

The 1st case occurs on any day of the week before Thursday, and the 2nd case occurs from Thursday onwards.