### PR TITLE
IGNORE_BUILD: Conditionally pass build step

### DIFF
--- a/.github/workflows/auto-pass.yml
+++ b/.github/workflows/auto-pass.yml
@@ -1,0 +1,17 @@
+name: Auto Pass
+run-name: Auto Pass Setup
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+      - development
+
+jobs:
+  build:
+    if: github.actor == 'roswaaltifbot' || startsWith(github.event.pull_request.title, 'IGNORE_BUILD')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: echo "Skipping build action for ${{ github.actor }} or PR title starting with IGNORE_BUILD"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   setup_and_lint:
+    if: github.actor != 'roswaaltifbot' && !startsWith(github.event.pull_request.title, 'IGNORE_BUILD')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -43,6 +44,7 @@ jobs:
         run: npm run staged-lint
 
   unit_tests:
+    if: github.actor != 'roswaaltifbot' && !startsWith(github.event.pull_request.title, 'IGNORE_BUILD')
     needs: setup_and_lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -65,6 +67,7 @@ jobs:
         run: npm run test:ci
 
   build:
+    if: github.actor != 'roswaaltifbot' && !startsWith(github.event.pull_request.title, 'IGNORE_BUILD')
     needs: unit_tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For roswaal PR's or any other PR that is unimportant, we want the option to skip the long build steps.

TASK_UNTRACKED