### PR TITLE
Navigate to Event Details After Joining

### DIFF
--- a/event/EventCard.tsx
+++ b/event/EventCard.tsx
@@ -16,12 +16,11 @@ import { useCoreNavigation } from "@components/Navigation"
 
 export type EventCardProps = {
   event: ClientSideEvent
-  onJoined?: () => void
   onLeft?: () => void
   style?: StyleProp<ViewStyle>
 }
 
-const _EventCard = ({ event, onJoined, onLeft, style }: EventCardProps) => {
+const _EventCard = ({ event, onLeft, style }: EventCardProps) => {
   const { presentProfile, pushEventDetails, pushAttendeesList } =
     useCoreNavigation()
   const previewedAttendees = event.previewAttendees.slice(0, 3)
@@ -108,7 +107,7 @@ const _EventCard = ({ event, onJoined, onLeft, style }: EventCardProps) => {
           <EventUserAttendanceButton
             event={event}
             maximumFontSizeMultiplier={FontScaleFactors.large}
-            onJoinSuccess={() => onJoined?.()}
+            onJoinSuccess={() => pushEventDetails(event.id)}
             onLeaveSuccess={() => onLeft?.()}
             size="small"
             style={styles.attendanceButton}


### PR DESCRIPTION
Navigates to the event details after joining an event from its card.

## Tickets

https://trello.com/c/dcO68Dqa/895-event-card-navigate-to-details-after-joining-event