### PR TITLE
Event Arrivals: Deduplicate Arrival Operations

### DIFF
--- a/arrival-tracking/Storage.test.ts
+++ b/arrival-tracking/Storage.test.ts
@@ -42,5 +42,27 @@ describe("UpcomingArrivals tests", () => {
       expectOrderInsensitiveEventArrivals(await storage.current(), arrivals)
       expectOrderInsensitiveEventArrivals(await baseStorage.current(), arrivals)
     })
+
+    it("should use base storage for detecting arrival when permissions are enabled", async () => {
+      const storage = requireBackgroundLocationPermissions(
+        baseStorage,
+        jest.fn().mockResolvedValue(true)
+      )
+      const region = { ...mockEventArrivalRegion(), hasArrived: true }
+      const arrivals = EventArrivals.fromRegions([region])
+      await storage.replace(arrivals)
+      expect(await storage.hasArrivedAt(region)).toEqual(true)
+    })
+
+    it("should return false for detecting arrival when permissions are disabled", async () => {
+      const storage = requireBackgroundLocationPermissions(
+        baseStorage,
+        jest.fn().mockResolvedValue(false)
+      )
+      const region = { ...mockEventArrivalRegion(), hasArrived: true }
+      const arrivals = EventArrivals.fromRegions([region])
+      await storage.replace(arrivals)
+      expect(await storage.hasArrivedAt(region)).toEqual(false)
+    })
   })
 })

--- a/arrival-tracking/Tracker.test.ts
+++ b/arrival-tracking/Tracker.test.ts
@@ -14,8 +14,7 @@ import { repeatElements } from "TiFShared/lib/Array"
 import {
   addTestArrivals,
   expectOrderInsensitiveEventArrivals,
-  regionWithArrivalData,
-  removeTestArrivals
+  regionWithArrivalData
 } from "./TestHelpers"
 import { EventArrivals } from "./Arrivals"
 
@@ -31,7 +30,10 @@ describe("EventArrivalsTracker tests", () => {
     testGeofencer,
     performArrivalOperation
   )
-  beforeEach(() => testGeofencer.reset())
+  beforeEach(() => {
+    testGeofencer.reset()
+    tracker.startTracking()
+  })
   afterEach(() => {
     performArrivalOperation.mockReset()
   })
@@ -56,11 +58,6 @@ describe("EventArrivalsTracker tests", () => {
     )
   })
 
