### PR TITLE
Automatic Bottom Sheet Modal Dismissal  on Navigation

### DIFF
--- a/core-root/navigation/EditEvent.tsx
+++ b/core-root/navigation/EditEvent.tsx
@@ -1,4 +1,4 @@
-import { useCoreNavigation } from "@components/Navigation"
+import { useCoreNavigation, useTiFNavigation } from "@components/Navigation"
 import {
   withAlphaRegistration,
   WithAlphaRegistrationProps
@@ -14,7 +14,7 @@ import {
   LocationsSearchView,
   useLocationsSearch
 } from "@location-search-boundary"
-import { StaticScreenProps, useNavigation } from "@react-navigation/native"
+import { StaticScreenProps } from "@react-navigation/native"
 import { EventID } from "TiFShared/domain-models/Event"
 import { useSetAtom } from "jotai"
 import { StyleSheet } from "react-native"
@@ -25,7 +25,7 @@ type EditEventScreenProps = WithAlphaRegistrationProps<
 
 const EditEventScreen = withAlphaRegistration(
   ({ session, route }: EditEventScreenProps) => {
-    const navigation = useNavigation()
+    const navigation = useTiFNavigation()
     const { pushEventDetails } = useCoreNavigation()
     return (
       <EditEventView
@@ -45,7 +45,7 @@ const EditEventScreen = withAlphaRegistration(
 
 const LocationSearchScreen = () => {
   const setLocation = useSetAtom(editEventFormValueAtoms.location)
-  const navigation = useNavigation()
+  const navigation = useTiFNavigation()
   return (
     <LocationsSearchView
       state={useLocationsSearch()}
@@ -62,7 +62,7 @@ const LocationSearchScreen = () => {
 }
 
 const EditEventFormBackButton = () => (
-  <EditEventFormDismissButton onDismiss={useNavigation().goBack} />
+  <EditEventFormDismissButton onDismiss={useTiFNavigation().goBack} />
 )
 
 export const editEventScreens = () => ({

--- a/core-root/navigation/EventDetails.tsx
+++ b/core-root/navigation/EventDetails.tsx
@@ -1,4 +1,4 @@
-import { useBackButton } from "@components/Navigation"
+import { useBackButton, useTiFNavigation } from "@components/Navigation"
 import {
   EventAttendeesListView,
   useEventAttendeesList
@@ -6,7 +6,7 @@ import {
 import { EventDetailsContentView } from "@event-details-boundary/Content"
 import { EventDetailsView } from "@event-details-boundary/Details"
 import { useLoadEventDetails } from "@event/DetailsQuery"
-import { StaticScreenProps, useNavigation } from "@react-navigation/native"
+import { StaticScreenProps } from "@react-navigation/native"
 import { EventID } from "TiFShared/domain-models/Event"
 
 export const eventDetailsScreens = () => ({
@@ -23,7 +23,7 @@ export const eventDetailsScreens = () => ({
 type AttendeesListScreenProps = StaticScreenProps<{ id: EventID }>
 
 const AttendeesListScreen = ({ route }: AttendeesListScreenProps) => {
-  const navigation = useNavigation()
+  const navigation = useTiFNavigation()
   useBackButton()
   return (
     <EventAttendeesListView
@@ -36,7 +36,7 @@ const AttendeesListScreen = ({ route }: AttendeesListScreenProps) => {
 type EventDetailsScreenProps = StaticScreenProps<{ id: EventID }>
 
 const EventDetailsScreen = ({ route }: EventDetailsScreenProps) => {
-  const navigation = useNavigation()
+  const navigation = useTiFNavigation()
   useBackButton()
   return (
     <EventDetailsContentView

--- a/core-root/navigation/auth/SignUp.tsx
+++ b/core-root/navigation/auth/SignUp.tsx
@@ -1,10 +1,10 @@
 import {
   ChevronBackButton,
   StackNavigatorType,
-  XMarkBackButton
+  XMarkBackButton,
+  useTiFNavigation
 } from "@components/Navigation"
 import { TouchableIonicon } from "@components/common/Icons"
-import { useNavigation } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import React, { memo } from "react"
 import { Alert, StyleSheet } from "react-native"
@@ -192,7 +192,7 @@ const EndingScreen = ({
 )
 
 const SignUpExitButton = () => {
-  const navigation = useNavigation()
+  const navigation = useTiFNavigation()
   return (
     <TouchableIonicon
       icon={{ name: "close" }}

--- a/explore-events-boundary/BottomSheet.tsx
+++ b/explore-events-boundary/BottomSheet.tsx
@@ -14,7 +14,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import { TiFBottomSheet, TiFBottomSheetProvider } from "@components/BottomSheet"
+import { TiFBottomSheet } from "@components/BottomSheet"
 
 export type ExploreEventsBottomSheetProps = {
   events: ClientSideEvent[]
@@ -34,41 +34,38 @@ export const ExploreEventsBottomSheet = ({
   EmptyEventsComponent,
   style
 }: ExploreEventsBottomSheetProps) => (
-  <TiFBottomSheetProvider>
-    <View style={style}>
-      <TiFBottomSheet
-        isPresented
-        overlay="on-screen"
-        sizing={{ snapPoints: SNAP_POINTS }}
-        initialSnapPointIndex={1}
-        HandleView={useCallback(
-          (props: BottomSheetHandleProps) => (
-            <View style={styles.handle}>
-              <BottomSheetHandle {...props} />
-              <HeaderComponent />
-            </View>
-          ),
-          [HeaderComponent]
-        )}
-        canSwipeToDismiss={false}
-        shouldIncludeBackdrop={false}
-      >
-        <BottomSheetFlatList
-          data={events}
-          keyExtractor={(event) => event.id.toString()}
-          renderItem={({ item }: ListRenderItemInfo<ClientSideEvent>) => (
-            <EventCard event={item} style={styles.event} />
-          )}
-          ListEmptyComponent={EmptyEventsComponent}
-          ItemSeparatorComponent={() => <View style={styles.separator} />}
-          contentContainerStyle={{
-            paddingBottom: Platform.OS === "ios" ? 16 : 104
-          }}
-          contentInset={{ bottom: 104 }}
-        />
-      </TiFBottomSheet>
-    </View>
-  </TiFBottomSheetProvider>
+  <TiFBottomSheet
+    isTerminallyPresented
+    overlay="on-screen"
+    sizing={{ snapPoints: SNAP_POINTS }}
+    initialSnapPointIndex={1}
+    HandleView={useCallback(
+      (props: BottomSheetHandleProps) => (
+        <View style={styles.handle}>
+          <BottomSheetHandle {...props} />
+          <HeaderComponent />
+        </View>
+      ),
+      [HeaderComponent]
+    )}
+    canSwipeToDismiss={false}
+    shouldIncludeBackdrop={false}
+    style={style}
+  >
+    <BottomSheetFlatList
+      data={events}
+      keyExtractor={(event) => event.id.toString()}
+      renderItem={({ item }: ListRenderItemInfo<ClientSideEvent>) => (
+        <EventCard event={item} style={styles.event} />
+      )}
+      ListEmptyComponent={EmptyEventsComponent}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      contentContainerStyle={{
+        paddingBottom: Platform.OS === "ios" ? 16 : 104
+      }}
+      contentInset={{ bottom: 104 }}
+    />
+  </TiFBottomSheet>
 )
 
 const styles = StyleSheet.create({

--- a/jest/setupBottomSheetMock.jsx
+++ b/jest/setupBottomSheetMock.jsx
@@ -3,51 +3,14 @@
 // @ts-nocheck
 jest.mock("@gorhom/bottom-sheet", () => {
   const reactNative = jest.requireActual("react-native")
-  const {
-    useState,
-    useImperativeHandle,
-    createContext,
-    useContext,
-    forwardRef
-  } = jest.requireActual("react")
   const { View } = reactNative
-  const ModalContext = createContext(undefined)
   const BottomSheet = jest.requireActual("@gorhom/bottom-sheet")
-
-  const useModal = () => useContext(ModalContext)
-
   return {
     __esModule: true,
     ...BottomSheet,
     BottomSheetView: View,
-    BottomSheetModal: forwardRef(function ({ children }, ref) {
-      const [isPresented, setIsPresented] = useModal()
-
-      useImperativeHandle(
-        ref,
-        () => ({
-          dismiss: () => setIsPresented(false),
-          present: () => setIsPresented(true)
-        }),
-        []
-      )
-
-      return <View>{isPresented && children}</View>
-    }),
-    BottomSheetModalProvider: ({ children }) => {
-      const [isPresented, setIsPresented] = useState(false)
-      return (
-        <ModalContext.Provider value={[isPresented, setIsPresented]}>
-          {children}
-        </ModalContext.Provider>
-      )
-    },
-    useBottomSheetModal: () => {
-      const [, setIsPresented] = useModal()
-      return {
-        dismiss: () => setIsPresented(false),
-        present: () => setIsPresented(true)
-      }
-    }
+    BottomSheetModal: View,
+    BottomSheetModalProvider: View,
+    useBottomSheetModal: () => ({ dismissAll: () => {} })
   }
 })

--- a/location-search-boundary/Search.tsx
+++ b/location-search-boundary/Search.tsx
@@ -26,12 +26,12 @@ import { LocationSearchResultsListView } from "./SearchResultsList"
 import { debouncedSearchTextAtom } from "./SearchTextAtoms"
 import { useAtomValue } from "jotai"
 import { useScreenBottomPadding } from "@components/Padding"
-import { useNavigation } from "@react-navigation/native"
 import { LocationSearchBar } from "./SearchBar"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { logger } from "TiFShared/logging"
 import { recentLocationsStorage } from "@location/Recents"
 import { featureContext } from "@lib/FeatureContext"
+import { useTiFNavigation } from "@components/Navigation"
 
 const log = logger("location.search")
 
@@ -111,7 +111,7 @@ export const LocationsSearchView = ({
     <SafeAreaView edges={safeAreaEdges}>
       <View onLayout={(e) => setHeaderLayout(e.nativeEvent.layout)}>
         <LocationSearchBar
-          onBackTapped={useNavigation().goBack}
+          onBackTapped={useTiFNavigation().goBack}
           placeholder="Enter a Location"
           style={[
             styles.locationSearchBarHeaderSpacing,


### PR DESCRIPTION
When presenting bottom sheets, one of the biggest problems was ensuring that the sheet was dismissed when tapping on something in the sheet that causes navigation to occur. In doing this, the app would navigate to the correct screen, but the bottom sheet would still be presented. This is weird, so I made a hook to get around it.

`useCoreNavigation` is called from within `EventCard`, but `EventCard` is rendered in many different places including bottom sheet modals and ordinary flat lists. If we wanted to be explicit about modal dismissals, we would have to introduce some `onNavigated` prop to `EventCard`, and then call it for all the navigation events. This is weird and error prone (only some instances of the event card would need to pass a value here), so I decided to embed modal dismissal logic within the `useTiFNavigation` hook.

`useTiFNavigation` behaves exactly like `useNavigation`, but it automatically dismisses all bottom sheets when calling `navigate` or `replace`. Therefore, you'll want to always call this hook instead of `useNavigation`, otherwise you'll be forced to handle bottom sheet dismissals yourself. For the record, `useCoreNavigation` already calls `useTiFNavigation` for you.

Suppose you present a bottom sheet that should _never_ be dismissed. In that case, you can use the new `isTerminallyPresented` prop on `TiFBottomSheet`. `isTerminallyPresented` wraps the sheet and its contents with `BottomSheetModalProvider`, thus allowing it to be immune from dismissals.

TASK_UNTRACKED