### PR TITLE
Friend Request: Generic Friend Request View

### DIFF
--- a/event-details-boundary/Details.tsx
+++ b/event-details-boundary/Details.tsx
@@ -28,7 +28,7 @@ import { EventID, EventWhenBlockedByHost } from "TiFShared/domain-models/Event"
  * calculating accurate countdown times.
  */
 export const loadEventDetails = async (
-  eventId: number,
+  eventId: EventID,
   tifAPI: TiFAPI
 ): Promise<EventDetailsLoadingResult> => {
   const resp = await tifAPI.eventDetails({ params: { eventId } })

--- a/lib/utils/Form.ts
+++ b/lib/utils/Form.ts
@@ -11,7 +11,7 @@ export const useReactHookFormContext = <T extends FieldValues>() => {
   if (!formContext) {
     throw new Error(`
     Attempted to use a component that required a form context, but none was available.
-          
+
     To fix this, make sure to wrap the component with a FormProvider from react-hook-form.
     `)
   }
@@ -45,27 +45,29 @@ export const useFormSubmission = <
   SubmissionResult,
   InvalidValidationResult extends { status: "invalid" }
 >(
-    submit: (args: SubmissionArgs) => Promise<SubmissionResult>,
-    validate: (
+  submit: (args: SubmissionArgs) => Promise<SubmissionResult>,
+  validate: (
     submissionMutation: FormSubmissionMutation<SubmissionResult, SubmissionArgs>
   ) => FormValidationResult<InvalidValidationResult, SubmissionArgs>,
-    options?: MutationHookOptions<SubmissionResult, SubmissionArgs>
-  ) => {
+  options?: MutationHookOptions<SubmissionResult, SubmissionArgs>
+) => {
   const submissionMutation = useMutation(submit, options)
   const validationResult = validate(submissionMutation)
 
   if (validationResult.status === "invalid") {
-    return validationResult
+    return { result: submissionMutation.data, ...validationResult }
   }
 
   if (submissionMutation.isLoading) {
     return {
+      result: submissionMutation.data,
       status: "submitting",
       submissionValues: validationResult.submissionValues
     } as const
   }
 
   return {
+    result: submissionMutation.data,
     ...validationResult,
     submit: () => {
       submissionMutation.mutate(validationResult.submissionValues)

--- a/user/FriendRequest.test.tsx
+++ b/user/FriendRequest.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react-native"
 import { UserHandle, UserRelationsStatus } from "TiFShared/domain-models/User"
-import { ALERTS, useFriendRequest } from "./FriendRequest"
+import {
+  ALERTS,
+  FriendRequestProvider,
+  useFriendRequest
+} from "./FriendRequest"
 import { uuidString } from "@lib/utils/UUID"
 import { faker } from "@faker-js/faker"
 import { TestQueryClientProvider } from "@test-helpers/ReactQuery"
@@ -89,13 +93,14 @@ describe("FriendRequest tests", () => {
         () => {
           return useFriendRequest({
             user: { ...TEST_USER, relationStatus },
-            sendFriendRequest,
             onSuccess
           })
         },
         {
           wrapper: ({ children }) => (
-            <TestQueryClientProvider>{children}</TestQueryClientProvider>
+            <FriendRequestProvider sendFriendRequest={sendFriendRequest}>
+              <TestQueryClientProvider>{children}</TestQueryClientProvider>
+            </FriendRequestProvider>
           )
         }
       )

--- a/user/FriendRequest.test.tsx
+++ b/user/FriendRequest.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native"
+import { UserHandle, UserRelationsStatus } from "TiFShared/domain-models/User"
+import { ALERTS, useFriendRequest } from "./FriendRequest"
+import { uuidString } from "@lib/utils/UUID"
+import { faker } from "@faker-js/faker"
+import { TestQueryClientProvider } from "@test-helpers/ReactQuery"
+import { captureAlerts } from "@test-helpers/Alerts"
+
+describe("FriendRequest tests", () => {
+  describe("UseFriendRequest tests", () => {
+    const sendFriendRequest = jest.fn()
+    const onSuccess = jest.fn()
+
+    beforeEach(() => jest.resetAllMocks())
+
+    const TEST_USER = {
+      id: uuidString(),
+      name: faker.name.firstName(),
+      handle: UserHandle.sillyBitchell,
+      relationStatus: "not-friends"
+    }
+
+    it.each([
+      "blocked-them",
+      "blocked-you",
+      "friends",
+      "current-user",
+      "friend-request-sent"
+    ])(
+      "should not allow sending a friend request when status is %s",
+      (status: UserRelationsStatus) => {
+        const { result } = renderUseFriendRequest(status)
+        expect(result.current.submission.status).toEqual("invalid")
+      }
+    )
+
+    it("should call the onSuccess callback with the updated relation status when request sent successfully", async () => {
+      const { result } = renderUseFriendRequest()
+      sendFriendRequest.mockResolvedValueOnce("friend-request-sent")
+      expect(result.current.updatedStatus).toEqual(undefined)
+      act(() => (result.current.submission as any).submit())
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith("friend-request-sent")
+      })
+      expect(sendFriendRequest).toHaveBeenCalledWith(TEST_USER.id)
+      expect(result.current.updatedStatus).toEqual("friend-request-sent")
+    })
+
+    it.each(["user-not-found", "blocked-you"])(
+      "should present an error alert for %s",
+      async (status: "user-not-found" | "blocked-you") => {
+        const { result } = renderUseFriendRequest()
+        sendFriendRequest.mockResolvedValueOnce(status)
+        expect(result.current.updatedStatus).toEqual(undefined)
+        act(() => (result.current.submission as any).submit())
+
+        await waitFor(() => {
+          expect(alertPresentationSpy).toHaveBeenPresentedWith(
+            ALERTS[status](TEST_USER)
+          )
+        })
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(result.current.updatedStatus).toEqual(undefined)
+      }
+    )
+
+    it("should present a generic error alert for an error", async () => {
+      const { result } = renderUseFriendRequest()
+      sendFriendRequest.mockRejectedValueOnce(new Error())
+      expect(result.current.updatedStatus).toEqual(undefined)
+      act(() => (result.current.submission as any).submit())
+
+      await waitFor(() => {
+        expect(alertPresentationSpy).toHaveBeenPresentedWith(
+          ALERTS.genericError
+        )
+      })
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(result.current.updatedStatus).toEqual(undefined)
+    })
+
+    const { alertPresentationSpy } = captureAlerts()
+
+    const renderUseFriendRequest = (
+      relationStatus: UserRelationsStatus = "not-friends"
+    ) => {
+      return renderHook(
+        () => {
+          return useFriendRequest({
+            user: { ...TEST_USER, relationStatus },
+            sendFriendRequest,
+            onSuccess
+          })
+        },
+        {
+          wrapper: ({ children }) => (
+            <TestQueryClientProvider>{children}</TestQueryClientProvider>
+          )
+        }
+      )
+    }
+  })
+})

--- a/user/FriendRequest.tsx
+++ b/user/FriendRequest.tsx
@@ -1,0 +1,127 @@
+import { TextToastView } from "@components/common/Toasts"
+import { AlertsObject, presentAlert } from "@lib/Alerts"
+import { useFormSubmission } from "@lib/utils/Form"
+import {
+  UserHandle,
+  UserID,
+  UserRelationsStatus
+} from "TiFShared/domain-models/User"
+import { ReactNode } from "react"
+import { View, ViewStyle, StyleProp } from "react-native"
+
+export const ALERTS = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "user-not-found": (
+    user: Omit<FriendRequestUser, "relationStatus" | "id">
+  ) => ({
+    title: "User Not Found",
+    description: `${user.name} (${user.handle}) does not seem to exist.`
+  }),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "blocked-you": (user: Omit<FriendRequestUser, "relationStatus" | "id">) => ({
+    title: "You've Been Blocked",
+    description: `It seems that ${user.name} (${user.handle}) has blocked you. Try getting on better terms with them before becoming friends.`
+  }),
+  genericError: {
+    title: "Uh Oh!",
+    description: "It seems that something has gone wrong. Please try again."
+  }
+} satisfies AlertsObject
+
+export type FriendRequestUser = {
+  id: UserID
+  name: string
+  handle: UserHandle
+  relationStatus: UserRelationsStatus
+}
+
+export type UseFriendRequestEnvironment = {
+  user: FriendRequestUser
+  sendFriendRequest: (
+    id: UserID
+  ) => Promise<
+    "friends" | "friend-request-sent" | "user-not-found" | "blocked-you"
+  >
+  onSuccess: (status: "friends" | "friend-request-sent") => void
+}
+
+const REQUESTABLE_RELATION_STATUSES = ["not-friends", "friend-request-received"]
+
+const isSuccessfulStatus = (
+  status: string | undefined
+): status is "friends" | "friend-request-sent" => {
+  return status === "friends" || status === "friend-request-sent"
+}
+
+/**
+ * A generic hook to use for friend request behavior.
+ *
+ * This hook should be used on with any UI element that needs to send or accept friend requests to
+ * and from other users. You use this hook in conjunction with {@link FriendRequestView} to manage
+ * friend request flow for your UI element.
+ *
+ * The `onSuccess` callback is called when the friend request is sent successfully to the other
+ * user. You receive the updated status in the callback, and can use it to update any UI state
+ * related to the user's relation status with the current user.
+ */
+export const useFriendRequest = ({
+  user,
+  sendFriendRequest,
+  onSuccess
+}: UseFriendRequestEnvironment) => {
+  const submission = useFormSubmission(
+    (user: FriendRequestUser) => sendFriendRequest(user.id),
+    () => {
+      if (REQUESTABLE_RELATION_STATUSES.includes(user.relationStatus)) {
+        return { status: "submittable", submissionValues: user }
+      }
+      return { status: "invalid" }
+    },
+    {
+      onSuccess: (status, user: FriendRequestUser) => {
+        if (!isSuccessfulStatus(status)) {
+          presentAlert(ALERTS[status](user))
+        } else {
+          onSuccess(status)
+        }
+      },
+      onError: () => presentAlert(ALERTS.genericError)
+    }
+  )
+  return {
+    user,
+    updatedStatus: isSuccessfulStatus(submission.result)
+      ? submission.result
+      : undefined,
+    submission
+  }
+}
+
+export type FriendRequestProps = {
+  state: ReturnType<typeof useFriendRequest>
+  style?: StyleProp<ViewStyle>
+  children: ReactNode
+}
+
+/**
+ * A generic view for UI elements that need to be able to send friend and accept friend requests.
+ *
+ * See {@link useFriendRequest} for more.
+ */
+export const FriendRequestView = ({
+  state,
+  style,
+  children
+}: FriendRequestProps) => (
+  <View style={style}>
+    {children}
+    <TextToastView
+      isVisible={state.updatedStatus === "friends"}
+      text={`${state.user.name} (${state.user.handle}) has been added as your friend!`}
+    />
+    <TextToastView
+      isVisible={state.updatedStatus === "friend-request-sent"}
+      text={`Friend request sent to ${state.user.name} (${state.user.handle}).`}
+    />
+  </View>
+)


### PR DESCRIPTION
We'll have multiple UI elements in the app that have the ability to both send and accept friend requests. However, the logic and friend request specific UI for these UI elements will be the same, so I decided to extract that logic and shared friend request UI into a `FriendRequestView` and `useFriendRequest` hook respectively.

## Tickets

https://trello.com/c/hESd3xVW