### PR TITLE
Alpha User Storage

### DIFF
--- a/.storybook/.ondevice/storybook.requires.ts
+++ b/.storybook/.ondevice/storybook.requires.ts
@@ -13,12 +13,12 @@ const normalizedStories = [
     directory: "./.storybook/components",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
     // @ts-ignore
     req: require.context(
       "../components",
       true,
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
 ];

--- a/.storybook/App.tsx
+++ b/.storybook/App.tsx
@@ -1,4 +1,4 @@
-import "@lib/TiFAPI"
+import "@api"
 import "@date-time/DateRangeFormatting"
 import CustomStorybookUI from "./.ondevice/Storybook"
 

--- a/.storybook/components/SignIn/SignIn.stories.tsx
+++ b/.storybook/components/SignIn/SignIn.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryMeta } from ".storybook/HelperTypes"
+import { awsTiFAPITransport } from "@api"
 import { createForgotPasswordEnvironment } from "@auth-boundary/forgot-password"
 import { CognitoSignInAuthenticator } from "@auth-boundary/sign-in"
 import {
@@ -15,7 +16,6 @@ import {
 import { createSignUpScreens } from "@core-root/navigation/auth/SignUp"
 import { API_URL } from "@env"
 import { TiFQueryClientProvider } from "@lib/ReactQuery"
-import { awsTiFAPITransport } from "@lib/TiFAPI"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { ComponentStory } from "@storybook/react-native"

--- a/.storybook/components/SignUp/SignUp.stories.tsx
+++ b/.storybook/components/SignUp/SignUp.stories.tsx
@@ -1,4 +1,4 @@
-import { awsTiFAPITransport } from "@lib/TiFAPI"
+import { awsTiFAPITransport } from "@api"
 import {
   cognitoConfirmSignUpWithAutoSignIn,
   createSignUpEnvironment

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import "@lib/TiFAPI"
+import "@api"
 import "date-time/DateRangeFormatting"
 import { useAppFonts } from "@lib/Fonts"
 import React from "react"

--- a/api/TiFAPI.test.ts
+++ b/api/TiFAPI.test.ts
@@ -3,12 +3,17 @@ import {
   CognitoUserSession,
   CognitoIdToken
 } from "amazon-cognito-identity-js"
-import { cognitoBearerToken } from "./TiFAPI"
+import { bearerToken } from "./TiFAPI"
+import { AlphaUserStorage } from "@user/alpha"
+import { AlphaUserMocks } from "@user/alpha/MockData"
 
 describe("TiFAPI tests", () => {
-  describe("CognitoBearerToken tests", () => {
+  describe("BearerToken tests", () => {
     const TEST_USER_TOKEN = "I was here at the beginning"
     const TEST_COGNITO_USER_TOKEN = "And I will proclaim the end"
+
+    let storage = AlphaUserStorage.ephemeral()
+    beforeEach(() => (storage = AlphaUserStorage.ephemeral()))
 
     const TEST_COGNITO_USER_SESSION = new CognitoUserSession({
       AccessToken: new CognitoAccessToken({
@@ -18,28 +23,41 @@ describe("TiFAPI tests", () => {
     })
 
     it("should use the launch argument token over the AWS token", async () => {
-      const token = await cognitoBearerToken(
+      const token = await bearerToken(
         {
           testCognitoUserToken: new CognitoAccessToken({
             AccessToken: TEST_USER_TOKEN
           })
         },
+        storage,
         jest.fn().mockResolvedValueOnce(TEST_COGNITO_USER_SESSION)
       )
       expect(token).toEqual(TEST_USER_TOKEN)
     })
 
     it("should use the token from the current cognito session", async () => {
-      const token = await cognitoBearerToken(
+      const token = await bearerToken(
         {},
+        storage,
         jest.fn().mockResolvedValueOnce(TEST_COGNITO_USER_SESSION)
       )
       expect(token).toEqual(TEST_COGNITO_USER_TOKEN)
     })
 
-    it("should return undefined loading the current session throws and no test token provided", async () => {
-      const token = await cognitoBearerToken(
+    it("should use the token from the alpha user storage if provided", async () => {
+      await storage.store(AlphaUserMocks.TheDarkLord.token)
+      const token = await bearerToken(
         {},
+        storage,
+        jest.fn().mockResolvedValueOnce(TEST_COGNITO_USER_SESSION)
+      )
+      expect(token).toEqual(AlphaUserMocks.TheDarkLord.token)
+    })
+
+    it("should return undefined loading the current session throws and no test token provided", async () => {
+      const token = await bearerToken(
+        {},
+        storage,
         jest.fn().mockRejectedValueOnce(new Error("No Session"))
       )
       expect(token).toBeUndefined()

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./TiFAPI"

--- a/babel.config.js
+++ b/babel.config.js
@@ -28,7 +28,8 @@ const MODULES = [
   "user",
   "settings-storage",
   "settings-boundary",
-  "edit-event-boundary"
+  "edit-event-boundary",
+  "api"
 ]
 
 module.exports = function (api) {

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -13,10 +13,15 @@ const COLORS = [
 
 export type AvatarProps = {
   name: string
+  maximumFontSizeMultiplier?: number
   style?: StyleProp<ViewStyle>
 }
 
-export const AvatarView = ({ name, style }: AvatarProps) => (
+export const AvatarView = ({
+  name,
+  maximumFontSizeMultiplier,
+  style
+}: AvatarProps) => (
   <View
     style={[
       style,
@@ -24,7 +29,12 @@ export const AvatarView = ({ name, style }: AvatarProps) => (
       { backgroundColor: COLORS[name.length % COLORS.length].toString() }
     ]}
   >
-    <Headline style={styles.text}>{initials(name)}</Headline>
+    <Headline
+      maxFontSizeMultiplier={maximumFontSizeMultiplier}
+      style={styles.text}
+    >
+      {initials(name)}
+    </Headline>
   </View>
 )
 

--- a/components/CalendarDay.tsx
+++ b/components/CalendarDay.tsx
@@ -1,0 +1,55 @@
+import { AppStyles } from "@lib/AppColorStyle"
+import { StyleProp, ViewStyle, StyleSheet, View } from "react-native"
+import { CaptionTitle, Headline } from "./Text"
+import dayjs from "dayjs"
+
+export type CalendarDayProps = {
+  date: Date
+  style?: StyleProp<ViewStyle>
+}
+
+export const CalendarDayView = ({ date, style }: CalendarDayProps) => (
+  <View style={style}>
+    <View>
+      <View style={styles.month}>
+        <CaptionTitle style={styles.monthText}>
+          {dayjs(date).format("MMM")}
+        </CaptionTitle>
+      </View>
+      <View style={styles.day}>
+        <Headline style={styles.dayText}>{dayjs(date).format("D")}</Headline>
+      </View>
+    </View>
+  </View>
+)
+
+const styles = StyleSheet.create({
+  column: {
+    display: "flex",
+    flexDirection: "column-reverse"
+  },
+  month: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 12,
+    color: "white",
+    backgroundColor: AppStyles.primaryColor,
+    zIndex: 1
+  },
+  monthText: {
+    color: "white"
+  },
+  day: {
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
+    backgroundColor: "white",
+    borderWidth: 2,
+    borderColor: AppStyles.colorOpacity15,
+    top: -12
+  },
+  dayText: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+    paddingTop: 16
+  }
+})

--- a/components/profileImageComponents/ProfileCircle.tsx
+++ b/components/profileImageComponents/ProfileCircle.tsx
@@ -1,0 +1,27 @@
+import { StyleProp } from "react-native"
+import ProfileImage from "./ProfileImage"
+import { AvatarView } from "@components/Avatar"
+import { ImageStyle } from "expo-image"
+
+export type ProfileCircleProps = {
+  imageURL?: string | null | undefined
+  name: string
+  maximumFontSizeMultiplier?: number
+  style?: StyleProp<ImageStyle>
+}
+
+export const ProfileCircleView = ({
+  imageURL,
+  name,
+  maximumFontSizeMultiplier,
+  style
+}: ProfileCircleProps) =>
+  imageURL ? (
+    <ProfileImage imageURL={imageURL ?? undefined} style={style} />
+  ) : (
+    <AvatarView
+      name={name}
+      maximumFontSizeMultiplier={maximumFontSizeMultiplier}
+      style={style}
+    />
+  )

--- a/components/profileImageComponents/ProfileImageAndName.tsx
+++ b/components/profileImageComponents/ProfileImageAndName.tsx
@@ -10,11 +10,14 @@ import { UserHandle } from "TiFShared/domain-models/User"
 import { BodyText, Caption, Headline, Subtitle } from "../Text"
 import ProfileImage from "./ProfileImage"
 import { AvatarView } from "@components/Avatar"
+import { ProfileCircleView } from "./ProfileCircle"
+import { useFontScale } from "@lib/Fonts"
 
 interface ImageAndNameProps {
   name: string
   handle: UserHandle
-  imageURL: string | null
+  imageURL: string | null | undefined
+  maximumFontSizeMultiplier?: number
   style?: StyleProp<ViewStyle>
   size?: "normal" | "large"
   imageStyle?: StyleProp<ImageStyle>
@@ -31,21 +34,26 @@ const ProfileImageAndName = ({
   imageURL,
   style,
   size = "normal",
+  maximumFontSizeMultiplier,
   imageStyle
 }: ImageAndNameProps) => {
+  const fontScale = useFontScale({
+    maximumScaleFactor: maximumFontSizeMultiplier
+  })
   const profileImageStyle =
-    imageStyle ?? (size === "normal" ? styles.image : styles.largeImage)
+    imageStyle ??
+    (size === "normal"
+      ? { width: 40 * fontScale, height: 40 * fontScale }
+      : { width: 64 * fontScale, height: 64 * fontScale })
   const [Name, Handle] = SIZE_TEXT_COMPONENTS[size]
   return (
     <View style={[style, styles.container]}>
-      {imageURL ? (
-        <ProfileImage
-          imageURL={imageURL ?? undefined}
-          style={profileImageStyle}
-        />
-      ) : (
-        <AvatarView name={name} style={profileImageStyle} />
-      )}
+      <ProfileCircleView
+        imageURL={imageURL}
+        name={name}
+        maximumFontSizeMultiplier={maximumFontSizeMultiplier}
+        style={profileImageStyle}
+      />
       <View style={styles.textContainer}>
         <Name>{name}</Name>
         <Handle style={styles.handle}>{handle.toString()}</Handle>

--- a/core-root/NameEntry.tsx
+++ b/core-root/NameEntry.tsx
@@ -6,30 +6,9 @@ import { TiFFormScrollableLayoutView } from "@components/form-components/Scrolla
 import { AlertsObject, presentAlert } from "@lib/Alerts"
 import { useFontScale } from "@lib/Fonts"
 import { useFormSubmission } from "@lib/utils/Form"
-import { TiFAPI } from "TiFShared/api"
-import { UserHandle, UserID } from "TiFShared/domain-models/User"
+import { AlphaUser } from "@user/alpha"
 import { useState } from "react"
 import { StyleProp, StyleSheet, View, ViewStyle } from "react-native"
-
-export type AlphaUser = {
-  name: string;
-  id: UserID;
-  handle: UserHandle;
-  token: string;
-}
-
-export const registerUser = async (
-  name: string,
-  api: TiFAPI = TiFAPI.productionInstance
-): Promise<AlphaUser> => {
-  const resp = await api.createCurrentUserProfile({ body: { name } })
-
-  if (resp.status === 400) {
-    throw new Error("invalid name")
-  }
-
-  return resp.data
-}
 
 export const ALERTS = {
   failedToRegister: {
@@ -89,9 +68,7 @@ export const AlphaRegisterView = ({ state, style }: AlphaRegisterProps) => (
     >
       <View style={styles.text}>
         <Subtitle>Register</Subtitle>
-        <BodyText>
-          Enter your name.
-        </BodyText>
+        <BodyText>Enter your name.</BodyText>
       </View>
       <ShadedTextField
         placeholder="Enter a Name"

--- a/event/EventCard.test.tsx
+++ b/event/EventCard.test.tsx
@@ -1,22 +1,11 @@
-import { render } from "@testing-library/react-native"
-import { EventCard } from "./EventCard"
-import React from "react"
-import { ClientSideEvent } from "@event/ClientSideEvent"
+import { eventCardFormattedDateRange } from "./EventCard"
 import "@test-helpers/Matchers"
 import { EventMocks } from "@event-details-boundary/MockData"
 
 describe("EventCard tests", () => {
-  beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date("2023-03-07T12:00:00"))
-  })
-  afterEach(() => jest.useRealTimers())
-
   it("formats the date range correctly", () => {
-    const { queryByText } = renderEventCard(EventMocks.PickupBasketball)
-    expect(queryByText("Sat, Mar 18 • 12:00 PM")).toBeDisplayed()
+    expect(
+      eventCardFormattedDateRange(EventMocks.PickupBasketball.time.dateRange)
+    ).toEqual("Saturday, 12:00-1:00 PM")
   })
 })
-
-const renderEventCard = (event: ClientSideEvent) => {
-  return render(<EventCard event={event} />)
-}

--- a/event/EventCard.tsx
+++ b/event/EventCard.tsx
@@ -1,129 +1,181 @@
-import { BodyText, Caption, Headline } from "@components/Text"
-import ConfirmationDialogue from "@components/common/ConfirmationDialogue"
-import { Ionicon, IoniconName } from "@components/common/Icons"
+import { TiFFormCardView } from "@components/form-components/Card"
 import ProfileImageAndName from "@components/profileImageComponents/ProfileImageAndName"
 import { ClientSideEvent } from "@event/ClientSideEvent"
-import { placemarkToAbbreviatedAddress } from "@lib/AddressFormatting"
-import { ColorString } from "TiFShared/domain-models/ColorString"
-import { now } from "TiFShared/lib/Dayjs"
-import dayjs from "dayjs"
 import React from "react"
-import { StyleProp, StyleSheet, View, ViewStyle } from "react-native"
+import { Pressable, StyleProp, StyleSheet, View, ViewStyle } from "react-native"
+import { EventActionsMenuView, useEventActionsMenu } from "./Menu"
+import {
+  BodyText,
+  BoldFootnote,
+  Caption,
+  Footnote,
+  Headline,
+  Subtitle
+} from "@components/Text"
+import { CalendarDayView } from "@components/CalendarDay"
+import { EventUserAttendanceButton } from "./UserAttendance"
+import { Ionicon } from "@components/common/Icons"
+import dayjs from "dayjs"
+import { FixedDateRange } from "TiFShared/domain-models/FixedDateRange"
+import { placemarkToAbbreviatedAddress } from "@lib/AddressFormatting"
+import { ProfileCircleView } from "@components/profileImageComponents/ProfileCircle"
+import { FontScaleFactors } from "@lib/Fonts"
 
 export type EventCardProps = {
   event: ClientSideEvent
+  onDetailsTapped?: () => void
+  onAttendeesTapped?: () => void
+  onEditEventTapped?: () => void
+  onCopyEventTapped?: () => void
+  onJoined?: () => void
+  onLeft?: () => void
   style?: StyleProp<ViewStyle>
 }
 
-export const EventCard = ({ event, style }: EventCardProps) => {
-  const formattedStartDate = event.time.dateRange.ext.formattedDate(
-    now(),
-    dayjs(event.time.dateRange.startDateTime)
-  )
-
-  return (
-    <View style={[style, styles.container]}>
-      <View style={[styles.topRow, styles.flexRow]}>
-        <ProfileImageAndName
-          name={event.host.name}
-          handle={event.host.handle}
-          imageURL={event.host.profileImageURL}
+export const EventCard = ({
+  event,
+  onDetailsTapped,
+  onAttendeesTapped,
+  onEditEventTapped,
+  onCopyEventTapped,
+  onJoined,
+  onLeft,
+  style
+}: EventCardProps) => (
+  <TiFFormCardView style={style}>
+    <View style={styles.container}>
+      <View style={styles.centeredRow}>
+        <View style={styles.leftRow}>
+          <ProfileImageAndName
+            name={event.host.name}
+            handle={event.host.handle}
+            imageURL={event.host.profileImageURL}
+            maximumFontSizeMultiplier={FontScaleFactors.xxxLarge}
+          />
+        </View>
+        <EventActionsMenuView
+          event={event}
+          state={useEventActionsMenu(event)}
+          eventShareContent={async () => ({
+            title: "TODO",
+            message: "We need to figure this out..."
+          })}
+          onCopyEventTapped={() => onCopyEventTapped?.()}
+          onEditEventTapped={() => onEditEventTapped?.()}
+          style={styles.menu}
         />
-        <ConfirmationDialogue style={styles.moreButtonStyle} />
       </View>
-
-      <View style={styles.middleRow}>
-        <Headline>{event.title}</Headline>
-
-        <BodyText style={styles.description} numberOfLines={3}>
-          {event.description}
-        </BodyText>
-        <IconRowView
-          icon="calendar"
-          text={`${formattedStartDate} • ${event.time.dateRange.ext.formattedStartTime()}`}
-          color={event.color}
-          style={styles.bottomSpacing}
-        />
-        <IconRowView
-          icon="location"
-          text={
-            event.location.placemark
-              ? placemarkToAbbreviatedAddress(event.location.placemark)
-              : "Unknown Address"
-          }
-          color={event.color}
+      <Pressable onPress={onDetailsTapped}>
+        <View style={styles.detailsRow}>
+          <View style={styles.infoColumn}>
+            <Subtitle>{event.title}</Subtitle>
+            <View style={[styles.centeredRow, styles.iconSpacing]}>
+              <Ionicon name="calendar" size={16} />
+              <Footnote>
+                {eventCardFormattedDateRange(event.time.dateRange)}
+              </Footnote>
+            </View>
+            <View style={[styles.centeredRow, styles.iconSpacing]}>
+              <Ionicon name="location" size={16} />
+              <Footnote>
+                {event.location.placemark
+                  ? placemarkToAbbreviatedAddress(event.location.placemark)
+                  : "Unknown Location"}
+              </Footnote>
+            </View>
+          </View>
+          <CalendarDayView date={event.time.dateRange.startDateTime} />
+        </View>
+      </Pressable>
+      <View style={styles.centeredRow}>
+        <Pressable onPress={onAttendeesTapped} style={styles.leftRow}>
+          <View style={styles.centeredRow}>
+            {event.previewAttendees.slice(0, 3).map((a, index) => (
+              <ProfileCircleView
+                key={a.id}
+                imageURL={a.profileImageURL}
+                name={a.name}
+                maximumFontSizeMultiplier={FontScaleFactors.large}
+                style={[styles.profileCircle, { left: index * -16 }]}
+              />
+            ))}
+            {event.attendeeCount > 3 ? (
+              <BoldFootnote
+                maxFontSizeMultiplier={FontScaleFactors.large}
+                style={styles.attendingText}
+              >
+                + {event.attendeeCount - 3} Attending
+              </BoldFootnote>
+            ) : (
+              <BoldFootnote
+                maxFontSizeMultiplier={FontScaleFactors.large}
+                style={styles.attendingText}
+              >
+                Attending
+              </BoldFootnote>
+            )}
+          </View>
+        </Pressable>
+        <EventUserAttendanceButton
+          event={event}
+          maximumFontSizeMultiplier={FontScaleFactors.large}
+          onJoinSuccess={() => onJoined?.()}
+          onLeaveSuccess={() => onLeft?.()}
+          size="small"
+          style={styles.attendanceButton}
         />
       </View>
     </View>
-  )
-}
-
-type IconRowProps = {
-  icon: IoniconName
-  color: ColorString
-  text: string
-  style?: StyleProp<ViewStyle>
-}
-
-const IconRowView = ({ icon, color, text, style }: IconRowProps) => (
-  <View style={[style, styles.flexRow]}>
-    <View style={[styles.iconContainer, { backgroundColor: color.toString() }]}>
-      <Ionicon name={icon} color="white" style={styles.icon} />
-    </View>
-    <Caption style={styles.infoText}>{text}</Caption>
-  </View>
+  </TiFFormCardView>
 )
 
+export const eventCardFormattedDateRange = (range: FixedDateRange) => {
+  const start = dayjs(range.startDateTime).format("dddd, h:mm")
+  const end = dayjs(range.endDateTime).format("h:mm A")
+  return `${start}-${end}`
+}
+
 const styles = StyleSheet.create({
-  flexRow: {
-    flexDirection: "row"
+  container: {
+    padding: 16,
+    rowGap: 16
   },
-  topRow: {
-    marginBottom: 16,
+  profileCircle: {
+    width: 32,
+    height: 32
+  },
+  centeredRow: {
+    display: "flex",
+    flexDirection: "row",
     alignItems: "center"
   },
-  middleRow: {
-    flex: 1,
-    flexDirection: "column"
+  iconSpacing: {
+    columnGap: 8
   },
-  bottomSpacing: {
-    marginBottom: 8
+  infoColumn: {
+    rowGap: 8,
+    flex: 1
   },
-  infoText: {
-    textAlignVertical: "center",
-    textAlign: "center",
-    alignSelf: "center"
+  detailsRow: {
+    display: "flex",
+    flexDirection: "row",
+    columnGap: 32
   },
-  description: {
-    marginBottom: 16,
-    marginTop: 8
+  row: {
+    display: "flex",
+    flexDirection: "row"
   },
-  container: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    borderRadius: 12,
-    backgroundColor: "#F4F4F6"
+  leftRow: {
+    flex: 1
   },
-  iconMargin: {
-    marginRight: 16
-  },
-  moreButtonStyle: {
-    flex: 1,
-    opacity: 0.4,
-    alignItems: "flex-end"
-  },
-  dotIcon: {
+  menu: {
     justifyContent: "center",
-    alignItems: "center",
-    marginHorizontal: 8
+    opacity: 0.5
   },
-  iconContainer: {
-    justifyContent: "center",
-    alignContent: "center",
-    borderRadius: 12,
-    marginRight: 16
+  attendanceButton: {
+    padding: 12
   },
-  icon: {
-    padding: 4
+  attendingText: {
+    left: -24
   }
 })

--- a/event/JoinEvent.tsx
+++ b/event/JoinEvent.tsx
@@ -17,7 +17,7 @@ import {
   requestPermissionsAsync as requestNotificationPermissions
 } from "expo-notifications"
 import React, { useEffect, useState } from "react"
-import { StyleProp, StyleSheet, View, ViewStyle } from "react-native"
+import { StyleProp, StyleSheet, View, ViewStyle, TextProps } from "react-native"
 import { IoniconCloseButton } from "@components/common/Icons"
 import { BodyText, Title } from "@components/Text"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -294,20 +294,31 @@ const useCurrentJoinEventPermission = (
 
 export type JoinEventButtonProps = {
   state: UseJoinEvent
+  Text: (props: TextProps) => JSX.Element
+  maximumFontSizeMultipler?: number
   style?: StyleProp<ViewStyle>
 }
 
-export const JoinEventButton = ({ state, style }: JoinEventButtonProps) => (
+export const JoinEventButton = ({
+  state,
+  Text,
+  maximumFontSizeMultipler,
+  style
+}: JoinEventButtonProps) => (
   <PrimaryButton
     disabled={state.stage !== "idle"}
     onPress={() => {
       if (state.stage !== "idle") return
       state.joinButtonTapped()
     }}
-    maximumFontSizeMultiplier={FontScaleFactors.xxxLarge}
     style={style}
   >
-    Join Now!
+    <Text
+      maxFontSizeMultiplier={maximumFontSizeMultipler}
+      style={styles.joinText}
+    >
+      Join Now!
+    </Text>
   </PrimaryButton>
 )
 
@@ -408,5 +419,8 @@ const styles = StyleSheet.create({
     height: 200,
     backgroundColor: "red",
     marginVertical: 16
+  },
+  joinText: {
+    color: "white"
   }
 })

--- a/event/LeaveEvent.tsx
+++ b/event/LeaveEvent.tsx
@@ -1,4 +1,4 @@
-import { PrimaryButton } from "@components/Buttons"
+import { PrimaryButton, SecondaryOutlinedButton } from "@components/Buttons"
 import { ClientSideEvent } from "@event/ClientSideEvent"
 import { updateEventDetailsQueryEvent } from "@event/DetailsQuery"
 import { AlertsObject, presentAlert } from "@lib/Alerts"
@@ -8,7 +8,7 @@ import { useFormSubmission } from "@lib/utils/Form"
 import { useQueryClient } from "@tanstack/react-query"
 import { TiFAPI } from "TiFShared/api"
 import { EventID } from "TiFShared/domain-models/Event"
-import { ViewStyle, StyleProp, StyleSheet } from "react-native"
+import { ViewStyle, StyleProp, StyleSheet, TextProps } from "react-native"
 
 export const leaveEvent = async (
   id: EventID,
@@ -121,22 +121,23 @@ export const useLeaveEvent = (
 
 export type LeaveEventButtonProps = {
   state: ReturnType<typeof useLeaveEvent>
+  Text: (props: TextProps) => JSX.Element
+  maximumFontSizeMultipler?: number
   style?: StyleProp<ViewStyle>
 }
 
-export const LeaveEventButton = ({ state, style }: LeaveEventButtonProps) => (
-  <PrimaryButton
+export const LeaveEventButton = ({
+  state,
+  Text,
+  maximumFontSizeMultipler,
+  style
+}: LeaveEventButtonProps) => (
+  <SecondaryOutlinedButton
     disabled={!state.leaveStarted}
     onPress={() => state.leaveStarted?.()}
-    maximumFontSizeMultiplier={FontScaleFactors.xxxLarge}
-    style={[style, styles.button]}
+    maximumFontSizeMultiplier={maximumFontSizeMultipler}
+    style={style}
   >
-    Leave
-  </PrimaryButton>
+    <Text maxFontSizeMultiplier={maximumFontSizeMultipler}>Joined</Text>
+  </SecondaryOutlinedButton>
 )
-
-const styles = StyleSheet.create({
-  button: {
-    backgroundColor: AppStyles.red.toString()
-  }
-})

--- a/event/Menu.test.tsx
+++ b/event/Menu.test.tsx
@@ -10,14 +10,18 @@ import { act, renderHook, waitFor } from "@testing-library/react-native"
 import { EmailAddress } from "@user/privacy"
 import { UserSessionProvider } from "@user/Session"
 import { UnblockedUserRelationsStatus } from "TiFShared/domain-models/User"
-import { UseLoadEventDetailsResult } from "./Details"
+import { UseLoadEventDetailsResult } from "@event-details-boundary/Details"
 import {
   EVENT_MENU_ACTION,
   formatEventMenuActions,
   useEventActionsMenu
 } from "./Menu"
-import { EventAttendeeMocks, EventMocks } from "./MockData"
-import { renderSuccessfulUseLoadEventDetails } from "./TestHelpers"
+import {
+  EventAttendeeMocks,
+  EventMocks
+} from "@event-details-boundary/MockData"
+import { renderSuccessfulUseLoadEventDetails } from "@event-details-boundary/TestHelpers"
+import { UserBlockingProvider } from "@user/Blocking"
 
 describe("EventDetailsMenu tests", () => {
   describe("FormatEventMenuActions tests", () => {
@@ -25,7 +29,7 @@ describe("EventDetailsMenu tests", () => {
 
     it("should format the contact-host action with the host's name", () => {
       const actions = formatEventMenuActions(
-        { host: EventAttendeeMocks.Alivs } as ClientSideEvent,
+        { host: EventAttendeeMocks.Alivs } as unknown as ClientSideEvent,
         [EVENT_MENU_ACTION.copyEvent, EVENT_MENU_ACTION.contactHost]
       )
       expect(actions).toEqual([
@@ -36,7 +40,7 @@ describe("EventDetailsMenu tests", () => {
 
     it("should format the toggle-block-host with 'Block Hostname' when user is not blocking host", () => {
       const actions = formatEventMenuActions(
-        { host: EventAttendeeMocks.Alivs } as ClientSideEvent,
+        { host: EventAttendeeMocks.Alivs } as unknown as ClientSideEvent,
         [EVENT_MENU_ACTION.toggleBlockHost]
       )
       expect(actions).toEqual([
@@ -55,7 +59,7 @@ describe("EventDetailsMenu tests", () => {
             ...EventAttendeeMocks.Alivs,
             relationStatus: "blocked-them"
           }
-        } as ClientSideEvent,
+        } as unknown as ClientSideEvent,
         [EVENT_MENU_ACTION.toggleBlockHost]
       )
       expect(actions).toEqual([
@@ -201,18 +205,20 @@ describe("EventDetailsMenu tests", () => {
     }
 
     const renderUseEventDetailsMenuActions = (event: ClientSideEvent) => {
-      return renderHook(
-        () => useEventActionsMenu(event, { blockHost, unblockHost }),
-        {
-          wrapper: ({ children }: any) => (
-            <TestQueryClientProvider client={queryClient}>
+      return renderHook(() => useEventActionsMenu(event), {
+        wrapper: ({ children }: any) => (
+          <TestQueryClientProvider client={queryClient}>
+            <UserBlockingProvider
+              blockUser={blockHost}
+              unblockUser={unblockHost}
+            >
               <UserSessionProvider userSession={userSession}>
                 {children}
               </UserSessionProvider>
-            </TestQueryClientProvider>
-          )
-        }
-      )
+            </UserBlockingProvider>
+          </TestQueryClientProvider>
+        )
+      })
     }
   })
 })

--- a/event/Menu.tsx
+++ b/event/Menu.tsx
@@ -11,7 +11,8 @@ import {
   Share,
   ShareContent,
   StyleProp,
-  ViewStyle
+  ViewStyle,
+  StyleSheet
 } from "react-native"
 import {
   UnblockedUserRelationsStatus,
@@ -125,7 +126,7 @@ export const EventActionsMenuView = ({
     shouldOpenOnLongPress={false}
     style={[style, { width: 44 * useFontScale(), height: 44 * useFontScale() }]}
   >
-    <Ionicon name="ellipsis-horizontal" />
+    <Ionicon name="ellipsis-horizontal" style={styles.icon} />
   </MenuView>
 )
 
@@ -262,3 +263,9 @@ const EVENT_MENU_ACTIONS_LISTS = {
   ],
   "not-signed-in": [EVENT_MENU_ACTION.shareEvent]
 } as const satisfies Readonly<Record<string, EventMenuAction[]>>
+
+const styles = StyleSheet.create({
+  icon: {
+    alignSelf: "center"
+  }
+})

--- a/event/UserAttendance.tsx
+++ b/event/UserAttendance.tsx
@@ -22,6 +22,7 @@ import { mergeWithPartial } from "TiFShared/lib/Object"
 import { EventRegionMonitor } from "@arrival-tracking"
 import { TrueRegionMonitor } from "@arrival-tracking/region-monitoring/MockRegionMonitors"
 import { ClientSideEvent } from "./ClientSideEvent"
+import { BoldFootnote, Headline } from "@components/Text"
 
 export type EventUserAttendanceContextValues = {
   monitor: EventRegionMonitor
@@ -59,6 +60,8 @@ export const EventUserAttendanceProvider = ({
 
 export type EventAttendanceButtonProps = {
   event: ClientSideEvent
+  size?: "small" | "normal"
+  maximumFontSizeMultiplier?: number
   onJoinSuccess: () => void
   onLeaveSuccess: () => void
   style?: StyleProp<ViewStyle>
@@ -74,6 +77,8 @@ export const EventUserAttendanceButton = ({
   event,
   onJoinSuccess,
   onLeaveSuccess,
+  size = "normal",
+  maximumFontSizeMultiplier,
   style
 }: EventAttendanceButtonProps) => {
   const { monitor, joinEvent, loadPermissions, leaveEvent } =
@@ -88,14 +93,30 @@ export const EventUserAttendanceButton = ({
     leaveEvent,
     onSuccess: onLeaveSuccess
   })
+  const Text = SIZE_TEXT_COMPONENT[size]
   return (
     <>
       {isAttendingEvent(event.userAttendeeStatus) ? (
-        <LeaveEventButton state={leaveState} style={style} />
+        <LeaveEventButton
+          Text={Text}
+          maximumFontSizeMultipler={maximumFontSizeMultiplier}
+          state={leaveState}
+          style={style}
+        />
       ) : (
-        <JoinEventButton state={joinState} style={style} />
+        <JoinEventButton
+          Text={Text}
+          maximumFontSizeMultipler={maximumFontSizeMultiplier}
+          state={joinState}
+          style={style}
+        />
       )}
       <JoinEventPermissionsSheetView state={joinState} />
     </>
   )
+}
+
+const SIZE_TEXT_COMPONENT = {
+  small: BoldFootnote,
+  normal: Headline
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,8 @@
       "@settings-boundary": ["./settings-boundary"],
       "@edit-event-boundary": ["./edit-event-boundary"],
       "@edit-event-boundary/*": ["./edit-event-boundary/*"],
+      "@api": ["./api"],
+      "@api/*": ["./api/*"],
       "env": ["./.env"]
     }
   },

--- a/user/Blocking.tsx
+++ b/user/Blocking.tsx
@@ -1,0 +1,60 @@
+import { TiFAPI } from "TiFShared/api"
+import { UserID } from "TiFShared/domain-models/User"
+import { mergeWithPartial } from "TiFShared/lib/Object"
+import { logger } from "TiFShared/logging"
+import React, { ReactNode, createContext, useContext } from "react"
+
+const log = logger("tif.user.blocking")
+
+export const blockUser = async (
+  id: UserID,
+  api: TiFAPI = TiFAPI.productionInstance
+) => {
+  const resp = await api.blockUser({ params: { userId: id } })
+  checkForUserNotFound(resp, "block")
+}
+
+export const unblockUser = async (
+  id: UserID,
+  api: TiFAPI = TiFAPI.productionInstance
+) => {
+  const resp = await api.unblockUser({ params: { userId: id } })
+  checkForUserNotFound(resp, "unblock")
+}
+
+const checkForUserNotFound = (
+  resp: Awaited<ReturnType<typeof TiFAPI.productionInstance.unblockUser>>,
+  operation: string
+) => {
+  if (resp.status === 404) {
+    log.error(
+      `Unable to ${operation} user, TiF API responded with status code 404.`
+    )
+    throw new Error(resp.data.error)
+  }
+}
+
+export type UserBlockingContextValues = {
+  blockUser: (id: UserID) => Promise<void>
+  unblockUser: (id: UserID) => Promise<void>
+}
+
+const BlockingContext = createContext<UserBlockingContextValues>({
+  blockUser,
+  unblockUser
+})
+
+export const useUserBlocking = () => useContext(BlockingContext)
+
+export type UserBlockingProviderProps = Partial<UserBlockingContextValues> & {
+  children: ReactNode
+}
+
+export const UserBlockingProvider = ({
+  children,
+  ...values
+}: UserBlockingProviderProps) => (
+  <BlockingContext.Provider value={mergeWithPartial(useUserBlocking(), values)}>
+    {children}
+  </BlockingContext.Provider>
+)

--- a/user/alpha/AlphaUser.test.ts
+++ b/user/alpha/AlphaUser.test.ts
@@ -1,0 +1,59 @@
+import { TiFAPI } from "TiFShared/api"
+import { mockTiFEndpoint } from "TiFShared/test-helpers/mockAPIServer"
+import { AlphaUserStorage, registerAlphaUser } from "./AlphaUser"
+import { AlphaUserMocks } from "./MockData"
+
+describe("AlphaUser tests", () => {
+  describe("RegisterAlphaUser tests", () => {
+    it("should create and save the user from the API", async () => {
+      const storage = AlphaUserStorage.ephemeral()
+      mockTiFEndpoint(
+        "createCurrentUserProfile",
+        201,
+        AlphaUserMocks.TheDarkLord
+      )
+      const user = await registerAlphaUser(
+        AlphaUserMocks.TheDarkLord.name,
+        storage,
+        TiFAPI.testUnauthenticatedInstance
+      )
+      const storedUser = await storage.user()
+      expect(user).toEqual(AlphaUserMocks.TheDarkLord)
+      expect(storedUser).toEqual(user)
+    })
+
+    it("should throw an error when response code is 400", async () => {
+      mockTiFEndpoint("createCurrentUserProfile", 400, {
+        error: "invalid-name"
+      })
+      expect(
+        registerAlphaUser(
+          "",
+          AlphaUserStorage.ephemeral(),
+          TiFAPI.testUnauthenticatedInstance
+        )
+      ).rejects.toThrow(new Error("invalid name"))
+    })
+  })
+
+  describe("AlphaUserStorage tests", () => {
+    let storage = AlphaUserStorage.ephemeral()
+    beforeEach(() => (storage = AlphaUserStorage.ephemeral()))
+
+    it("should not decode any user details when no user set", async () => {
+      const user = await storage.user()
+      expect(user).toEqual(undefined)
+    })
+
+    it("should decode the user details of the set token", async () => {
+      await storage.store(AlphaUserMocks.Blob.token)
+      expect(await storage.user()).toEqual(AlphaUserMocks.Blob)
+    })
+
+    it("should override the user details of the existing user", async () => {
+      await storage.store(AlphaUserMocks.Blob.token)
+      await storage.store(AlphaUserMocks.TheDarkLord.token)
+      expect(await storage.user()).toEqual(AlphaUserMocks.TheDarkLord)
+    })
+  })
+})

--- a/user/alpha/AlphaUser.tsx
+++ b/user/alpha/AlphaUser.tsx
@@ -1,0 +1,122 @@
+import { SecureStore, InMemorySecureStore } from "@lib/SecureStore"
+import { UserSessionProvider } from "@user/Session"
+import { EmailAddress } from "@user/privacy"
+import { TiFAPI } from "TiFShared/api"
+import {
+  UserID,
+  UserHandle,
+  UserHandleSchema,
+  UserIDSchema
+} from "TiFShared/domain-models/User"
+import { jwtBody } from "TiFShared/lib/JWT"
+import { useCallback } from "react"
+import { z } from "zod"
+import * as ExpoSecureStore from "expo-secure-store"
+
+/**
+ * All the data associated with an Alpha User.
+ *
+ * Alpha users have limited info (only a name, id, and handle), and cannot edit their profiles
+ * after creation.
+ *
+ * All alpha users have a non-expiring access token to the TiFAPI. However, this token is the
+ * only access token linked to their account, so their account is lost if the token is lost.
+ */
+export type AlphaUser = {
+  name: string
+  id: UserID
+  handle: UserHandle
+  token: string
+}
+
+const ALPHA_USER_STORAGE_KEY = "tif.alpha.user.storage"
+
+const AlphaUserTokenBodySchema = z.object({
+  name: z.string().min(1),
+  handle: UserHandleSchema,
+  id: UserIDSchema
+})
+
+/**
+ * A class that stores user data for Alpha users.
+ */
+export class AlphaUserStorage {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private readonly _store: SecureStore) {}
+
+  /**
+   * Returns the alpha user details if they exist.
+   */
+  async user(): Promise<AlphaUser | undefined> {
+    const token = await this._store.getItemAsync(ALPHA_USER_STORAGE_KEY)
+    if (!token) return undefined
+    const userResult = await AlphaUserTokenBodySchema.safeParseAsync(
+      jwtBody(token)
+    )
+    if (!userResult.success) return undefined
+    return { ...userResult.data, token }
+  }
+
+  /**
+   * Stores the JWT access token containing the alpha user details in its payload.
+   */
+  async store(token: string) {
+    await this._store.setItemAsync(ALPHA_USER_STORAGE_KEY, token)
+  }
+
+  /**
+   * The default storage instance which stores user data to the keychain.
+   */
+  static default = new AlphaUserStorage(ExpoSecureStore)
+
+  /**
+   * Returns an in-memory storage instance.
+   */
+  static ephemeral() {
+    return new AlphaUserStorage(new InMemorySecureStore())
+  }
+}
+
+/**
+ * Registeres an alpha user with the API.
+ *
+ * @param name The name to register the user with.
+ * @param storage The {@link AlphaUserStorage} instance to save the registered user to.
+ * @param api The {@link TiFAPI} instance to use.
+ */
+export const registerAlphaUser = async (
+  name: string,
+  storage: AlphaUserStorage = AlphaUserStorage.default,
+  api: TiFAPI = TiFAPI.productionInstance
+): Promise<AlphaUser> => {
+  const resp = await api.createCurrentUserProfile({ body: { name } })
+  if (resp.status === 400) {
+    throw new Error("invalid name")
+  }
+  await storage.store(resp.data.token)
+  return resp.data
+}
+
+export type AlphaUserSessionProviderProps = {
+  storage?: AlphaUserStorage
+  children: JSX.Element
+}
+
+/**
+ * A user session provider wrapper that loads alpha user data as the session.
+ */
+export const AlphaUserSessionProvider = ({
+  storage = AlphaUserStorage.default,
+  children
+}: AlphaUserSessionProviderProps) => (
+  <UserSessionProvider
+    userSession={useCallback(async () => {
+      const user = await storage.user()
+      if (!user) throw new Error("No stored alpha user.")
+      // NB: Alpha users don't need to register with their email, so use a mock.
+      return { id: user.id, primaryContactInfo: EmailAddress.alphaUser }
+    }, [storage])}
+  >
+    {children}
+  </UserSessionProvider>
+)

--- a/user/alpha/MockData.ts
+++ b/user/alpha/MockData.ts
@@ -1,0 +1,19 @@
+import { UserHandle } from "TiFShared/domain-models/User"
+
+export namespace AlphaUserMocks {
+  export const Blob = {
+    id: "01938e5d-7743-725c-8e19-c68092b598d3",
+    handle: UserHandle.optionalParse("blob0952")!,
+    name: "Blob",
+    token:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjAxOTM4ZTVkLTc3NDMtNzI1Yy04ZTE5LWM2ODA5MmI1OThkMyIsImhhbmRsZSI6ImJsb2IwOTUyIiwibmFtZSI6IkJsb2IiLCJpYXQiOjE3MzMyNjAzMTB9.AS0z0zckPcCGoGQW3DgZcXDllmGWYtnYkaxbGXXHXlU"
+  }
+
+  export const TheDarkLord = {
+    id: "01938e5f-10de-767d-9bb9-36d34ba77971",
+    handle: UserHandle.optionalParse("thedarklord2420")!,
+    name: "The Dark Lord",
+    token:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjAxOTM4ZTVmLTEwZGUtNzY3ZC05YmI5LTM2ZDM0YmE3Nzk3MSIsImhhbmRsZSI6InRoZWRhcmtsb3JkMjQyMCIsIm5hbWUiOiJUaGUgRGFyayBMb3JkIiwiaWF0IjoxNzMzMjYwNDE1fQ.WSWI-HXnLPRXqA64-OsX8cGL4-KV53hqqVKMVDD4RGs"
+  }
+}

--- a/user/alpha/index.ts
+++ b/user/alpha/index.ts
@@ -1,0 +1,1 @@
+export * from "./AlphaUser"

--- a/user/privacy/EmailAddress.ts
+++ b/user/privacy/EmailAddress.ts
@@ -8,6 +8,7 @@ const RawStringEmailAddressSchema = z.string().email()
  */
 export class EmailAddress implements ContactInfoFormattable {
   static peacock69 = EmailAddress.parse("peacock69@gmail.com")!
+  static alphaUser = EmailAddress.parse("alphauser@test.com")!
 
   readonly formattedContactInfoType = "Email"
   readonly contactInfoTypeIconName = "mail"


### PR DESCRIPTION
Implements the data layer for storing alpha users. I didn't nuke the production user system that we plan on using, but rather integrated the alpha auth system alongside it. For all intensive purposes, the alpha auth system may be a decent way to implement an anonymous account feature down the line.

I introduced an `AlphaUserStorage` class that stores the access token for the alpha user. Since that token never expires, and since it holds all the user data in its body, we can retrieve the user details by decoding the body of the JWT instead of having to hit the API. You can use `AlphaUserStorage` with the `AlphaUserSessionProvider` component to integrate the alpha user data with `useUserSessionQuery` or `useIsSignedIn`.

Lastly, I had to move the `TiFAPI` production instance into a dedicated `api` module because the transport now needs to load the JWT from `AlphaUserStorage`. Originally the production instance lived in the `lib` module, but it would need to import `user/alpha` in order to access `AlphaUserStorage`. This could cause circular imports down the line, so I was better off making a single dedicated module for the `TiFAPI` even if it only has a single file.

TASK_UNTRACKED