### PR TITLE
Make create-story.ts a JS file

### DIFF
--- a/create-story.js
+++ b/create-story.js
@@ -1,13 +1,13 @@
 const fs = require("fs")
 const path = require("path")
 
-const COMPONENTS_DIR = path.resolve(__dirname, "./storybook/components")
+const COMPONENTS_DIR = path.resolve(__dirname, ".storybook/components")
 const STORYBOOK_FILE = path.resolve(
   __dirname,
   ".storybook/.ondevice/Storybook.tsx"
 )
 
-const addStoryToStorybook = (storyName: string): void => {
+const addStoryToStorybook = (storyName) => {
   let storybookContent = fs.readFileSync(STORYBOOK_FILE, "utf-8")
   const importStatement = `import ${storyName}Meta, { Basic as ${storyName} } from "../components/${storyName}/${storyName}.stories";`
 
@@ -56,7 +56,7 @@ const addStoryToStorybook = (storyName: string): void => {
   fs.writeFileSync(STORYBOOK_FILE, storybookContent, "utf-8")
 }
 
-const createComponentFolder = (storyName: string): void => {
+const createComponentFolder = (storyName) => {
   const storyFolderPath = path.join(COMPONENTS_DIR, storyName)
   if (!fs.existsSync(storyFolderPath)) {
     fs.mkdirSync(storyFolderPath, { recursive: true })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "create-story": "node --loader ts-node/esm create-story.ts",
+    "create-story": "node create-story.js",
     "pr": "node --loader ts-node/esm ./node_modules/TiFShared/npm-scripts/auto-pr.ts --env .env.infra",
     "start": "node enableStorybook.js false && node checkEnv.js && npx expo start --dev-client --clear",
     "sb_start": "node enableStorybook.js true && sb-rn-get-stories --config-path .storybook/.ondevice && npx expo start --dev-client",


### PR DESCRIPTION
I was getting syntax errors when it was a typescript file. Since it's a simple script, typescript shouldn't be needed.

TASK_UNTRACKED