### PR TITLE
Edit Event: Duration Slider Haptics

### DIFF
--- a/event/EventCard.tsx
+++ b/event/EventCard.tsx
@@ -16,12 +16,11 @@ import { useCoreNavigation } from "@components/Navigation"
 
 export type EventCardProps = {
   event: ClientSideEvent
-  onJoined?: () => void
   onLeft?: () => void
   style?: StyleProp<ViewStyle>
 }
 
-const _EventCard = ({ event, onJoined, onLeft, style }: EventCardProps) => {
+const _EventCard = ({ event, onLeft, style }: EventCardProps) => {
   const { presentProfile, pushEventDetails, pushAttendeesList } =
     useCoreNavigation()
   const previewedAttendees = event.previewAttendees.slice(0, 3)
@@ -108,7 +107,7 @@ const _EventCard = ({ event, onJoined, onLeft, style }: EventCardProps) => {
           <EventUserAttendanceButton
             event={event}
             maximumFontSizeMultiplier={FontScaleFactors.large}
-            onJoinSuccess={() => onJoined?.()}
+            onJoinSuccess={() => pushEventDetails(event.id)}
             onLeaveSuccess={() => onLeft?.()}
             size="small"
             style={styles.attendanceButton}


### PR DESCRIPTION
Adds some haptic effects to the duration slider. As you slide to the right, the haptics get stronger, and as you slide to the left, the haptics get weaker. Once we pair this with natural sound effects, it should be the first step in making event creation more interesting.

## Tickets

https://trello.com/c/okMswwwQ/896-durations-slider-haptic-feedback