### PR TITLE
Auto-removal of userToken in TiFPreview

### DIFF
--- a/.storybook/components/TiFPreview/TiFPreview.stories.tsx
+++ b/.storybook/components/TiFPreview/TiFPreview.stories.tsx
@@ -6,7 +6,6 @@ import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
 import { SQLiteUserSettingsStorage } from "@settings-storage/UserSettings"
 import { testSQLite } from "@test-helpers/SQLite"
 import { AlphaUserSessionProvider, AlphaUserStorage } from "@user/alpha"
-import { AlphaUserMocks } from "@user/alpha/MockData"
 import React from "react"
 import { UserProfileFeature } from "user-profile-boundary/Context"
 
@@ -16,7 +15,8 @@ const TiFPreview = {
 
 export default TiFPreview
 
-const storage = AlphaUserStorage.ephemeral(AlphaUserMocks.TheDarkLord)
+const storage = AlphaUserStorage.default
+storage.removeUserToken()
 
 const localSettings = PersistentSettingsStores.local(
   new SQLiteLocalSettingsStorage(testSQLite)
@@ -33,14 +33,14 @@ export const Basic = () => (
     localSettingsStore={localSettings}
     userSettingsStore={userSettings}
   >
-    <UserProfileFeature.Provider>
-      <AlphaUserSessionProvider storage={storage}>
+    <AlphaUserSessionProvider storage={storage}>
+      <UserProfileFeature.Provider>
         <TiFView
           fetchEvents={eventsByRegion}
           isFontsLoaded={true}
           style={{ flex: 1 }}
         />
-      </AlphaUserSessionProvider>
-    </UserProfileFeature.Provider>
+      </UserProfileFeature.Provider>
+    </AlphaUserSessionProvider>
   </SettingsProvider>
 )

--- a/AppEntry.js
+++ b/AppEntry.js
@@ -1,16 +1,18 @@
-import { API_URL, BUILD_TYPE } from "@env"
+import { BUILD_TYPE } from "@env"
 import { registerRootComponent } from "expo"
 import "TiFShared"
 
-if (BUILD_TYPE !== "storybook") {
-  console.log(BUILD_TYPE)
+console.log(BUILD_TYPE)
+
+const Module = require("./.storybook/App")
+registerRootComponent(Module.default)
+
+/* if (BUILD_TYPE !== "storybook") {
   // @ts-ignore App entry
-  const Module = require("./.storybook/App")
-  registerRootComponent(Module.default)
 } else {
   // @ts-ignore App entry
   const Module = require("./App")
   // @ts-ignore Not inferring the type of "Module" correctly
   Module.setupApp()
   registerRootComponent(Module.default)
-}
+} */

--- a/user/alpha/AlphaUser.tsx
+++ b/user/alpha/AlphaUser.tsx
@@ -58,6 +58,15 @@ export class AlphaUserStorage {
   }
 
   /**
+   * Removes the current JWT access token from the current store.
+   */
+  async removeUserToken(): Promise<void> {
+    const token = await this._store.getItemAsync(ALPHA_USER_STORAGE_KEY)
+    if (!token) return
+    return await this._store.deleteItemAsync(ALPHA_USER_STORAGE_KEY)
+  }
+
+  /**
    * Stores the JWT access token containing the alpha user details in its payload.
    */
   async store(token: string) {


### PR DESCRIPTION
* Implements an interface that deletes the current user token, to prevent a JWT token glitch; said glitch preventing connection to the backend by giving a 403 error.
* Replaces the ephemeral instance in the TiFPreview storybook with the default instance, to allow for testing this new userToken behavior.

![Screenshot_20250210_002540_FitnessApp.jpg](https://github.com/user-attachments/assets/85effe3f-98f3-4498-891e-29fc153f9717)



## Tickets

https://trello.com/c/0GH5cNnI