### PR TITLE
Remove attendeeCount from map when attendeeCount at or below 1

### DIFF
--- a/.storybook/components/TiFPreview/TiFPreview.stories.tsx
+++ b/.storybook/components/TiFPreview/TiFPreview.stories.tsx
@@ -6,7 +6,6 @@ import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
 import { SQLiteUserSettingsStorage } from "@settings-storage/UserSettings"
 import { testSQLite } from "@test-helpers/SQLite"
 import { AlphaUserSessionProvider, AlphaUserStorage } from "@user/alpha"
-import { AlphaUserMocks } from "@user/alpha/MockData"
 import React from "react"
 import { UserProfileFeature } from "user-profile-boundary/Context"
 
@@ -16,7 +15,7 @@ const TiFPreview = {
 
 export default TiFPreview
 
-const storage = AlphaUserStorage.ephemeral(AlphaUserMocks.TheDarkLord)
+const storage = AlphaUserStorage.ephemeral()
 
 const localSettings = PersistentSettingsStores.local(
   new SQLiteLocalSettingsStorage(testSQLite)

--- a/explore-events-boundary/MapMarker.tsx
+++ b/explore-events-boundary/MapMarker.tsx
@@ -4,7 +4,7 @@ import {
 } from "@components/AvatarMapMarker"
 import { CaptionTitle } from "@components/Text"
 import { Ionicon } from "@components/common/Icons"
-import React, { memo } from "react"
+import React from "react"
 import { StyleProp, StyleSheet, View, ViewStyle } from "react-native"
 
 export type ExploreEventsMarkerProps = {
@@ -23,10 +23,17 @@ export const ExploreEventsMarkerView = ({
   style
 }: ExploreEventsMarkerProps) => (
   <AvatarMapMarkerView name={hostName} imageURL={imageURL} style={style}>
-    <View style={[{ backgroundColor: color }, styles.badgeContainer]}>
-      <Ionicon style={styles.badgeIcon} name="people" color="white" size={12} />
-      <CaptionTitle style={styles.badgeText}>{attendeeCount}</CaptionTitle>
-    </View>
+    {attendeeCount > 1 ? (
+      <View style={[{ backgroundColor: color }, styles.badgeContainer]}>
+        <Ionicon
+          style={styles.badgeIcon}
+          name="people"
+          color="white"
+          size={12}
+        />
+        <CaptionTitle style={styles.badgeText}>{attendeeCount}</CaptionTitle>
+      </View>
+    ) : undefined}
   </AvatarMapMarkerView>
 )
 

--- a/explore-events-boundary/MapMarker.tsx
+++ b/explore-events-boundary/MapMarker.tsx
@@ -23,17 +23,12 @@ export const ExploreEventsMarkerView = ({
   style
 }: ExploreEventsMarkerProps) => (
   <AvatarMapMarkerView name={hostName} imageURL={imageURL} style={style}>
-    {attendeeCount > 1 ? (
-      <View style={[{ backgroundColor: color }, styles.badgeContainer]}>
-        <Ionicon
-          style={styles.badgeIcon}
-          name="people"
-          color="white"
-          size={12}
-        />
+    <View style={[{ backgroundColor: color }, styles.badgeContainer]}>
+      <Ionicon style={styles.badgeIcon} name="people" color="white" size={12} />
+      {attendeeCount > 1 ? (
         <CaptionTitle style={styles.badgeText}>{attendeeCount}</CaptionTitle>
-      </View>
-    ) : undefined}
+      ) : undefined}
+    </View>
   </AvatarMapMarkerView>
 )
 


### PR DESCRIPTION
* When AttendeeCount for an event is 1 or below, removes the AttendeeCount from the map marker, on the explore events screen.

![Screenshot_20250211_115423_FitnessApp.jpg](https://github.com/user-attachments/assets/681805bf-5619-42d1-94ce-88c4ecb38a5a)

![Screenshot_20250210_002018_FitnessApp.jpg](https://github.com/user-attachments/assets/cbc1244b-1b5d-45f1-a07c-eee63662a979)



## Tickets

https://trello.com/c/UleFqGgP