### PR TITLE
Expandable Map Snippet View

### DIFF
--- a/.storybook/.ondevice/Storybook.tsx
+++ b/.storybook/.ondevice/Storybook.tsx
@@ -1,6 +1,16 @@
 import React, { useState } from "react"
 
-import { FlatList, Text, TouchableOpacity, View } from "react-native"
+import MapSnippetMeta, {
+  Basic as MapSnippet
+} from "../components/MapSnippet/MapSnippet.stories"
+
+import {
+  FlatList,
+  SafeAreaView,
+  Text,
+  TouchableOpacity,
+  View
+} from "react-native"
 import { useAppFonts } from "../../lib/Fonts"
 
 // Import your
@@ -94,6 +104,12 @@ addLogHandler(
 
 // Create an array of stories
 const stories = [
+  {
+    name: MapSnippetMeta.title,
+    component: MapSnippet,
+    args: MapSnippetMeta.args
+  },
+
   {
     name: NameEntryMeta.title,
     component: NameEntryBasic
@@ -252,7 +268,7 @@ const CustomStorybookUI = () => {
 
   // Render the story list
   return (
-    <View style={{ flex: 1, margin: 20 }}>
+    <SafeAreaView style={{ flex: 1, margin: 20 }}>
       <FlatList
         data={stories}
         renderItem={({ item, index }) => (
@@ -270,7 +286,7 @@ const CustomStorybookUI = () => {
           </TouchableOpacity>
         )}
       />
-    </View>
+    </SafeAreaView>
   )
 }
 

--- a/.storybook/components/MapSnippet/MapSnippet.stories.tsx
+++ b/.storybook/components/MapSnippet/MapSnippet.stories.tsx
@@ -1,0 +1,28 @@
+import { MapSnippetView } from "@components/MapSnippetView"
+import { Headline } from "@components/Text"
+import { TiFFormScrollView } from "@components/form-components/ScrollView"
+import { XEROX_ALTO_DEFAULT_REGION } from "@explore-events-boundary"
+import React from "react"
+import { View, Text } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { StoryMeta } from "storybook/HelperTypes"
+import { PortalProvider } from "@gorhom/portal"
+
+export const MapSnippetMeta: StoryMeta = {
+  title: "MapSnippet"
+}
+
+export default MapSnippetMeta
+
+export const Basic = () => (
+  <PortalProvider>
+    <SafeAreaView>
+      <TiFFormScrollView>
+        <View style={{ height: 64 }} />
+        <Headline>Hello World</Headline>
+        <MapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
+        <Headline>Hello World</Headline>
+      </TiFFormScrollView>
+    </SafeAreaView>
+  </PortalProvider>
+)

--- a/.storybook/components/MapSnippet/MapSnippet.stories.tsx
+++ b/.storybook/components/MapSnippet/MapSnippet.stories.tsx
@@ -2,7 +2,7 @@ import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { Headline } from "@components/Text"
 import { TiFFormScrollView } from "@components/form-components/ScrollView"
 import { XEROX_ALTO_DEFAULT_REGION } from "@explore-events-boundary"
-import React from "react"
+import React, { useState } from "react"
 import { View, Text } from "react-native"
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context"
 import { StoryMeta } from "storybook/HelperTypes"
@@ -14,17 +14,24 @@ export const MapSnippetMeta: StoryMeta = {
 
 export default MapSnippetMeta
 
-export const Basic = () => (
-  <SafeAreaProvider>
-    <PortalProvider>
-      <SafeAreaView>
-        <TiFFormScrollView>
-          <View style={{ height: 64 }} />
-          <Headline>Hello World</Headline>
-          <ExpandableMapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
-          <Headline>Hello World</Headline>
-        </TiFFormScrollView>
-      </SafeAreaView>
-    </PortalProvider>
-  </SafeAreaProvider>
-)
+export const Basic = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  return (
+    <SafeAreaProvider>
+      <PortalProvider>
+        <SafeAreaView>
+          <TiFFormScrollView>
+            <View style={{ height: 64 }} />
+            <Headline>Hello World</Headline>
+            <ExpandableMapSnippetView
+              isExpanded={isExpanded}
+              onExpansionChanged={setIsExpanded}
+              region={XEROX_ALTO_DEFAULT_REGION}
+            />
+            <Headline>Hello World</Headline>
+          </TiFFormScrollView>
+        </SafeAreaView>
+      </PortalProvider>
+    </SafeAreaProvider>
+  )
+}

--- a/.storybook/components/MapSnippet/MapSnippet.stories.tsx
+++ b/.storybook/components/MapSnippet/MapSnippet.stories.tsx
@@ -1,4 +1,4 @@
-import { MapSnippetView } from "@components/MapSnippetView"
+import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { Headline } from "@components/Text"
 import { TiFFormScrollView } from "@components/form-components/ScrollView"
 import { XEROX_ALTO_DEFAULT_REGION } from "@explore-events-boundary"
@@ -21,7 +21,7 @@ export const Basic = () => (
         <TiFFormScrollView>
           <View style={{ height: 64 }} />
           <Headline>Hello World</Headline>
-          <MapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
+          <ExpandableMapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
           <Headline>Hello World</Headline>
         </TiFFormScrollView>
       </SafeAreaView>

--- a/.storybook/components/MapSnippet/MapSnippet.stories.tsx
+++ b/.storybook/components/MapSnippet/MapSnippet.stories.tsx
@@ -4,7 +4,7 @@ import { TiFFormScrollView } from "@components/form-components/ScrollView"
 import { XEROX_ALTO_DEFAULT_REGION } from "@explore-events-boundary"
 import React from "react"
 import { View, Text } from "react-native"
-import { SafeAreaView } from "react-native-safe-area-context"
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context"
 import { StoryMeta } from "storybook/HelperTypes"
 import { PortalProvider } from "@gorhom/portal"
 
@@ -15,14 +15,16 @@ export const MapSnippetMeta: StoryMeta = {
 export default MapSnippetMeta
 
 export const Basic = () => (
-  <PortalProvider>
-    <SafeAreaView>
-      <TiFFormScrollView>
-        <View style={{ height: 64 }} />
-        <Headline>Hello World</Headline>
-        <MapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
-        <Headline>Hello World</Headline>
-      </TiFFormScrollView>
-    </SafeAreaView>
-  </PortalProvider>
+  <SafeAreaProvider>
+    <PortalProvider>
+      <SafeAreaView>
+        <TiFFormScrollView>
+          <View style={{ height: 64 }} />
+          <Headline>Hello World</Headline>
+          <MapSnippetView region={XEROX_ALTO_DEFAULT_REGION} />
+          <Headline>Hello World</Headline>
+        </TiFFormScrollView>
+      </SafeAreaView>
+    </PortalProvider>
+  </SafeAreaProvider>
 )

--- a/.storybook/components/TiFPreview/TiFPreview.stories.tsx
+++ b/.storybook/components/TiFPreview/TiFPreview.stories.tsx
@@ -23,7 +23,7 @@ const TiFPreview = {
 
 export default TiFPreview
 
-const storage = AlphaUserStorage.ephemeral(AlphaUserMocks.TheDarkLord)
+const storage = AlphaUserStorage.ephemeral()
 const localSettings = PersistentSettingsStores.local(
   new SQLiteLocalSettingsStorage(testSQLite)
 )
@@ -39,7 +39,7 @@ export const Basic = () => (
     localSettingsStore={localSettings}
     userSettingsStore={userSettings}
   >
-    <AlphaUserSessionProvider>
+    <AlphaUserSessionProvider storage={storage}>
       <TiFView
         fetchEvents={eventsByRegion}
         isFontsLoaded={true}

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -146,6 +146,7 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
             marker={marker}
             mapLayout={snippetLayout}
             overlayLayout={overlayLayout}
+            onMarkerPressed={onMarkerPressed}
             expandedMapProps={expandedMapProps}
           />
         )}

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -1,0 +1,178 @@
+import React, { useRef, useState, useCallback } from "react"
+import {
+  View,
+  Text,
+  Dimensions,
+  StyleSheet,
+  Pressable,
+  findNodeHandle,
+  UIManager,
+  StyleProp,
+  ViewStyle,
+  LayoutRectangle
+} from "react-native"
+import MapView, { Marker, Region } from "react-native-maps"
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  runOnJS,
+  interpolate,
+  Extrapolation,
+  SharedValue
+} from "react-native-reanimated"
+import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
+import { Portal } from "@gorhom/portal"
+import { withTiFDefaultSpring } from "@lib/Reanimated"
+
+export type MapSnippetProps = {
+  region: Region
+  style?: StyleProp<ViewStyle>
+}
+
+const SCREEN_WIDTH = Dimensions.get("window").width
+const SCREEN_HEIGHT = Dimensions.get("window").height
+
+/**
+ * A snippet of a map with an expand button that
+ * transitions to a full-screen map using Reanimated.
+ */
+export const MapSnippetView = ({ region }: MapSnippetProps) => {
+  const snippetRef = useRef<View>(null)
+  const [snippetLayout, setSnippetLayout] = useState<
+    LayoutRectangle | undefined
+  >()
+  const [portalVisible, setPortalVisible] = useState(false)
+  const progress = useSharedValue(0)
+  const isExpanding = useSharedValue(false)
+  const expand = useCallback(() => {
+    if (!snippetRef.current) return
+
+    snippetRef.current.measure((_, __, width, height, pageX, pageY) => {
+      setSnippetLayout({ x: pageX, y: pageY, width, height })
+      isExpanding.value = true
+      progress.value = 0
+      setPortalVisible(true)
+      progress.value = withTiFDefaultSpring(1)
+    })
+  }, [progress, isExpanding])
+  const collapse = useCallback(() => {
+    isExpanding.value = false
+    progress.value = withTiFDefaultSpring(0, (finished) => {
+      "worklet"
+      if (finished) {
+        runOnJS(setPortalVisible)(false)
+      }
+    })
+  }, [progress, isExpanding])
+  return (
+    <View style={styles.container}>
+      <View ref={snippetRef} style={styles.snippetContainer}>
+        <MapView style={StyleSheet.absoluteFill} initialRegion={region}>
+          <Marker coordinate={region} />
+        </MapView>
+        <Pressable onPress={expand} style={styles.expandButton}>
+          <Text style={styles.expandButtonText}>Expand</Text>
+        </Pressable>
+      </View>
+      {snippetLayout && (
+        <PortalView
+          isVisible={portalVisible}
+          region={region}
+          onCollapsed={collapse}
+          isExpanding={isExpanding}
+          progress={progress}
+          layout={snippetLayout}
+        />
+      )}
+    </View>
+  )
+}
+
+type PortalProps = {
+  progress: SharedValue<number>
+  isExpanding: SharedValue<boolean>
+  layout: LayoutRectangle
+  isVisible: boolean
+  region: Region
+  onCollapsed: () => void
+}
+
+const PortalView = ({
+  layout,
+  isVisible,
+  onCollapsed,
+  region,
+  progress,
+  isExpanding
+}: PortalProps) => {
+  const animatedMapStyle = useAnimatedStyle(() => {
+    const { x, y, width, height } = layout
+    // NB: This needs to capture progress.value for the expanding animation to work.
+    // eslint-disable-next-line no-unused-vars
+    const _ = progress.value
+    return {
+      position: "absolute",
+      top: withTiFDefaultSpring(isExpanding.value ? 0 : y),
+      left: withTiFDefaultSpring(isExpanding.value ? 0 : x),
+      width: withTiFDefaultSpring(isExpanding.value ? SCREEN_WIDTH : width),
+      height: withTiFDefaultSpring(isExpanding.value ? SCREEN_HEIGHT : height),
+      zIndex: 9999
+    }
+  }, [layout])
+  return (
+    <Portal>
+      {isVisible && (
+        <Animated.View style={[animatedMapStyle]}>
+          <MapView style={StyleSheet.absoluteFill} initialRegion={region}>
+            <Marker coordinate={region} />
+          </MapView>
+          <Pressable onPress={onCollapsed} style={styles.closeButton}>
+            <Text style={styles.closeButtonText}>✕</Text>
+          </Pressable>
+        </Animated.View>
+      )}
+    </Portal>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  snippetContainer: {
+    height: 150,
+    margin: 16,
+    borderRadius: 8,
+    overflow: "hidden"
+  },
+  expandButton: {
+    position: "absolute",
+    top: 8,
+    right: 8,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 4
+  },
+  expandButtonText: {
+    color: "#fff",
+    fontWeight: "600"
+  },
+  closeButton: {
+    position: "absolute",
+    top: 40,
+    right: 20,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  closeButtonText: {
+    color: "#fff",
+    fontSize: 24,
+    lineHeight: 28,
+    fontWeight: "bold"
+  }
+})

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -33,6 +33,7 @@ import { FullWindowOverlay } from "react-native-screens"
 export type ExpandableMapSnippetProps = {
   isExpanded: boolean
   onExpansionChanged: (isExpanded: boolean) => void
+  onMarkerPressed?: () => void
   region: Region
   overlay?: ReactNode
   marker?: ReactNode
@@ -53,6 +54,7 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
     overlay,
     marker,
     style,
+    onMarkerPressed,
     collapsedMapProps,
     expandedMapProps
   }: ExpandableMapSnippetProps,
@@ -109,7 +111,13 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
               }}
               initialRegion={region}
             >
-              <Marker coordinate={region}>{marker}</Marker>
+              <Marker
+                coordinate={region}
+                tracksViewChanges={false}
+                onPress={onMarkerPressed}
+              >
+                {marker}
+              </Marker>
             </MapView>
           )}
           <TouchableIonicon
@@ -156,6 +164,7 @@ type ExpandedMapProps = {
   overlayLayout: LayoutRectangle
   isVisible: boolean
   expandedMapProps?: MapViewProps
+  onMarkerPressed?: () => void
   onCollapsed: () => void
 }
 
@@ -171,6 +180,7 @@ const ExpandedMapView = ({
   marker,
   progress,
   isExpanding,
+  onMarkerPressed,
   expandedMapProps
 }: ExpandedMapProps) => {
   const safeAreaInsets = useSafeAreaInsets()
@@ -228,7 +238,13 @@ const ExpandedMapView = ({
               bottom: overlayLayout.height + 24
             }}
           >
-            <Marker coordinate={region}>{marker}</Marker>
+            <Marker
+              coordinate={region}
+              tracksViewChanges={false}
+              onPress={onMarkerPressed}
+            >
+              {marker}
+            </Marker>
           </MapView>
           <Animated.View
             style={[styles.fullscreenOverlayContainer, overlayStyle]}

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState, useCallback, Children } from "react"
+import React, { useRef, useState, useCallback, ReactNode } from "react"
 import {
+  Platform,
   View,
-  Dimensions,
+  useWindowDimensions,
   StyleSheet,
   StyleProp,
   ViewStyle,
@@ -19,16 +20,14 @@ import { withTiFDefaultSpring } from "@lib/Reanimated"
 import { TouchableIonicon } from "./common/Icons"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useScreenBottomPadding } from "./Padding"
+import { FullWindowOverlay } from "react-native-screens"
 
 export type MapSnippetProps = {
   region: Region
-  overlay?: JSX.Element
-  marker?: JSX.Element
+  overlay?: ReactNode
+  marker?: ReactNode
   style?: StyleProp<ViewStyle>
 } & MapViewProps
-
-const SCREEN_WIDTH = Dimensions.get("window").width
-const SCREEN_HEIGHT = Dimensions.get("window").height
 
 /**
  * A snippet of a map with an expand button that
@@ -70,7 +69,6 @@ export const MapSnippetView = ({
       }
     })
   }, [progress, isExpanding])
-  console.log(overlayLayout)
   return (
     <View style={style}>
       <View style={styles.container}>
@@ -109,7 +107,7 @@ export const MapSnippetView = ({
           </View>
         </View>
         {snippetLayout && overlayLayout && (
-          <PortalView
+          <ExpandedMapView
             isVisible={portalVisible}
             region={region}
             onCollapsed={collapse}
@@ -126,7 +124,7 @@ export const MapSnippetView = ({
   )
 }
 
-type PortalProps = MapSnippetProps & {
+type ExpandedMapProps = MapSnippetProps & {
   progress: SharedValue<number>
   isExpanding: SharedValue<boolean>
   mapLayout: LayoutRectangle
@@ -135,7 +133,9 @@ type PortalProps = MapSnippetProps & {
   onCollapsed: () => void
 }
 
-const PortalView = ({
+const PortalView = Platform.OS === "ios" ? FullWindowOverlay : Portal
+
+const ExpandedMapView = ({
   mapLayout,
   isVisible,
   onCollapsed,
@@ -146,27 +146,49 @@ const PortalView = ({
   progress,
   isExpanding,
   ...mapProps
-}: PortalProps) => {
+}: ExpandedMapProps) => {
+  const safeAreaInsets = useSafeAreaInsets()
+  const windowDimensions = useWindowDimensions()
   const animatedMapStyle = useAnimatedStyle(() => {
     const { x, y, width, height } = mapLayout
     // NB: This needs to capture progress.value for the expanding animation to work.
     // eslint-disable-next-line no-unused-vars
     const _ = progress.value
+    const mapHeightAdder = Platform.OS === "android" ? safeAreaInsets.top : 0
     return {
       position: "absolute",
       top: withTiFDefaultSpring(isExpanding.value ? 0 : y),
       left: withTiFDefaultSpring(isExpanding.value ? 0 : x),
-      width: withTiFDefaultSpring(isExpanding.value ? SCREEN_WIDTH : width),
-      height: withTiFDefaultSpring(isExpanding.value ? SCREEN_HEIGHT : height)
+      width: withTiFDefaultSpring(
+        isExpanding.value ? windowDimensions.width : width
+      ),
+      height: withTiFDefaultSpring(
+        isExpanding.value ? windowDimensions.height + mapHeightAdder : height
+      )
     }
   }, [mapLayout])
-  const { top, bottom } = useSafeAreaInsets()
   const bottomPadding = useScreenBottomPadding({
     safeAreaScreens: 8,
     nonSafeAreaScreens: 24
   })
+  const animatedCollapseButtonStyle = useAnimatedStyle(() => ({
+    position: "absolute",
+    height: "100%",
+    top: withTiFDefaultSpring(
+      isExpanding.value
+        ? safeAreaInsets.top + (Platform.OS === "android" ? 8 : 0)
+        : 8
+    ),
+    right: withTiFDefaultSpring(isExpanding.value ? 24 : 8)
+  }))
+  const overlayStyle = useAnimatedStyle(() => ({
+    paddingHorizontal: withTiFDefaultSpring(isExpanding.value ? 24 : 16),
+    bottom: withTiFDefaultSpring(
+      isExpanding.value ? safeAreaInsets.bottom + bottomPadding : 16
+    )
+  }))
   return (
-    <Portal>
+    <PortalView>
       {isVisible && (
         <Animated.View style={animatedMapStyle}>
           <MapView
@@ -177,30 +199,38 @@ const PortalView = ({
               top: 0,
               left: 0,
               right: 0,
-              bottom: overlayLayout.height + 16
+              bottom: overlayLayout.height + 24
             }}
           >
             <Marker coordinate={region}>{marker}</Marker>
           </MapView>
-          <View
-            style={[
-              styles.fullscreenOverlayContainer,
-              { bottom: bottom + bottomPadding }
-            ]}
+          <Animated.View
+            style={[styles.fullscreenOverlayContainer, overlayStyle]}
           >
             <View style={styles.fullscreenOverlay}>{overlay}</View>
-          </View>
-          <TouchableIonicon
-            icon={{ name: "contract" }}
-            onPress={onCollapsed}
-            activeOpacity={0.8}
-            style={[styles.closeButton, { top }]}
-          />
+          </Animated.View>
+          <Animated.View style={animatedCollapseButtonStyle}>
+            <TouchableIonicon
+              icon={{ name: "contract" }}
+              onPress={onCollapsed}
+              activeOpacity={0.8}
+              style={styles.zoomButton}
+            />
+          </Animated.View>
         </Animated.View>
       )}
-    </Portal>
+    </PortalView>
   )
 }
+
+const ZOOM_BUTTON_STYLES = {
+  width: 40,
+  minHeight: 40,
+  borderRadius: 12,
+  backgroundColor: "white",
+  alignItems: "center",
+  justifyContent: "center"
+} as const
 
 const styles = StyleSheet.create({
   container: {
@@ -216,27 +246,12 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     overflow: "hidden"
   },
-  closeButton: {
-    position: "absolute",
-    right: 24,
-    top: 24,
-    width: 40,
-    minHeight: 40,
-    borderRadius: 12,
-    backgroundColor: "white",
-    alignItems: "center",
-    justifyContent: "center"
-  },
+  zoomButton: ZOOM_BUTTON_STYLES,
   expandButton: {
+    ...ZOOM_BUTTON_STYLES,
     position: "absolute",
     right: 8,
-    top: 8,
-    width: 40,
-    minHeight: 40,
-    borderRadius: 12,
-    backgroundColor: "white",
-    alignItems: "center",
-    justifyContent: "center"
+    top: 8
   },
   overlayContainer: {
     paddingHorizontal: 16

--- a/core-root/TiFView.tsx
+++ b/core-root/TiFView.tsx
@@ -7,6 +7,7 @@ import { TiFQueryClientProvider } from "@lib/ReactQuery"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { TiFBottomSheetProvider } from "@components/BottomSheet"
 import { RootNavigation } from "./navigation/Root"
+import { PortalProvider } from "@gorhom/portal"
 
 export type TiFProps = {
   isFontsLoaded: boolean
@@ -20,19 +21,21 @@ export const TiFView = ({ isFontsLoaded, style, ...props }: TiFProps) => {
   if (!isFontsLoaded) return null
   return (
     <GestureHandlerRootView>
-      <TiFQueryClientProvider>
-        <SafeAreaProvider>
-          <RootSiblingParent>
-            <TiFBottomSheetProvider>
-              <View style={style}>
-                <TiFContext.Provider value={props}>
-                  <RootNavigation />
-                </TiFContext.Provider>
-              </View>
-            </TiFBottomSheetProvider>
-          </RootSiblingParent>
-        </SafeAreaProvider>
-      </TiFQueryClientProvider>
+      <PortalProvider>
+        <TiFQueryClientProvider>
+          <SafeAreaProvider>
+            <RootSiblingParent>
+              <TiFBottomSheetProvider>
+                <View style={style}>
+                  <TiFContext.Provider value={props}>
+                    <RootNavigation />
+                  </TiFContext.Provider>
+                </View>
+              </TiFBottomSheetProvider>
+            </RootSiblingParent>
+          </SafeAreaProvider>
+        </TiFQueryClientProvider>
+      </PortalProvider>
     </GestureHandlerRootView>
   )
 }

--- a/core-root/navigation/EventDetails.tsx
+++ b/core-root/navigation/EventDetails.tsx
@@ -8,6 +8,7 @@ import { EventDetailsView } from "@event-details-boundary/Details"
 import { useLoadEventDetails } from "@event/DetailsQuery"
 import { StaticScreenProps, useNavigation } from "@react-navigation/native"
 import { EventID } from "TiFShared/domain-models/Event"
+import { PortalProvider } from "@gorhom/portal"
 
 export const eventDetailsScreens = () => ({
   eventDetails: {
@@ -47,11 +48,13 @@ type EventDetailsScreenProps = StaticScreenProps<{
 const EventDetailsScreen = ({ route }: EventDetailsScreenProps) => {
   const navigation = useNavigation()
   return (
+    // <PortalProvider>
     <EventDetailsContentView
       result={useLoadEventDetails(route.params.id)}
       onExploreOtherEventsTapped={() => navigation.navigate("home")}
     >
       {(state) => <EventDetailsView state={state} />}
     </EventDetailsContentView>
+    // </PortalProvider>
   )
 }

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -126,6 +126,7 @@ const LocationView = ({
               }
             ]
           }}
+          expandedMapProps={{ showsUserLocation: true }}
           marker={
             <AvatarMapMarkerView
               name={hostName}

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -4,7 +4,6 @@ import {
   StyleProp,
   View,
   StyleSheet,
-  LayoutRectangle,
   ActivityIndicator
 } from "react-native"
 import { editEventFormValueAtoms } from "./FormAtoms"
@@ -16,14 +15,13 @@ import {
 import React, { useEffect, useRef, useState } from "react"
 import { TiFFormNavigationLinkView } from "@components/form-components/NavigationLink"
 import { AppStyles } from "@lib/AppColorStyle"
-import MapView, { Marker } from "react-native-maps"
-import Animated, { FadeIn } from "react-native-reanimated"
-import { TiFFormCardView } from "@components/form-components/Card"
+import MapView from "react-native-maps"
 import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
 import { FontScaleFactors } from "@lib/Fonts"
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { EditEventFormLocation } from "@event/EditFormValues"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
+import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 
 export const useEditEventFormLocation = () => {
   const [location, setLocation] = useAtom(editEventFormValueAtoms.location)
@@ -102,101 +100,77 @@ const LocationView = ({
   onSelectLocationTapped
 }: LocationProps) => {
   const mapRef = useRef<MapView>(null)
-  const [overlayLayout, setOverlayLayout] = useState<
-    LayoutRectangle | undefined
-  >(undefined)
   useEffect(() => {
     if (location.coordinate) {
       mapRef.current?.animateToRegion(mapRegion(location.coordinate))
     }
   }, [location.coordinate])
-  const mapHeight = overlayLayout && Math.max(300, 200 + overlayLayout.height)
+  const [isExpanded, setIsExpanded] = useState(false)
   return (
-    <View style={[styles.locationContainer, { height: mapHeight }]}>
-      {mapHeight && (
-        <Animated.View
-          entering={FadeIn.duration(300)}
-          style={styles.mapDimensions}
-        >
-          {location.coordinate ? (
-            <MapView
-              style={[styles.mapDimensions, { height: mapHeight }]}
-              loadingEnabled
-              ref={mapRef}
-              zoomEnabled={false}
-              scrollEnabled={false}
-              initialRegion={mapRegion(location.coordinate)}
-              mapPadding={{
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: overlayLayout.height + 24
-              }}
-              customMapStyle={[
-                {
-                  featureType: "poi",
-                  stylers: [{ visibility: "off" }]
-                },
-                {
-                  featureType: "transit",
-                  stylers: [{ visibility: "off" }]
-                }
-              ]}
-            >
-              <Marker coordinate={location.coordinate}>
-                <AvatarMapMarkerView
-                  name={hostName}
-                  imageURL={hostProfileImageURL}
+    <View>
+      {location.coordinate ? (
+        <ExpandableMapSnippetView
+          ref={mapRef}
+          isExpanded={isExpanded}
+          onExpansionChanged={setIsExpanded}
+          region={mapRegion(location.coordinate)}
+          collapsedMapProps={{
+            customMapStyle: [
+              {
+                featureType: "poi",
+                stylers: [{ visibility: "off" }]
+              },
+              {
+                featureType: "transit",
+                stylers: [{ visibility: "off" }]
+              }
+            ]
+          }}
+          marker={
+            <AvatarMapMarkerView
+              name={hostName}
+              imageURL={hostProfileImageURL}
+            />
+          }
+          overlay={
+            <View style={styles.overlayContainer}>
+              {!location.placemark ? (
+                <TiFFormNavigationLinkView
+                  iconName="location"
+                  iconBackgroundColor={AppStyles.primary}
+                  maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                  style={styles.locationMapNavigationLink}
+                  title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
+                  onTapped={() => {
+                    setIsExpanded(false)
+                    onSelectLocationTapped()
+                  }}
                 />
-              </Marker>
-            </MapView>
-          ) : (
-            <View
-              style={[
-                styles.mapDimensions,
-                styles.loadingMap,
-                { height: mapHeight }
-              ]}
-            >
-              <ActivityIndicator
-                style={{ marginTop: (mapHeight - overlayLayout.height) / 2 }}
-              />
+              ) : (
+                <TiFFormNavigationLinkView
+                  iconName="location"
+                  iconBackgroundColor={AppStyles.primary}
+                  style={styles.locationMapNavigationLink}
+                  title={location.placemark.name ?? "Unknown Location"}
+                  maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                  description={
+                    placemarkToFormattedAddress(location.placemark) ??
+                    "Unknown Address"
+                  }
+                  onTapped={() => {
+                    setIsExpanded(false)
+                    onSelectLocationTapped()
+                  }}
+                />
+              )}
             </View>
-          )}
-        </Animated.View>
+          }
+        />
+      ) : (
+        <View style={[styles.mapDimensions, styles.loadingMap]}>
+          <ActivityIndicator />
+        </View>
       )}
-      <View style={styles.overlayContainer}>
-        <TiFFormCardView borderRadius={8} style={styles.overlay}>
-          <View
-            style={styles.overlayRow}
-            onLayout={(event) => setOverlayLayout(event.nativeEvent.layout)}
-          >
-            {!location.placemark ? (
-              <TiFFormNavigationLinkView
-                iconName="location"
-                iconBackgroundColor={AppStyles.primary}
-                maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                style={styles.locationMapNavigationLink}
-                title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
-                onTapped={onSelectLocationTapped}
-              />
-            ) : (
-              <TiFFormNavigationLinkView
-                iconName="location"
-                iconBackgroundColor={AppStyles.primary}
-                style={styles.locationMapNavigationLink}
-                title={location.placemark.name ?? "Unknown Location"}
-                maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                description={
-                  placemarkToFormattedAddress(location.placemark) ??
-                  "Unknown Address"
-                }
-                onTapped={onSelectLocationTapped}
-              />
-            )}
-          </View>
-        </TiFFormCardView>
-      </View>
     </View>
   )
 }
@@ -230,10 +204,12 @@ const styles = StyleSheet.create({
     height: 300
   },
   loadingMap: {
+    height: 300,
     backgroundColor: AppStyles.colorOpacity15
   },
   overlayContainer: {
-    paddingHorizontal: 16
+    borderRadius: 12,
+    overflow: "hidden"
   },
   overlay: {
     position: "absolute",

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -1,4 +1,5 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
+import { MapSnippetView } from "@components/MapSnippetView"
 import { BodyText, Caption, CaptionTitle, Headline } from "@components/Text"
 import { Ionicon, RoundedIonicon } from "@components/common/Icons"
 import { ClientSideEvent } from "@event/ClientSideEvent"
@@ -197,84 +198,60 @@ export const EventTravelEstimatesView = ({
           precise ETA.
         </NoticeLabel>
       )}
-      <Animated.View
-        layout={TiFDefaultLayoutTransition}
-        style={styles.mapContainer}
-      >
-        {overlayLayout && (
-          <Animated.View entering={FadeIn.duration(300)}>
-            <MapView
-              style={[
-                styles.mapDimensions,
-                { height: Math.max(300, 200 + overlayLayout.height) }
-              ]}
-              loadingEnabled
-              zoomEnabled={false}
-              scrollEnabled={false}
-              initialRegion={{
-                ...location.coordinate,
-                latitudeDelta: 0.007,
-                longitudeDelta: 0.007
-              }}
-              mapPadding={{
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: overlayLayout.height + 16
-              }}
-              customMapStyle={[
-                {
-                  featureType: "poi",
-                  stylers: [{ visibility: "off" }]
-                },
-                {
-                  featureType: "transit",
-                  stylers: [{ visibility: "off" }]
-                }
-              ]}
-            >
-              <Marker coordinate={location.coordinate}>
-                <AvatarMapMarkerView
-                  name={host.name}
-                  imageURL={host.profileImageURL ?? undefined}
+      <Animated.View layout={TiFDefaultLayoutTransition}>
+        <MapSnippetView
+          region={{
+            ...location.coordinate,
+            latitudeDelta: 0.007,
+            longitudeDelta: 0.007
+          }}
+          overlay={
+            <>
+              <Headline
+                maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
+                style={styles.directionsText}
+              >
+                Get Directions
+              </Headline>
+              <View style={styles.travelTypesContainer}>
+                <TravelTypeButton
+                  travelKey="walking"
+                  location={location}
+                  result={result}
+                  style={styles.travelTypeButton}
                 />
-              </Marker>
-            </MapView>
-          </Animated.View>
-        )}
-        <View style={styles.overlayContainer}>
-          <View
-            style={styles.overlay}
-            onLayout={(event) => setOverlayLayout(event.nativeEvent.layout)}
-          >
-            <Headline
-              maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
-              style={styles.directionsText}
-            >
-              Get Directions
-            </Headline>
-            <View style={styles.travelTypesContainer}>
-              <TravelTypeButton
-                travelKey="walking"
-                location={location}
-                result={result}
-                style={styles.travelTypeButton}
-              />
-              <TravelTypeButton
-                travelKey="automobile"
-                location={location}
-                result={result}
-                style={styles.travelTypeButton}
-              />
-              <TravelTypeButton
-                travelKey="publicTransportation"
-                location={location}
-                result={result}
-                style={styles.travelTypeButton}
-              />
-            </View>
-          </View>
-        </View>
+                <TravelTypeButton
+                  travelKey="automobile"
+                  location={location}
+                  result={result}
+                  style={styles.travelTypeButton}
+                />
+                <TravelTypeButton
+                  travelKey="publicTransportation"
+                  location={location}
+                  result={result}
+                  style={styles.travelTypeButton}
+                />
+              </View>
+            </>
+          }
+          customMapStyle={[
+            {
+              featureType: "poi",
+              stylers: [{ visibility: "off" }]
+            },
+            {
+              featureType: "transit",
+              stylers: [{ visibility: "off" }]
+            }
+          ]}
+          marker={
+            <AvatarMapMarkerView
+              name={host.name}
+              imageURL={host.profileImageURL ?? undefined}
+            />
+          }
+        />
       </Animated.View>
     </View>
   )

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -256,7 +256,10 @@ export const EventTravelEstimatesView = ({
               imageURL={host.profileImageURL ?? undefined}
             />
           }
-          onMarkerPressed={() => presentProfile(host.id)}
+          onMarkerPressed={() => {
+            setIsExpanded(false)
+            presentProfile(host.id)
+          }}
         />
       </Animated.View>
     </View>

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -1,5 +1,6 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { ExpandableMapSnippetView } from "@components/MapSnippetView"
+import { useCoreNavigation } from "@components/Navigation"
 import { BodyText, Caption, CaptionTitle, Headline } from "@components/Text"
 import { Ionicon, RoundedIonicon } from "@components/common/Icons"
 import { ClientSideEvent } from "@event/ClientSideEvent"
@@ -26,6 +27,7 @@ import { openSettings } from "expo-linking"
 import { LocationAccuracy } from "expo-location"
 import { CodedError } from "expo-modules-core"
 import { ReactNode, useState } from "react"
+import { Pressable } from "react-native"
 import {
   LayoutRectangle,
   Platform,
@@ -174,6 +176,7 @@ export const EventTravelEstimatesView = ({
   style
 }: EventTravelEstimatesProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const { presentProfile } = useCoreNavigation()
   return (
     <View style={[style]}>
       {result.status === "disabled" && (
@@ -253,6 +256,7 @@ export const EventTravelEstimatesView = ({
               imageURL={host.profileImageURL ?? undefined}
             />
           }
+          onMarkerPressed={() => presentProfile(host.id)}
         />
       </Animated.View>
     </View>

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -1,5 +1,5 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
-import { MapSnippetView } from "@components/MapSnippetView"
+import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { BodyText, Caption, CaptionTitle, Headline } from "@components/Text"
 import { Ionicon, RoundedIonicon } from "@components/common/Icons"
 import { ClientSideEvent } from "@event/ClientSideEvent"
@@ -173,9 +173,7 @@ export const EventTravelEstimatesView = ({
   result,
   style
 }: EventTravelEstimatesProps) => {
-  const [overlayLayout, setOverlayLayout] = useState<
-    LayoutRectangle | undefined
-  >(undefined)
+  const [isExpanded, setIsExpanded] = useState(false)
   return (
     <View style={[style]}>
       {result.status === "disabled" && (
@@ -199,14 +197,16 @@ export const EventTravelEstimatesView = ({
         </NoticeLabel>
       )}
       <Animated.View layout={TiFDefaultLayoutTransition}>
-        <MapSnippetView
+        <ExpandableMapSnippetView
+          isExpanded={isExpanded}
+          onExpansionChanged={setIsExpanded}
           region={{
             ...location.coordinate,
             latitudeDelta: 0.007,
             longitudeDelta: 0.007
           }}
           overlay={
-            <>
+            <View style={styles.overlay}>
               <Headline
                 maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
                 style={styles.directionsText}
@@ -233,18 +233,20 @@ export const EventTravelEstimatesView = ({
                   style={styles.travelTypeButton}
                 />
               </View>
-            </>
+            </View>
           }
-          customMapStyle={[
-            {
-              featureType: "poi",
-              stylers: [{ visibility: "off" }]
-            },
-            {
-              featureType: "transit",
-              stylers: [{ visibility: "off" }]
-            }
-          ]}
+          collapsedMapProps={{
+            customMapStyle: [
+              {
+                featureType: "poi",
+                stylers: [{ visibility: "off" }]
+              },
+              {
+                featureType: "transit",
+                stylers: [{ visibility: "off" }]
+              }
+            ]
+          }}
           marker={
             <AvatarMapMarkerView
               name={host.name}
@@ -385,15 +387,7 @@ const styles = StyleSheet.create({
     width: "100%",
     borderRadius: 12
   },
-  overlayContainer: {
-    paddingHorizontal: 16
-  },
   overlay: {
-    position: "absolute",
-    bottom: 16,
-    marginHorizontal: 16,
-    borderRadius: 12,
-    backgroundColor: "white",
     width: "100%",
     padding: 16
   },

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -18,7 +18,7 @@ import {
   eventTravelEstimates
 } from "@modules/tif-travel-estimates"
 import { useQuery } from "@tanstack/react-query"
-import { EventAttendee, EventLocation } from "TiFShared/domain-models/Event"
+import { EventLocation } from "TiFShared/domain-models/Event"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
 import { dayjs } from "TiFShared/lib/Dayjs"
 import { metersToMiles } from "TiFShared/lib/MetricConversions"
@@ -27,9 +27,7 @@ import { openSettings } from "expo-linking"
 import { LocationAccuracy } from "expo-location"
 import { CodedError } from "expo-modules-core"
 import { ReactNode, useState } from "react"
-import { Pressable } from "react-native"
 import {
-  LayoutRectangle,
   Platform,
   StyleProp,
   StyleSheet,
@@ -37,7 +35,6 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import MapView, { Marker } from "react-native-maps"
 import Animated, { FadeIn } from "react-native-reanimated"
 
 export const EventTravelEstimatesFeature = featureContext({
@@ -250,6 +247,7 @@ export const EventTravelEstimatesView = ({
               }
             ]
           }}
+          expandedMapProps={{ showsUserLocation: true }}
           marker={
             <AvatarMapMarkerView
               name={host.name}

--- a/lib/Reanimated.ts
+++ b/lib/Reanimated.ts
@@ -1,11 +1,19 @@
-import { Layout, withSpring, AnimatableValue } from "react-native-reanimated"
+import {
+  Layout,
+  withSpring,
+  AnimatableValue,
+  AnimationCallback
+} from "react-native-reanimated"
 
 /**
  * The default layout transition to use whe working with reanimated.
  */
 export const TiFDefaultLayoutTransition = Layout.springify().damping(14)
 
-export const withTiFDefaultSpring = <T extends AnimatableValue>(value: T) => {
+export const withTiFDefaultSpring = <T extends AnimatableValue>(
+  value: T,
+  callback?: AnimationCallback
+) => {
   "worklet"
-  return withSpring(value, { damping: 14 })
+  return withSpring(value, { damping: 14 }, callback)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@expo/prebuild-config": "~7.0.0",
         "@fragaria/address-formatter": "^5.0.1",
         "@gorhom/bottom-sheet": "^4.6.4",
+        "@gorhom/portal": "^1.0.14",
         "@jest/reporters": "29.4.1",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-community/checkbox": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@expo/prebuild-config": "~7.0.0",
     "@fragaria/address-formatter": "^5.0.1",
     "@gorhom/bottom-sheet": "^4.6.4",
+    "@gorhom/portal": "^1.0.14",
     "@jest/reporters": "29.4.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/checkbox": "^0.5.5",


### PR DESCRIPTION
One of our complaints revolved around not being able to interact with the map snipped in any meaningful way when in the event details view such as panning it or zooming it. Because interacting with a small map snippet isn't very ergonomic from the UX standpoint, I decided to add an expand button that expands the map to fullscreen, and allows interactivity once in full screen.

Here's a look:
https://imgur.com/m1fbhKV

To implement this, I had to make use of `@gorhom/portal` on Android in order to make the map expand to full screen. On iOS, I could use `FullWindowOverlay` to achieve the same effect. This led to some differences on how size and padding were calculated on both OSes.

The animation works by springing the size of the map to full screen using reanimated. This turned out to have acceptable performance even on my ~6 year old S10e, so it should be good to go.

I also adopted this logic into a shared `ExpandableMapSnippetView` used in both the edit event form and event details.

## Tickets

https://trello.com/c/e9PTHy5I