### PR TITLE
Better Primary Button

### DIFF
--- a/.storybook/components/Buttons/Buttons.stories.tsx
+++ b/.storybook/components/Buttons/Buttons.stories.tsx
@@ -31,17 +31,18 @@ export const Basic: ButtonsStory = () => (
           <View style={{ marginVertical: 16 }} />
           <PrimaryButton>Hello World</PrimaryButton>
           <View style={{ marginVertical: 16 }} />
-          <PrimaryButton title="Hello World with title prop" />
+          <PrimaryButton>Hello World with title prop</PrimaryButton>
           <View style={{ marginVertical: 16 }} />
-          <PrimaryButton title="Disabled" disabled />
+          <PrimaryButton disabled>Disabled</PrimaryButton>
           <View style={{ marginVertical: 16 }} />
           <PrimaryButton
-            title="Max Width"
             style={{
               width: "100%",
               backgroundColor: AppStyles.orange.toString()
             }}
-          />
+          >
+            Max Width
+          </PrimaryButton>
           <View style={{ marginVertical: 16 }} />
           <SecondaryOutlinedButton>Hello World</SecondaryOutlinedButton>
           <View style={{ marginVertical: 16 }} />

--- a/.storybook/components/SettingsScreen/EventSettingsDurations.stories.tsx
+++ b/.storybook/components/SettingsScreen/EventSettingsDurations.stories.tsx
@@ -75,11 +75,12 @@ const DurationScreenTest = () => {
   return (
     <SafeAreaView edges={["bottom"]}>
       <PrimaryButton
-        title="Add Test Buttons"
         onPress={() =>
           update({ eventPresetDurations: [600, 1200, 1800, 2400, 4800, 7200] })
         }
-      />
+      >
+        Add Test Buttons
+      </PrimaryButton>
       <EventDurationView />
     </SafeAreaView>
   )

--- a/auth-boundary/AuthLayout.tsx
+++ b/auth-boundary/AuthLayout.tsx
@@ -83,7 +83,6 @@ export const AuthLayoutView = ({
           {footer}
           <Animated.View layout={TiFDefaultLayoutTransition}>
             <PrimaryButton
-              title={callToActionTitle}
               style={[
                 styles.callToActionButton,
                 { opacity: isCallToActionDisabled ? 0.5 : 1 }
@@ -91,7 +90,9 @@ export const AuthLayoutView = ({
               disabled={isCallToActionDisabled}
               onPress={onCallToActionTapped}
               accessibilityLabel={callToActionTitle}
-            />
+            >
+              {callToActionTitle}
+            </PrimaryButton>
           </Animated.View>
         </View>
       </KeyboardAvoidingView>
@@ -125,17 +126,17 @@ export const AuthFormView = <Submission extends { status: "invalid" }>({
   submissionTitle,
   ...props
 }: AuthFormProps<Submission>) => (
-    <AuthLayoutView
-      callToActionTitle={submissionTitle}
-      isCallToActionDisabled={submission.status !== "submittable"}
-      onCallToActionTapped={() => {
-        if (submission.status === "submittable") {
-          submission.submit()
-        }
-      }}
-      {...props}
-    />
-  )
+  <AuthLayoutView
+    callToActionTitle={submissionTitle}
+    isCallToActionDisabled={submission.status !== "submittable"}
+    onCallToActionTapped={() => {
+      if (submission.status === "submittable") {
+        submission.submit()
+      }
+    }}
+    {...props}
+  />
+)
 
 const styles = StyleSheet.create({
   container: {

--- a/components/Buttons.tsx
+++ b/components/Buttons.tsx
@@ -15,14 +15,6 @@ type ContentStyle<Children extends ReactNode> = Children extends string | number
   ? { contentStyle?: StyleProp<TextStyle> }
   : { contentStyle?: StyleProp<ViewStyle> }
 
-export type LegacyButtonProps = {
-  /**
-   * @deprecated Use `children` to render just text instead.
-   */
-  title: string
-  contentStyle?: StyleProp<TextStyle>
-} & Omit<TouchableOpacityProps, "children">
-
 /**
  * Props for a button.
  */

--- a/components/Buttons.tsx
+++ b/components/Buttons.tsx
@@ -1,6 +1,5 @@
 import { Headline } from "@components/Text"
 import { AppStyles } from "@lib/AppColorStyle"
-import { useFontScale } from "@lib/Fonts"
 import React, { ReactNode } from "react"
 import {
   StyleProp,
@@ -26,14 +25,9 @@ export type LegacyButtonProps = {
 
 /**
  * Props for a button.
- *
- * If you just want a text button, you can either pass in a `title` prop or use `children`.
- * In this case, always use the `children` prop as `title` is only kept around for legacy reasons.
  */
-export type ButtonProps<Children extends ReactNode> = (
-  | LegacyButtonProps
-  | (TouchableOpacityProps & ContentStyle<Children>)
-) & {
+export type ButtonProps<Children extends ReactNode> = (TouchableOpacityProps &
+  ContentStyle<Children>) & {
   maximumFontSizeMultiplier?: number
 }
 
@@ -98,25 +92,9 @@ const BaseButton = <Children extends ReactNode>({
   maximumFontSizeMultiplier,
   ...props
 }: ButtonProps<Children>) => (
-  <TouchableOpacity
-    {...props}
-    style={[
-      style,
-      {
-        height:
-          48 * useFontScale({ maximumScaleFactor: maximumFontSizeMultiplier })
-      }
-    ]}
-  >
-    {"title" in props ? (
-      <Headline
-        maxFontSizeMultiplier={maximumFontSizeMultiplier}
-        style={props.contentStyle}
-      >
-        {props.title}
-      </Headline>
-    ) : typeof props.children === "string" ||
-      typeof props.children === "number" ? (
+  <TouchableOpacity {...props} style={style}>
+    {typeof props.children === "string" ||
+    typeof props.children === "number" ? (
       <Headline
         maxFontSizeMultiplier={maximumFontSizeMultiplier}
         style={props.contentStyle}
@@ -135,7 +113,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     borderRadius: 12,
-    paddingHorizontal: 16
+    padding: 16
   },
   primaryContent: {
     color: "white"

--- a/content-reporting-boundary/Success.tsx
+++ b/content-reporting-boundary/Success.tsx
@@ -31,11 +31,9 @@ export const ReportSuccessView = ({
       </BodyText>
     </View>
     <View style={styles.doneButtonContainer}>
-      <PrimaryButton
-        title="Done"
-        onPress={onDoneTapped}
-        style={styles.doneButton}
-      />
+      <PrimaryButton onPress={onDoneTapped} style={styles.doneButton}>
+        Done
+      </PrimaryButton>
     </View>
   </SafeAreaView>
 )

--- a/explore-events-boundary/ExploreEvents.tsx
+++ b/explore-events-boundary/ExploreEvents.tsx
@@ -114,7 +114,7 @@ const useExploreEventsRegion = (initialCenter: ExploreEventsInitialCenter) => {
   const exploreRegion =
     userRegion === "loading"
       ? pannedRegion
-      : pannedRegion ?? userRegion ?? SAN_FRANCISCO_DEFAULT_REGION
+      : (pannedRegion ?? userRegion ?? SAN_FRANCISCO_DEFAULT_REGION)
   return { region: exploreRegion, panToRegion: setPannedRegion }
 }
 
@@ -256,11 +256,9 @@ const ErrorView = ({ onRetried }: ErrorProps) => (
     <BodyText style={styles.emptyEventsText}>
       An error occurred, please try again.
     </BodyText>
-    <PrimaryButton
-      style={styles.tryAgainButton}
-      title="Try Again"
-      onPress={onRetried}
-    />
+    <PrimaryButton style={styles.tryAgainButton} onPress={onRetried}>
+      Try Again
+    </PrimaryButton>
   </View>
 )
 


### PR DESCRIPTION
Increases the height of `PrimaryButton` so that it stands out more as a CTA. Additionally, I also removed the legacy `title` prop as nothing was using it anymore.
![Simulator Screenshot - iPhone 16 Pro - 2024-10-11 at 13 57 45](https://github.com/user-attachments/assets/8375eade-b049-4e22-b7e5-34944a065363)
