### PR TITLE
Event Arrivals: Unconditionally Subscribe to Geofencer

### DIFF
--- a/arrival-tracking/Tracker.test.ts
+++ b/arrival-tracking/Tracker.test.ts
@@ -14,8 +14,7 @@ import { repeatElements } from "TiFShared/lib/Array"
 import {
   addTestArrivals,
   expectOrderInsensitiveEventArrivals,
-  regionWithArrivalData,
-  removeTestArrivals
+  regionWithArrivalData
 } from "./TestHelpers"
 import { EventArrivals } from "./Arrivals"
 
@@ -31,7 +30,10 @@ describe("EventArrivalsTracker tests", () => {
     testGeofencer,
     performArrivalOperation
   )
-  beforeEach(() => testGeofencer.reset())
+  beforeEach(() => {
+    testGeofencer.reset()
+    tracker.startTracking()
+  })
   afterEach(() => {
     performArrivalOperation.mockReset()
   })
@@ -56,11 +58,6 @@ describe("EventArrivalsTracker tests", () => {
     )
   })
 
-  test("does not subscribe to geofencing updates when no tracked arrivals", async () => {
-    await tracker.startTracking()
-    expect(testGeofencer.hasSubscriber).toEqual(false)
-  })
-
   test("subscribes to geofencing updates when new instance detects previously tracked arrivals", async () => {
     await addTestArrivals(tracker, mockEventArrival())
     tracker.stopTracking()
@@ -70,16 +67,8 @@ describe("EventArrivalsTracker tests", () => {
       testGeofencer,
       jest.fn()
     )
-    await tracker2.startTracking()
+    tracker2.startTracking()
     expect(testGeofencer.hasSubscriber).toEqual(true)
-  })
-
-  test("unsubscribes from tracker when removing all tracked arrivals", async () => {
-    const arrival = mockEventArrival()
-    await addTestArrivals(tracker, arrival)
-    expect(testGeofencer.hasSubscriber).toEqual(true)
-    await removeTestArrivals(tracker, arrival.eventId)
-    expect(testGeofencer.hasSubscriber).toEqual(false)
   })
 
   test("handle geofencing update, does arrived operation for all arrivals when entering region", async () => {

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -66,7 +66,7 @@ export class EventArrivalsTracker {
         this.geofencer.replaceGeofencedRegions(arrivals.regions),
         this.storage.replace(arrivals)
       ])
-      this.updateGeofencingSubscription(arrivals)
+      // this.updateGeofencingSubscription(arrivals)
       this.callbacks.send(arrivals)
     } catch (e) {
       log.error("Failed to replace regions", { message: e.message })
@@ -84,10 +84,13 @@ export class EventArrivalsTracker {
   }
 
   /**
-   * Starts tracking if there is at least 1 upcoming event arrival.
+   * Starts tracking arrivals by subscribing to the underlying geofencer.
    */
-  async startTracking() {
-    this.updateGeofencingSubscription(await this.storage.current())
+  startTracking() {
+    this.stopTracking()
+    this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
+      this.handleGeofencingUpdate(update)
+    })
   }
 
   /**
@@ -123,14 +126,12 @@ export class EventArrivalsTracker {
     await this.replaceArrivals(await work(await this.storage.current()))
   }
 
-  private updateGeofencingSubscription(arrivals: EventArrivals) {
-    this.stopTracking()
-    if (arrivals.regions.length > 0) {
-      this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
-        this.handleGeofencingUpdate(update)
-      })
-    }
-  }
+  // private updateGeofencingSubscription(arrivals: EventArrivals) {
+  //   this.stopTracking()
+  //   this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
+  //     this.handleGeofencingUpdate(update)
+  //   })
+  // }
 
   private async handleGeofencingUpdate(update: EventArrivalGeofencedRegion) {
     const upcomingArrivals = await this.performArrivalsOperation(

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -66,7 +66,6 @@ export class EventArrivalsTracker {
         this.geofencer.replaceGeofencedRegions(arrivals.regions),
         this.storage.replace(arrivals)
       ])
-      // this.updateGeofencingSubscription(arrivals)
       this.callbacks.send(arrivals)
     } catch (e) {
       log.error("Failed to replace regions", { message: e.message })

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -126,13 +126,6 @@ export class EventArrivalsTracker {
     await this.replaceArrivals(await work(await this.storage.current()))
   }
 
-  // private updateGeofencingSubscription(arrivals: EventArrivals) {
-  //   this.stopTracking()
-  //   this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
-  //     this.handleGeofencingUpdate(update)
-  //   })
-  // }
-
   private async handleGeofencingUpdate(update: EventArrivalGeofencedRegion) {
     const upcomingArrivals = await this.performArrivalsOperation(
       update,

--- a/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
+++ b/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
@@ -41,6 +41,7 @@ describe("EventArrivalsTrackerRegionMonitor tests", () => {
   beforeEach(() => {
     performArrivalsOperation.mockReset()
     geofencer.reset()
+    tracker.startTracking()
     monitor = new EventArrivalsTrackerRegionMonitor(
       tracker,
       createForegroundMonitor()


### PR DESCRIPTION
Makes `EventArrivalsTracker.startTracking` unconditionally subscribe to the geofencer no matter how many arrivals are stored. This allows `startTracking` to be made into a synchronous function, which is necessary because we need to call it before calling `ExpoEventArrivalsGeofencer.shared.defineTask()` to not miss geofencing updates in the background.