### PR TITLE
Arrivals: Remove Buffer Time from `ForegroundEventRegionMonitor`

### DIFF
--- a/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
+++ b/arrival-tracking/region-monitoring/EventArrivalsTrackerRegionMonitor.test.ts
@@ -9,7 +9,6 @@ import { SQLiteEventArrivalsStorage } from "../Storage"
 import { TestEventArrivalsGeofencer } from "../geofencing/TestGeofencer"
 import { EventArrivalsTrackerRegionMonitor } from "./EventArrivalsTrackerRegionMonitor"
 import { ForegroundEventRegionMonitor } from "./ForegroundRegionMonitor"
-import { advanceByForegroundMonitorBufferTime } from "./TestHelpers"
 import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
 import { addTestArrivals, removeTestArrivals } from "../TestHelpers"
@@ -29,7 +28,6 @@ describe("EventArrivalsTrackerRegionMonitor tests", () => {
     return new ForegroundEventRegionMonitor(async (callback) => {
       sendForegroundLocationUpdate = (coordinate) => {
         callback(coordinate)
-        advanceByForegroundMonitorBufferTime()
       }
       return { remove: jest.fn() }
     })

--- a/arrival-tracking/region-monitoring/TestHelpers.ts
+++ b/arrival-tracking/region-monitoring/TestHelpers.ts
@@ -1,9 +1,0 @@
-import { ForegroundEventRegionMonitor } from "./ForegroundRegionMonitor"
-
-export const advanceByForegroundMonitorBufferTime = (
-  multiplier: number = 1
-) => {
-  jest.advanceTimersByTime(
-    ForegroundEventRegionMonitor.BUFFER_TIME * multiplier
-  )
-}


### PR DESCRIPTION
When dealing with foreground location updates in `ForegroundEventRegionMonitor`, we buffered any location update by 20 seconds. The original intent of this behavior was to prevent the UI from being spammed with many updates if the user was constantly walking in and out of the arrival radius.

Based on our field tests, this behavior caused many inaccuracies compared to the results of `EventArrivalsTrackerRegionMonitor`. At first, I wanted just to reduce the delay, however, I think it's best that we remove it entirely for the following reasons:
1. Foreground location updates don't happen as often as we think. Even with the highest accuracy, you have to walk quite far (usually ~1 minute in any direction) before a new location is delivered to the app.
2. Even if the above weren't true, there wasn't any possible spamming of UI updates due to the nature of physical movement. In other words, overengineering.

TASK_UNTRACKED