-  test("does not subscribe to geofencing updates when no tracked arrivals", async () => {
-    await tracker.startTracking()
-    expect(testGeofencer.hasSubscriber).toEqual(false)
-  })
-
   test("subscribes to geofencing updates when new instance detects previously tracked arrivals", async () => {
     await addTestArrivals(tracker, mockEventArrival())
     tracker.stopTracking()
@@ -70,16 +67,8 @@ describe("EventArrivalsTracker tests", () => {
       testGeofencer,
       jest.fn()
     )
-    await tracker2.startTracking()
+    tracker2.startTracking()
     expect(testGeofencer.hasSubscriber).toEqual(true)
-  })
-
-  test("unsubscribes from tracker when removing all tracked arrivals", async () => {
-    const arrival = mockEventArrival()
-    await addTestArrivals(tracker, arrival)
-    expect(testGeofencer.hasSubscriber).toEqual(true)
-    await removeTestArrivals(tracker, arrival.eventId)
-    expect(testGeofencer.hasSubscriber).toEqual(false)
   })
 
   test("handle geofencing update, does arrived operation for all arrivals when entering region", async () => {

--- a/arrival-tracking/Tracker.test.ts
+++ b/arrival-tracking/Tracker.test.ts
@@ -175,6 +175,15 @@ describe("EventArrivalsTracker tests", () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
+  it("should only perform the arrivals operatio when arrival status changes for region", async () => {
+    const arrival = { ...mockEventArrival(), hasArrived: true }
+    await addTestArrivals(tracker, arrival)
+    testGeofencer.sendUpdate(arrival)
+    await verifyNeverOccurs(() => {
+      expect(performArrivalOperation).toHaveBeenCalled()
+    })
+  })
+
   const expectTrackedArrivals = async (arrivals: EventArrivals) => {
     await waitFor(async () => {
       const trackedArrivals = await tracker.trackedArrivals()

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -126,6 +126,8 @@ export class EventArrivalsTracker {
   }
 
   private async handleGeofencingUpdate(update: EventArrivalGeofencedRegion) {
+    const hasArrived = await this.storage.hasArrivedAt(update)
+    if (hasArrived === update.hasArrived) return
     const upcomingArrivals = await this.performArrivalsOperation(
       update,
       update.hasArrived ? "arrived" : "departed"

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -66,7 +66,7 @@ export class EventArrivalsTracker {
         this.geofencer.replaceGeofencedRegions(arrivals.regions),
         this.storage.replace(arrivals)
       ])
-      this.updateGeofencingSubscription(arrivals)
+      // this.updateGeofencingSubscription(arrivals)
       this.callbacks.send(arrivals)
     } catch (e) {
       log.error("Failed to replace regions", { message: e.message })
@@ -84,10 +84,13 @@ export class EventArrivalsTracker {
   }
 
   /**
-   * Starts tracking if there is at least 1 upcoming event arrival.
+   * Starts tracking arrivals by subscribing to the underlying geofencer.
    */
-  async startTracking() {
-    this.updateGeofencingSubscription(await this.storage.current())
+  startTracking() {
+    this.stopTracking()
+    this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
+      this.handleGeofencingUpdate(update)
+    })
   }
 
   /**
@@ -123,14 +126,12 @@ export class EventArrivalsTracker {
     await this.replaceArrivals(await work(await this.storage.current()))
   }
 
-  private updateGeofencingSubscription(arrivals: EventArrivals) {
-    this.stopTracking()
-    if (arrivals.regions.length > 0) {
-      this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
-        this.handleGeofencingUpdate(update)
-      })
-    }
-  }
+  // private updateGeofencingSubscription(arrivals: EventArrivals) {
+  //   this.stopTracking()
+  //   this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
+  //     this.handleGeofencingUpdate(update)
+  //   })
+  // }
 
   private async handleGeofencingUpdate(update: EventArrivalGeofencedRegion) {
     const upcomingArrivals = await this.performArrivalsOperation(

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -66,7 +66,6 @@ export class EventArrivalsTracker {
         this.geofencer.replaceGeofencedRegions(arrivals.regions),
         this.storage.replace(arrivals)
       ])
-      // this.updateGeofencingSubscription(arrivals)
       this.callbacks.send(arrivals)
     } catch (e) {
       log.error("Failed to replace regions", { message: e.message })

--- a/arrival-tracking/Tracker.ts
+++ b/arrival-tracking/Tracker.ts
@@ -126,13 +126,6 @@ export class EventArrivalsTracker {
     await this.replaceArrivals(await work(await this.storage.current()))
   }
 
-  // private updateGeofencingSubscription(arrivals: EventArrivals) {
-  //   this.stopTracking()
-  //   this.unsubscribeFromGeofencing = this.geofencer.onUpdate((update) => {
-  //     this.handleGeofencingUpdate(update)
-  //   })
-  // }
-
   private async handleGeofencingUpdate(update: EventArrivalGeofencedRegion) {
     const upcomingArrivals = await this.performArrivalsOperation(
       update,

--- a/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
+++ b/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
@@ -41,6 +41,7 @@ describe("EventArrivalsTrackerRegionMonitor tests", () => {
   beforeEach(() => {
     performArrivalsOperation.mockReset()
     geofencer.reset()
+    tracker.startTracking()
     monitor = new EventArrivalsTrackerRegionMonitor(
       tracker,
       createForegroundMonitor()


### PR DESCRIPTION
There was a complex infinite loop that occurred with the `EventArrivalsTracker` which would cause the background task to run repeatedly, and spam requests to the backend. For brevity, here is the description of the loop from slack.

![Screenshot 2024-08-25 at 7 24 55 PM](https://github.com/user-attachments/assets/bfacb621-5ba2-422c-87d4-9c7a2174d5f1)

The fix is to deduplicate arrival operations when the updated `hasArrived` matches the stored `hasArrived`. I added a new method requirement to the `EventArrivalsStorage` to return the `hasArrived` value for a particular stored region, and then called this inside `handleGeofencingEvent` in `EventArrivalsTracker`.

## Tickets

https://trello.com/c/28WJIizX