### PR TITLE
Event Details: Map Snippet Signifiers

### DIFF
--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -99,7 +99,12 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
             <MapView
               {...collapsedMapProps}
               ref={ref}
-              style={[{ height: Math.max(300, 200 + overlayLayout.height) }]}
+              style={[
+                {
+                  height: Math.max(300, 200 + overlayLayout.height),
+                  opacity: isExpanded ? 0 : 1
+                }
+              ]}
               loadingEnabled
               zoomEnabled={false}
               scrollEnabled={false}

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -35,7 +35,7 @@ export type ExpandableMapSnippetProps = {
   onExpansionChanged: (isExpanded: boolean) => void
   onMarkerPressed?: () => void
   region: Region
-  overlay?: ReactNode
+  overlay?: ReactNode | ((isExpanding: boolean) => ReactNode)
   marker?: ReactNode
   style?: StyleProp<ViewStyle>
   collapsedMapProps?: MapViewProps
@@ -68,29 +68,29 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
     LayoutRectangle | undefined
   >()
   const progress = useSharedValue(0)
-  const isExpanding = useSharedValue(false)
-  useEffect(() => {
-    isExpanding.value = isExpanded
-  }, [isExpanding, isExpanded])
+  const isExpandingShared = useSharedValue(false)
+  const [isExpanding, setIsExpanding] = useState(false)
+  isExpandingShared.value = isExpanding
+  useEffect(() => setIsExpanding(isExpanded), [isExpanded])
   const expand = useCallback(() => {
     if (!snippetRef.current) return
     snippetRef.current.measure((_, __, width, height, pageX, pageY) => {
       setSnippetLayout({ x: pageX, y: pageY, width, height })
-      isExpanding.value = true
+      setIsExpanding(true)
       progress.value = 0
       onExpansionChanged(true)
       progress.value = withTiFDefaultSpring(1)
     })
-  }, [progress, isExpanding, onExpansionChanged])
+  }, [progress, onExpansionChanged])
   const collapse = useCallback(() => {
-    isExpanding.value = false
+    setIsExpanding(false)
     progress.value = withTiFDefaultSpring(0, (finished) => {
       "worklet"
       if (finished) {
         runOnJS(onExpansionChanged)(false)
       }
     })
-  }, [progress, isExpanding, onExpansionChanged])
+  }, [progress, onExpansionChanged])
   return (
     <View style={style}>
       <View style={styles.container}>
@@ -136,7 +136,7 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
               style={styles.overlay}
               onLayout={(event) => setOverlayLayout(event.nativeEvent.layout)}
             >
-              {overlay}
+              {overlay instanceof Function ? overlay(isExpanding) : overlay}
             </View>
           </View>
         </View>
@@ -146,6 +146,7 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
             region={region}
             onCollapsed={collapse}
             isExpanding={isExpanding}
+            isExpandingShared={isExpandingShared}
             progress={progress}
             overlay={overlay}
             marker={marker}
@@ -162,10 +163,11 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
 
 type ExpandedMapProps = {
   region: Region
-  overlay?: ReactNode
+  overlay?: ReactNode | ((isExpanding: boolean) => ReactNode)
   marker?: ReactNode
   progress: SharedValue<number>
-  isExpanding: SharedValue<boolean>
+  isExpanding: boolean
+  isExpandingShared: SharedValue<boolean>
   mapLayout: LayoutRectangle
   overlayLayout: LayoutRectangle
   isVisible: boolean
@@ -186,6 +188,7 @@ const ExpandedMapView = ({
   marker,
   progress,
   isExpanding,
+  isExpandingShared,
   onMarkerPressed,
   expandedMapProps
 }: ExpandedMapProps) => {
@@ -199,16 +202,18 @@ const ExpandedMapView = ({
     const mapHeightAdder = Platform.OS === "android" ? safeAreaInsets.top : 0
     return {
       position: "absolute",
-      top: withTiFDefaultSpring(isExpanding.value ? 0 : y),
-      left: withTiFDefaultSpring(isExpanding.value ? 0 : x),
+      top: withTiFDefaultSpring(isExpandingShared.value ? 0 : y),
+      left: withTiFDefaultSpring(isExpandingShared.value ? 0 : x),
       width: withTiFDefaultSpring(
-        isExpanding.value ? windowDimensions.width : width
+        isExpandingShared.value ? windowDimensions.width : width
       ),
       height: withTiFDefaultSpring(
-        isExpanding.value ? windowDimensions.height + mapHeightAdder : height
+        isExpandingShared.value
+          ? windowDimensions.height + mapHeightAdder
+          : height
       )
     }
-  }, [mapLayout])
+  }, [mapLayout, isExpanding])
   const bottomPadding = useScreenBottomPadding({
     safeAreaScreens: 8,
     nonSafeAreaScreens: 24
@@ -217,16 +222,16 @@ const ExpandedMapView = ({
     position: "absolute",
     height: "100%",
     top: withTiFDefaultSpring(
-      isExpanding.value
+      isExpandingShared.value
         ? safeAreaInsets.top + (Platform.OS === "android" ? 8 : 0)
         : 8
     ),
-    right: withTiFDefaultSpring(isExpanding.value ? 24 : 8)
+    right: withTiFDefaultSpring(isExpandingShared.value ? 24 : 8)
   }))
   const overlayStyle = useAnimatedStyle(() => ({
-    paddingHorizontal: withTiFDefaultSpring(isExpanding.value ? 24 : 16),
+    paddingHorizontal: withTiFDefaultSpring(isExpandingShared.value ? 24 : 16),
     bottom: withTiFDefaultSpring(
-      isExpanding.value ? safeAreaInsets.bottom + bottomPadding : 16
+      isExpandingShared.value ? safeAreaInsets.bottom + bottomPadding : 16
     )
   }))
   return (
@@ -255,7 +260,9 @@ const ExpandedMapView = ({
           <Animated.View
             style={[styles.fullscreenOverlayContainer, overlayStyle]}
           >
-            <View style={styles.fullscreenOverlay}>{overlay}</View>
+            <View style={styles.fullscreenOverlay}>
+              {overlay instanceof Function ? overlay(isExpanding) : overlay}
+            </View>
           </Animated.View>
           <Animated.View style={animatedCollapseButtonStyle}>
             <TouchableIonicon
@@ -308,8 +315,6 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 16,
     marginHorizontal: 16,
-    borderRadius: 12,
-    backgroundColor: "white",
     width: "100%",
     overflow: "hidden"
   },
@@ -320,8 +325,6 @@ const styles = StyleSheet.create({
     bottom: 0
   },
   fullscreenOverlay: {
-    borderRadius: 12,
-    backgroundColor: "white",
     width: "100%",
     overflow: "hidden"
   }

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -22,6 +22,7 @@ import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { EditEventFormLocation } from "@event/EditFormValues"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
 import { ExpandableMapSnippetView } from "@components/MapSnippetView"
+import { TiFFormCardView } from "@components/form-components/Card"
 
 export const useEditEventFormLocation = () => {
   const [location, setLocation] = useAtom(editEventFormValueAtoms.location)
@@ -210,13 +211,13 @@ const styles = StyleSheet.create({
   },
   overlayContainer: {
     borderRadius: 12,
+    backgroundColor: "white",
     overflow: "hidden"
   },
   overlay: {
     position: "absolute",
     bottom: 16,
     marginHorizontal: 16,
-    borderRadius: 12,
     backgroundColor: "white",
     width: "100%",
     padding: 4

--- a/event-details-boundary/Details.tsx
+++ b/event-details-boundary/Details.tsx
@@ -147,6 +147,7 @@ const LocationSectionView = ({ event }: SectionProps) => (
       />
     </TiFFormCardView>
     <EventTravelEstimatesView
+      eventTitle={event.title}
       host={event.host}
       location={event.location}
       result={useEventTravelEstimates(event.location.coordinate)}

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -1,10 +1,20 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { useCoreNavigation } from "@components/Navigation"
-import { BodyText, Caption, CaptionTitle, Headline } from "@components/Text"
+import {
+  BodyText,
+  Caption,
+  CaptionTitle,
+  Footnote,
+  Headline
+} from "@components/Text"
 import { Ionicon, RoundedIonicon } from "@components/common/Icons"
+import { TiFFormLabelView } from "@components/form-components/Label"
+import { TiFFormNamedIconRowView } from "@components/form-components/NamedIconRow"
+import { TiFFormRowItemView } from "@components/form-components/RowItem"
 import { ClientSideEvent } from "@event/ClientSideEvent"
 import { openEventLocationInMaps } from "@event/LocationIdentifier"
+import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
 import { AppStyles } from "@lib/AppColorStyle"
 import { compactFormatDistance } from "@lib/DistanceFormatting"
 import { featureContext } from "@lib/FeatureContext"
@@ -35,7 +45,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import Animated, { FadeIn } from "react-native-reanimated"
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated"
 
 export const EventTravelEstimatesFeature = featureContext({
   eventTravelEstimates
@@ -153,6 +163,7 @@ const useEventTravelEstimatesQuery = (
 }
 
 export type EventTravelEstimatesProps = {
+  eventTitle: string
   host: ClientSideEvent["host"]
   location: EventLocation
   result: UseEventTravelEstimatesResult
@@ -167,6 +178,7 @@ export type EventTravelEstimatesProps = {
  * the displayed icon.
  */
 export const EventTravelEstimatesView = ({
+  eventTitle,
   host,
   location,
   result,
@@ -174,6 +186,9 @@ export const EventTravelEstimatesView = ({
 }: EventTravelEstimatesProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const { presentProfile } = useCoreNavigation()
+  const address = location.placemark
+    ? placemarkToFormattedAddress(location.placemark)
+    : "Unknown Address"
   return (
     <View style={[style]}>
       {result.status === "disabled" && (
@@ -205,36 +220,48 @@ export const EventTravelEstimatesView = ({
             latitudeDelta: 0.007,
             longitudeDelta: 0.007
           }}
-          overlay={
-            <View style={styles.overlay}>
-              <Headline
-                maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
-                style={styles.directionsText}
-              >
-                Get Directions
-              </Headline>
-              <View style={styles.travelTypesContainer}>
-                <TravelTypeButton
-                  travelKey="walking"
-                  location={location}
-                  result={result}
-                  style={styles.travelTypeButton}
-                />
-                <TravelTypeButton
-                  travelKey="automobile"
-                  location={location}
-                  result={result}
-                  style={styles.travelTypeButton}
-                />
-                <TravelTypeButton
-                  travelKey="publicTransportation"
-                  location={location}
-                  result={result}
-                  style={styles.travelTypeButton}
-                />
+          overlay={(isExpanding) => (
+            <View style={{ rowGap: 16 }}>
+              {isExpanding && (
+                <View style={styles.viewingOverlay}>
+                  <TiFFormNamedIconRowView
+                    iconName="location"
+                    iconBackgroundColor={AppStyles.primary}
+                    name={`Viewing ${eventTitle}`}
+                    description={address}
+                  />
+                </View>
+              )}
+              <View style={styles.overlay}>
+                <Headline
+                  maxFontSizeMultiplier={FontScaleFactors.xxxLarge}
+                  style={styles.directionsText}
+                >
+                  Get Directions
+                </Headline>
+                <View style={styles.travelTypesContainer}>
+                  <TravelTypeButton
+                    travelKey="walking"
+                    location={location}
+                    result={result}
+                    style={styles.travelTypeButton}
+                  />
+                  <TravelTypeButton
+                    travelKey="automobile"
+                    location={location}
+                    result={result}
+                    style={styles.travelTypeButton}
+                  />
+                  <TravelTypeButton
+                    travelKey="publicTransportation"
+                    location={location}
+                    result={result}
+                    style={styles.travelTypeButton}
+                  />
+                </View>
               </View>
             </View>
-          }
+          )}
           collapsedMapProps={{
             customMapStyle: [
               {
@@ -392,9 +419,16 @@ const styles = StyleSheet.create({
     width: "100%",
     borderRadius: 12
   },
+  viewingOverlay: {
+    width: "100%",
+    backgroundColor: "white",
+    borderRadius: 12
+  },
   overlay: {
     width: "100%",
-    padding: 16
+    backgroundColor: "white",
+    padding: 16,
+    borderRadius: 12
   },
   directionsText: {
     textAlign: "center"
@@ -445,5 +479,8 @@ const styles = StyleSheet.create({
   },
   settingsButton: {
     color: AppStyles.linkColor
+  },
+  addressText: {
+    opacity: 0.5
   }
 })


### PR DESCRIPTION
Adds a signifier on the event details expanded map that indicates that the user is viewing an event.

This required some changes to `ExpandableMapSnippetView` that involved letting the overlay know whether or not the map was expanding (this unfortunately came out quite hacky with a manual sync between a shared value and state variable...). Additionally, `ExpandableMapSnippetView` also no longer proclaims the overlay component to be a white card, now the overlay component must facilitate that itself.

![Simulator Screenshot - iPhone 16 Pro - 2025-02-11 at 14 26 22](https://github.com/user-attachments/assets/3e89d0bc-9630-4e9e-99ba-f14b373aa9cf)

## Tickets

https://trello.com/c/WItcJ1bw