### PR TITLE
Navigation Cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,6 +69,7 @@
   "globals": {
     "RequestInfo": "readonly",
     "RequestInit": "readonly",
+    "ReactNavigation": "readonly",
     "JSX": "readonly",
     "NodeJS": "readonly",
     "__DEV__": "readonly"

--- a/.storybook/.ondevice/storybook.requires.ts
+++ b/.storybook/.ondevice/storybook.requires.ts
@@ -13,12 +13,12 @@ const normalizedStories = [
     directory: "./.storybook/components",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
     // @ts-ignore
     req: require.context(
       "../components",
       true,
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
 ];

--- a/.storybook/components/TiFPreview/TiFPreview.stories.tsx
+++ b/.storybook/components/TiFPreview/TiFPreview.stories.tsx
@@ -1,6 +1,7 @@
 import { TiFView } from "@core-root"
 import { EventMocks } from "@event-details-boundary/MockData"
 import { clientSideEventFromResponse } from "@event/ClientSideEvent"
+import { eventsByRegion } from "@explore-events-boundary"
 import { randomIntegerInRange } from "@lib/utils/Random"
 import { SettingsProvider } from "@settings-storage/Hooks"
 import { SQLiteLocalSettingsStorage } from "@settings-storage/LocalSettings"
@@ -38,13 +39,7 @@ export const Basic = () => (
     <UserProfileFeature.Provider>
       <AlphaUserSessionProvider storage={storage}>
         <TiFView
-          fetchEvents={async () =>
-            repeatElements(10, () =>
-              clientSideEventFromResponse(
-                EventMocks.MockMultipleAttendeeResponse
-              )
-            ).map((e) => ({ ...e, id: randomIntegerInRange(0, 10_000) }))
-          }
+          fetchEvents={eventsByRegion}
           isFontsLoaded={true}
           style={{ flex: 1 }}
         />

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,12 +1,7 @@
-import {
-  NavigationProp,
-  ParamListBase,
-  useFocusEffect,
-  useNavigation
-} from "@react-navigation/native"
+import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { type NavigationState } from "@react-navigation/routers"
 import { createStackNavigator } from "@react-navigation/stack"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useRef } from "react"
 import { StyleProp, StyleSheet, ViewStyle } from "react-native"
 import { TouchableIonicon } from "./common/Icons"
 import { EventID } from "TiFShared/domain-models/Event"

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,10 +1,12 @@
 import {
   NavigationProp,
   ParamListBase,
+  useFocusEffect,
   useNavigation
 } from "@react-navigation/native"
+import { type NavigationState } from "@react-navigation/routers"
 import { createStackNavigator } from "@react-navigation/stack"
-import React from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { StyleProp, StyleSheet, ViewStyle } from "react-native"
 import { TouchableIonicon } from "./common/Icons"
 import { EventID } from "TiFShared/domain-models/Event"
@@ -32,33 +34,22 @@ export const useCoreNavigation = () => {
     presentEditEvent: (edit: EditEventFormValues, id?: EventID) => {
       const formValues = toRouteableEditFormValues(edit)
       if (id) {
-        navigation.navigate("editEvent", {
+        navigation.navigate("modal", {
           screen: "editEventForm",
           params: { ...formValues, id }
         })
       } else {
-        navigation.navigate("editEvent", {
+        navigation.navigate("modal", {
           screen: "createEventForm",
           params: formValues
         })
       }
     },
-    presentProfile: (
-      id: UserID | UserHandle,
-      method: "navigate" | "replace" = "navigate"
-    ) => {
-      ;(navigation as any)[method]("editEvent", {
-        screen: "userProfile",
-        params: { id, method }
-      })
+    presentProfile: (id: UserID | UserHandle) => {
+      navigation.navigate("modal", { screen: "userProfile", params: { id } })
     },
-    pushEventDetails: (
-      id: EventID,
-      method: "navigate" | "replace" = "navigate"
-    ) => {
-      // NB: Typescript doesn't like the subscript for some reason, but navigation should always
-      // have a navigate and replace method.
-      ;(navigation as any)[method]("eventDetails", { id, method })
+    pushEventDetails: (id: EventID) => {
+      navigation.navigate("eventDetails", { id })
     },
     pushAttendeesList: (id: EventID) => {
       navigation.navigate("eventAttendeesList", { id })
@@ -81,36 +72,83 @@ export const BASE_HEADER_SCREEN_OPTIONS = {
   }
 }
 
+// NB: ReturnType<typeof useNavigation> resolves to unknown, so we'll copy the type from react
+// navigation instead.
+
+export type UseNavigationReturn = Omit<
+  NavigationProp<ReactNavigation.RootParamList>,
+  "getState"
+> & {
+  getState(): NavigationState | undefined
+}
+
 export type BackButtonProps = NativeStackHeaderLeftProps & {
+  navigation?: UseNavigationReturn
   style?: StyleProp<ViewStyle>
+}
+
+/**
+ * Sets the back button for the current screen.
+ *
+ * Use this hook instead of setting the back button in the screen options because `useNavigation`
+ * will return the parent navigator inside a nested navigator screen. This causes the `goBack`
+ * method to dismiss the entire nested navigator instead of navigating to the previous screen
+ * within the nested navigator.
+ *
+ * @param Button The button component to render. By default, the component is determined by the position of the screen on the stack.
+ */
+export const useBackButton = (
+  Button?: (props: BackButtonProps) => JSX.Element
+) => {
+  const navigation = useNavigation()
+  const DefaultButton = useDefaultBackButtonView()
+  const HeaderButton = Button ?? DefaultButton
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => <HeaderButton navigation={navigation} />
+    })
+  }, [navigation, HeaderButton])
+}
+
+const useDefaultBackButtonView = () => {
+  const indexRef = useRef(-1)
+  const state = useNavigation().getState()
+  indexRef.current =
+    indexRef.current === -1 && state?.index !== undefined
+      ? state.index
+      : indexRef.current
+  const isFirstStackScreen = indexRef.current === 0
+  return isFirstStackScreen ? XMarkBackButton : ChevronBackButton
 }
 
 /**
  * A back button that is a simple chevron icon.
  */
 export const ChevronBackButton = ({
+  navigation,
   style = styles.backButtonPadding
 }: BackButtonProps) => {
-  const navigation: NavigationProp<ParamListBase> = useNavigation()
+  const currentNavigation = useNavigation()
   return (
     <TouchableIonicon
       icon={{ name: "chevron-back" }}
       accessibilityLabel="Go Back"
-      onPress={() => navigation.goBack()}
+      onPress={() => (navigation ?? currentNavigation).goBack()}
       style={style}
     />
   )
 }
 
 export const XMarkBackButton = ({
+  navigation,
   style = styles.backButtonPadding
 }: BackButtonProps) => {
-  const navigation: NavigationProp<ParamListBase> = useNavigation()
+  const currentNavigation = useNavigation()
   return (
     <TouchableIonicon
       icon={{ name: "close" }}
       accessibilityLabel="Go Back"
-      onPress={() => navigation.goBack()}
+      onPress={() => (navigation ?? currentNavigation).goBack()}
       style={style}
     />
   )

--- a/core-root/AlphaRegister.tsx
+++ b/core-root/AlphaRegister.tsx
@@ -95,6 +95,7 @@ export type WithAlphaRegistrationProps<Props> = Props & { session: UserSession }
  *
  * If the user is not authenticated, the {@link AlphaRegisterView} is presented instead.
  */
+// eslint-disable-next-line comma-spacing
 export const withAlphaRegistration = <Props,>(
   Component: (props: WithAlphaRegistrationProps<Props>) => ReactNode
 ) => {

--- a/core-root/navigation/EditEvent.tsx
+++ b/core-root/navigation/EditEvent.tsx
@@ -36,7 +36,7 @@ const EditEventScreen = withAlphaRegistration(
         onSelectLocationTapped={() => {
           navigation.navigate("modal", { screen: "editEventLocationSearch" })
         }}
-        onSuccess={(e) => pushEventDetails(e.id)}
+        onSuccess={(e) => pushEventDetails(e.id, "replace")}
         style={styles.screen}
       />
     )

--- a/core-root/navigation/EditEvent.tsx
+++ b/core-root/navigation/EditEvent.tsx
@@ -1,7 +1,4 @@
-import {
-  BASE_HEADER_SCREEN_OPTIONS,
-  useCoreNavigation
-} from "@components/Navigation"
+import { useCoreNavigation } from "@components/Navigation"
 import {
   withAlphaRegistration,
   WithAlphaRegistrationProps
@@ -18,12 +15,9 @@ import {
   useLocationsSearch
 } from "@location-search-boundary"
 import { StaticScreenProps, useNavigation } from "@react-navigation/native"
-import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { EventID } from "TiFShared/domain-models/Event"
 import { useSetAtom } from "jotai"
 import { StyleSheet } from "react-native"
-import { eventDetailsScreens } from "./EventDetails"
-import { profileScreens } from "./Profile"
 
 type EditEventScreenProps = WithAlphaRegistrationProps<
   StaticScreenProps<RouteableEditEventFormValues & { id?: EventID }>
@@ -40,11 +34,9 @@ const EditEventScreen = withAlphaRegistration(
         hostName={session.name}
         hostProfileImageURL={session.profileImageURL}
         onSelectLocationTapped={() => {
-          navigation.navigate("editEvent", {
-            screen: "editEventLocationSearch"
-          })
+          navigation.navigate("modal", { screen: "editEventLocationSearch" })
         }}
-        onSuccess={(e) => pushEventDetails(e.id, "replace")}
+        onSuccess={(e) => pushEventDetails(e.id)}
         style={styles.screen}
       />
     )
@@ -73,29 +65,24 @@ const EditEventFormBackButton = () => (
   <EditEventFormDismissButton onDismiss={useNavigation().goBack} />
 )
 
-export const EditEventNavigator = createNativeStackNavigator({
-  screenOptions: () => BASE_HEADER_SCREEN_OPTIONS,
-  screens: {
-    editEventForm: {
-      options: {
-        headerTitle: "Edit Event",
-        headerLeft: EditEventFormBackButton
-      },
-      screen: EditEventScreen
+export const editEventScreens = () => ({
+  editEventForm: {
+    options: {
+      headerTitle: "Edit Event",
+      headerLeft: EditEventFormBackButton
     },
-    createEventForm: {
-      options: {
-        headerTitle: "Create Event",
-        headerLeft: EditEventFormBackButton
-      },
-      screen: EditEventScreen
+    screen: EditEventScreen
+  },
+  createEventForm: {
+    options: {
+      headerTitle: "Create Event",
+      headerLeft: EditEventFormBackButton
     },
-    editEventLocationSearch: {
-      options: { headerShown: false },
-      screen: LocationSearchScreen
-    },
-    ...eventDetailsScreens(),
-    ...profileScreens()
+    screen: EditEventScreen
+  },
+  editEventLocationSearch: {
+    options: { headerShown: false },
+    screen: LocationSearchScreen
   }
 })
 

--- a/core-root/navigation/EventDetails.tsx
+++ b/core-root/navigation/EventDetails.tsx
@@ -1,4 +1,4 @@
-import { ChevronBackButton, XMarkBackButton } from "@components/Navigation"
+import { useBackButton } from "@components/Navigation"
 import {
   EventAttendeesListView,
   useEventAttendeesList
@@ -8,22 +8,14 @@ import { EventDetailsView } from "@event-details-boundary/Details"
 import { useLoadEventDetails } from "@event/DetailsQuery"
 import { StaticScreenProps, useNavigation } from "@react-navigation/native"
 import { EventID } from "TiFShared/domain-models/Event"
-import { PortalProvider } from "@gorhom/portal"
 
 export const eventDetailsScreens = () => ({
   eventDetails: {
-    // TODO: - Remove this any.
-    options: ({ route }: any) => ({
-      headerLeft:
-        route.params?.method === "navigate"
-          ? ChevronBackButton
-          : XMarkBackButton,
-      headerTitle: "Event"
-    }),
+    options: () => ({ headerTitle: "Event" }),
     screen: EventDetailsScreen
   },
   eventAttendeesList: {
-    options: { headerLeft: ChevronBackButton, headerTitle: "Attendees" },
+    options: { headerTitle: "Attendees" },
     screen: AttendeesListScreen
   }
 })
@@ -32,6 +24,7 @@ type AttendeesListScreenProps = StaticScreenProps<{ id: EventID }>
 
 const AttendeesListScreen = ({ route }: AttendeesListScreenProps) => {
   const navigation = useNavigation()
+  useBackButton()
   return (
     <EventAttendeesListView
       state={useEventAttendeesList({ eventId: route.params.id })}
@@ -40,21 +33,17 @@ const AttendeesListScreen = ({ route }: AttendeesListScreenProps) => {
   )
 }
 
-type EventDetailsScreenProps = StaticScreenProps<{
-  id: EventID
-  method?: "navigate" | "replace"
-}>
+type EventDetailsScreenProps = StaticScreenProps<{ id: EventID }>
 
 const EventDetailsScreen = ({ route }: EventDetailsScreenProps) => {
   const navigation = useNavigation()
+  useBackButton()
   return (
-    // <PortalProvider>
     <EventDetailsContentView
       result={useLoadEventDetails(route.params.id)}
       onExploreOtherEventsTapped={() => navigation.navigate("home")}
     >
       {(state) => <EventDetailsView state={state} />}
     </EventDetailsContentView>
-    // </PortalProvider>
   )
 }

--- a/core-root/navigation/ModalStack.tsx
+++ b/core-root/navigation/ModalStack.tsx
@@ -1,0 +1,14 @@
+import { BASE_HEADER_SCREEN_OPTIONS } from "@components/Navigation"
+import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { eventDetailsScreens } from "./EventDetails"
+import { profileScreens } from "./Profile"
+import { editEventScreens } from "./EditEvent"
+
+export const ModalStack = createNativeStackNavigator({
+  screenOptions: () => BASE_HEADER_SCREEN_OPTIONS,
+  screens: {
+    ...editEventScreens(),
+    ...eventDetailsScreens(),
+    ...profileScreens()
+  }
+})

--- a/core-root/navigation/Profile.tsx
+++ b/core-root/navigation/Profile.tsx
@@ -1,4 +1,4 @@
-import { XMarkBackButton } from "@components/Navigation"
+import { useBackButton } from "@components/Navigation"
 import { StaticScreenProps } from "@react-navigation/native"
 import { UserHandle, UserID } from "TiFShared/domain-models/User"
 import {
@@ -9,7 +9,7 @@ import {
 
 export const profileScreens = () => ({
   userProfile: {
-    options: { headerLeft: XMarkBackButton, headerTitle: "" },
+    options: { headerTitle: "" },
     screen: ProfileScreen
   }
 })
@@ -19,11 +19,10 @@ type ProfileScreenProps = StaticScreenProps<{
 }>
 
 const ProfileScreen = ({ route }: ProfileScreenProps) => {
+  useBackButton()
   return (
     <UserProfileView
-      userInfoState={useUserProfile({
-        userId: route.params.id.toString()
-      })}
+      userInfoState={useUserProfile({ userId: route.params.id.toString() })}
       upcomingEventsState={useUpcomingEvents({
         userId: route.params.id.toString()
       })}

--- a/core-root/navigation/Root.tsx
+++ b/core-root/navigation/Root.tsx
@@ -6,9 +6,9 @@ import {
   createStaticNavigation
 } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
-import { EditEventNavigator } from "./EditEvent"
 import { eventDetailsScreens } from "./EventDetails"
 import { StyleSheet } from "react-native"
+import { ModalStack } from "./ModalStack"
 
 const HomeScreen = withAlphaRegistration(() => (
   <HomeView style={styles.screen} />
@@ -26,7 +26,7 @@ const Stack = createNativeStackNavigator({
   groups: {
     modals: {
       screenOptions: { presentation: "modal", headerShown: false },
-      screens: { editEvent: EditEventNavigator }
+      screens: { modal: ModalStack }
     }
   }
 })


### PR DESCRIPTION
There were a few issues that needed to be resolved with navigation.

1. `useNavigation` returned the parent navigator within the header of a modal-nested stack screen instead of the modal navigator. This caused `goBack` to dismiss the entire modal, and not just pop back to the previous screen. Instead of setting the back button as the `headerLeft` in the screen options, now just call `useBackButton` on your screen component instead.
2. When a component is the first presented screen in the modal stack, it should use `XMarkBackButton` instead of `ChevronBackButton`. At first, screens that could be presented first in a modal had an additional route param to specify whether or not they were first in the modal. However, this was cumbersome and error-prone, so instead I decided to let `useBackButton` handle the logic of deciding which button to show. `useBackButton` will look at the current navigation state, and determine if the index is 0. If the index is 0, then the screen must be the first on the modal stack, so the back button becomes `XMarkBackButton`.
3. I made a separate file for the modal stack navigator to reduce coupling.

TASK_UNTRACKED