### PR TITLE
Move current location of event on Edit Event screen

### DIFF
--- a/.storybook/components/EditEvent/PragmaQuote.stories.tsx
+++ b/.storybook/components/EditEvent/PragmaQuote.stories.tsx
@@ -1,18 +1,12 @@
-import React, { useState } from "react"
-import { Button, View } from "react-native"
-import { GestureHandlerRootView } from "react-native-gesture-handler"
-import {
-  PragmaQuoteView,
-  createEventQuote
-} from "@edit-event-boundary/PragmaQuotes"
-import { Provider, atom, useAtomValue } from "jotai"
+import { BASE_HEADER_SCREEN_OPTIONS } from "@components/Navigation"
+import { EditEventFormDismissButton } from "@edit-event-boundary/Dismiss"
 import { EditEventView } from "@edit-event-boundary/EditEvent"
-import { SafeAreaProvider } from "react-native-safe-area-context"
-import { SQLiteLocalSettingsStorage } from "@settings-storage/LocalSettings"
-import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
-import { SQLiteUserSettingsStorage } from "@settings-storage/UserSettings"
-import { testSQLite } from "@test-helpers/SQLite"
-import { SettingsProvider } from "@settings-storage/Hooks"
+import { editEventFormValuesAtom } from "@edit-event-boundary/FormAtoms"
+import { defaultEditFormValues } from "@event/EditFormValues"
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
+import { sleep } from "@lib/utils/DelayData"
+import { GeocodingFunctionsProvider } from "@location/Geocoding"
+import { LocationCoordinatesMocks, mockPlacemark } from "@location/MockData"
 import {
   NavigationContainer,
   NavigationProp,
@@ -20,24 +14,17 @@ import {
   useNavigation
 } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
-import {
-  BASE_HEADER_SCREEN_OPTIONS,
-  XMarkBackButton
-} from "@components/Navigation"
-import { EditEventFormDismissButton } from "@edit-event-boundary/Dismiss"
-import {
-  LocationCoordinatesMocks,
-  mockLocationCoordinate2D,
-  mockPlacemark
-} from "@location/MockData"
+import { SettingsProvider } from "@settings-storage/Hooks"
+import { SQLiteLocalSettingsStorage } from "@settings-storage/LocalSettings"
+import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
+import { SQLiteUserSettingsStorage } from "@settings-storage/UserSettings"
 import { TestQueryClientProvider } from "@test-helpers/ReactQuery"
-import { sleep } from "@lib/utils/DelayData"
-import { EventMocks } from "@event-details-boundary/MockData"
-import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
-import { GeocodingFunctionsProvider } from "@location/Geocoding"
-import { neverPromise } from "@test-helpers/Promise"
-import { defaultEditFormValues } from "@event/EditFormValues"
-import { editEventFormValuesAtom } from "@edit-event-boundary/FormAtoms"
+import { testSQLite } from "@test-helpers/SQLite"
+import { useAtomValue } from "jotai"
+import React from "react"
+import { Button, View } from "react-native"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { SafeAreaProvider } from "react-native-safe-area-context"
 
 const EditEventPragmaQuotesMeta = {
   title: "Edit Event Pragma Quotes"
@@ -128,7 +115,6 @@ const EditEventScreen = () => {
           submit={async (id, edit) => {
             await sleep(3000)
             throw new Error()
-            return EventMocks.PickupBasketball
           }}
           onSuccess={(event) => {
             console.log("Edited", event)

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -18,7 +18,12 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import MapView, { MapViewProps, Marker, Region } from "react-native-maps"
+import MapView, {
+  LongPressEvent,
+  MapViewProps,
+  Marker,
+  Region
+} from "react-native-maps"
 import Animated, {
   runOnJS,
   SharedValue,
@@ -34,7 +39,7 @@ export type ExpandableMapSnippetProps = {
   isExpanded: boolean
   onExpansionChanged: (isExpanded: boolean) => void
   onMarkerPressed?: () => void
-  onMapLongPress?: () => void
+  onMapLongPress?: (event: LongPressEvent) => void
   region: Region
   overlay?: ReactNode | ((isExpanding: boolean) => ReactNode)
   marker?: ReactNode
@@ -240,6 +245,7 @@ const ExpandedMapView = ({
     <PortalView>
       {isVisible && (
         <Animated.View style={animatedMapStyle}>
+          {/* Expanded Map */}
           <MapView
             {...expandedMapProps}
             style={StyleSheet.absoluteFill}
@@ -259,6 +265,8 @@ const ExpandedMapView = ({
               {marker}
             </Marker>
           </MapView>
+
+          {/* Current Location overlay */}
           <Animated.View
             style={[styles.fullscreenOverlayContainer, overlayStyle]}
           >
@@ -266,6 +274,8 @@ const ExpandedMapView = ({
               {overlay instanceof Function ? overlay(isExpanding) : overlay}
             </View>
           </Animated.View>
+
+          {/* Collapse Button */}
           <Animated.View style={animatedCollapseButtonStyle}>
             <TouchableIonicon
               icon={{ name: "contract" }}

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -1,39 +1,40 @@
+import { Portal } from "@gorhom/portal"
+import { withTiFDefaultSpring } from "@lib/Reanimated"
 import React, {
-  useRef,
-  useState,
-  useCallback,
-  ReactNode,
   forwardRef,
   LegacyRef,
-  useEffect
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
 } from "react"
 import {
+  LayoutRectangle,
   Platform,
-  View,
-  useWindowDimensions,
-  StyleSheet,
   StyleProp,
-  ViewStyle,
-  LayoutRectangle
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  ViewStyle
 } from "react-native"
 import MapView, { MapViewProps, Marker, Region } from "react-native-maps"
 import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
   runOnJS,
-  SharedValue
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue
 } from "react-native-reanimated"
-import { Portal } from "@gorhom/portal"
-import { withTiFDefaultSpring } from "@lib/Reanimated"
-import { TouchableIonicon } from "./common/Icons"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { useScreenBottomPadding } from "./Padding"
 import { FullWindowOverlay } from "react-native-screens"
+import { TouchableIonicon } from "./common/Icons"
+import { useScreenBottomPadding } from "./Padding"
 
 export type ExpandableMapSnippetProps = {
   isExpanded: boolean
   onExpansionChanged: (isExpanded: boolean) => void
   onMarkerPressed?: () => void
+  onMapLongPress?: () => void
   region: Region
   overlay?: ReactNode | ((isExpanding: boolean) => ReactNode)
   marker?: ReactNode
@@ -55,6 +56,7 @@ export const ExpandableMapSnippetView = forwardRef(function Snippet(
     marker,
     style,
     onMarkerPressed,
+    onMapLongPress,
     collapsedMapProps,
     expandedMapProps
   }: ExpandableMapSnippetProps,

--- a/components/MapSnippetView.tsx
+++ b/components/MapSnippetView.tsx
@@ -245,7 +245,6 @@ const ExpandedMapView = ({
     <PortalView>
       {isVisible && (
         <Animated.View style={animatedMapStyle}>
-          {/* Expanded Map */}
           <MapView
             {...expandedMapProps}
             style={StyleSheet.absoluteFill}
@@ -265,8 +264,6 @@ const ExpandedMapView = ({
               {marker}
             </Marker>
           </MapView>
-
-          {/* Current Location overlay */}
           <Animated.View
             style={[styles.fullscreenOverlayContainer, overlayStyle]}
           >
@@ -274,8 +271,6 @@ const ExpandedMapView = ({
               {overlay instanceof Function ? overlay(isExpanding) : overlay}
             </View>
           </Animated.View>
-
-          {/* Collapse Button */}
           <Animated.View style={animatedCollapseButtonStyle}>
             <TouchableIonicon
               icon={{ name: "contract" }}

--- a/core-root/navigation/EditEvent.tsx
+++ b/core-root/navigation/EditEvent.tsx
@@ -7,8 +7,8 @@ import { EditEventFormDismissButton } from "@edit-event-boundary/Dismiss"
 import { EditEventView } from "@edit-event-boundary/EditEvent"
 import { editEventFormValueAtoms } from "@edit-event-boundary/FormAtoms"
 import {
-  RouteableEditEventFormValues,
-  fromRouteableEditFormValues
+  fromRouteableEditFormValues,
+  RouteableEditEventFormValues
 } from "@event/EditFormValues"
 import {
   LocationsSearchView,
@@ -36,6 +36,7 @@ const EditEventScreen = withAlphaRegistration(
         onSelectLocationTapped={() => {
           navigation.navigate("modal", { screen: "editEventLocationSearch" })
         }}
+        onMapLongPress={() => console.log("Map long pressed")}
         onSuccess={(e) => pushEventDetails(e.id, "replace")}
         style={styles.screen}
       />

--- a/core-root/navigation/EditEvent.tsx
+++ b/core-root/navigation/EditEvent.tsx
@@ -16,7 +16,7 @@ import {
 } from "@location-search-boundary"
 import { StaticScreenProps } from "@react-navigation/native"
 import { EventID } from "TiFShared/domain-models/Event"
-import { useSetAtom } from "jotai"
+import { useAtom, useSetAtom } from "jotai"
 import { StyleSheet } from "react-native"
 
 type EditEventScreenProps = WithAlphaRegistrationProps<
@@ -26,6 +26,7 @@ type EditEventScreenProps = WithAlphaRegistrationProps<
 const EditEventScreen = withAlphaRegistration(
   ({ session, route }: EditEventScreenProps) => {
     const navigation = useTiFNavigation()
+    const [location, setLocation] = useAtom(editEventFormValueAtoms.location)
     const { pushEventDetails } = useCoreNavigation()
     return (
       <EditEventView
@@ -36,7 +37,12 @@ const EditEventScreen = withAlphaRegistration(
         onSelectLocationTapped={() => {
           navigation.navigate("modal", { screen: "editEventLocationSearch" })
         }}
-        onMapLongPress={() => console.log("Map long pressed")}
+        onMapLongPress={(e) =>
+          setLocation({
+            placemark: undefined,
+            coordinate: e.nativeEvent.coordinate
+          })
+        }
         onSuccess={(e) => pushEventDetails(e.id, "replace")}
         style={styles.screen}
       />

--- a/edit-event-boundary/EditEvent.tsx
+++ b/edit-event-boundary/EditEvent.tsx
@@ -45,6 +45,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
+import { LongPressEvent } from "react-native-maps"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { EditEventDurationPickerView } from "./DurationPicker"
 import {
@@ -73,7 +74,7 @@ export type EditEventProps = {
   hostProfileImageURL?: string
   eventId?: EventID
   onSuccess: (event: ClientSideEvent) => void
-  onMapLongPress: () => void
+  onMapLongPress: (event: LongPressEvent) => void
   onSelectLocationTapped: () => void
   currentDate?: Date
   initialValues?: EditEventFormValues
@@ -179,19 +180,21 @@ const TitleSectionView = () => {
 
 type LocationSectionProps = {
   onSelectLocationTapped: () => void
-  onMapLongPress: () => void
+  onMapLongPress: (event: LongPressEvent) => void
   hostName: string
   hostProfileImageURL?: string
 }
 
-const LocationSectionView = (props: LocationSectionProps) => (
-  <TiFFormSectionView title="Where?">
-    <EditEventFormLocationView
-      location={useEditEventFormLocation()}
-      {...props}
-    />
-  </TiFFormSectionView>
-)
+const LocationSectionView = (props: LocationSectionProps) => {
+  return (
+    <TiFFormSectionView title="Where?">
+      <EditEventFormLocationView
+        location={useEditEventFormLocation()}
+        {...props}
+      />
+    </TiFFormSectionView>
+  )
+}
 
 const StartDateSectionView = () => {
   const [startDate, setStartDate] = useAtom(

--- a/edit-event-boundary/EditEvent.tsx
+++ b/edit-event-boundary/EditEvent.tsx
@@ -1,68 +1,68 @@
-import {
-  StyleProp,
-  ViewStyle,
-  View,
-  StyleSheet,
-  TouchableOpacity,
-  Platform
-} from "react-native"
-import {
-  editEventFormInitialValuesAtom,
-  editEventFormValueAtoms,
-  editEventFormValuesAtom
-} from "./FormAtoms"
-import { EventEditLocation, EventID } from "TiFShared/domain-models/Event"
-import {
-  PragmaQuoteView,
-  createEventQuote,
-  editEventQuote
-} from "./PragmaQuotes"
-import { useAtom, useAtomValue, useStore } from "jotai"
-import { ShadedTextField } from "@components/TextFields"
-import { useFontScale } from "@lib/Fonts"
-import { AppStyles } from "@lib/AppColorStyle"
-import React, { useCallback, useEffect, useState } from "react"
+import { TiFBottomSheet } from "@components/BottomSheet"
+import { TiFFooterView } from "@components/Footer"
 import { useScreenBottomPadding } from "@components/Padding"
-import { SafeAreaView } from "react-native-safe-area-context"
-import { useUserSettings } from "@settings-storage/Hooks"
-import { EditEventDurationPickerView } from "./DurationPicker"
+import { BodyText, Headline } from "@components/Text"
+import { ShadedTextField } from "@components/TextFields"
 import {
   Ionicon,
   IoniconCloseButton,
   TouchableIonicon
 } from "@components/common/Icons"
-import { dayjs } from "TiFShared/lib/Dayjs"
-import { BodyText, Headline } from "@components/Text"
+import { TiFFormCardView } from "@components/form-components/Card"
+import { TiFFormNamedToggleView } from "@components/form-components/NamedToggle"
+import { TiFFormScrollableLayoutView } from "@components/form-components/ScrollableFormLayout"
 import {
   TiFFormCardSectionView,
   TiFFormSectionView
 } from "@components/form-components/Section"
-import { TiFFormNamedToggleView } from "@components/form-components/NamedToggle"
-import { settingsSelector } from "@settings-storage/Settings"
+import { formatDateTimeFromBasis } from "@date-time"
+import { ClientSideEvent } from "@event/ClientSideEvent"
+import {
+  EditEventFormValues,
+  defaultEditFormValues
+} from "@event/EditFormValues"
+import { BottomSheetView } from "@gorhom/bottom-sheet"
+import { AppStyles } from "@lib/AppColorStyle"
+import { featureContext } from "@lib/FeatureContext"
+import { useFontScale } from "@lib/Fonts"
+import { useConst } from "@lib/utils/UseConst"
 import { useEffectEvent } from "@lib/utils/UseEffectEvent"
+import { DurationPickerView } from "@modules/tif-duration-picker"
+import RNDateTimePicker, {
+  DateTimePickerAndroid as RNDateTimePickerAndroid
+} from "@react-native-community/datetimepicker"
+import { useUserSettings } from "@settings-storage/Hooks"
+import { settingsSelector } from "@settings-storage/Settings"
+import { EventEditLocation, EventID } from "TiFShared/domain-models/Event"
+import { dayjs } from "TiFShared/lib/Dayjs"
+import { useAtom, useAtomValue, useStore } from "jotai"
+import React, { useCallback, useEffect, useState } from "react"
+import {
+  Platform,
+  StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ViewStyle
+} from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { EditEventDurationPickerView } from "./DurationPicker"
+import {
+  editEventFormInitialValuesAtom,
+  editEventFormValueAtoms,
+  editEventFormValuesAtom
+} from "./FormAtoms"
+import { EditEventFormLocationView, useEditEventFormLocation } from "./Location"
+import {
+  PragmaQuoteView,
+  createEventQuote,
+  editEventQuote
+} from "./PragmaQuotes"
 import {
   EditEventFormSubmitButton,
   submitEventEdit,
   useEditEventFormSubmission
 } from "./Submit"
-import { ClientSideEvent } from "@event/ClientSideEvent"
-import { BottomSheetView } from "@gorhom/bottom-sheet"
-import { DurationPickerView } from "@modules/tif-duration-picker"
-import RNDateTimePicker, {
-  DateTimePickerAndroid as RNDateTimePickerAndroid
-} from "@react-native-community/datetimepicker"
-import { TiFBottomSheet } from "@components/BottomSheet"
-import { useConst } from "@lib/utils/UseConst"
-import { TiFFormCardView } from "@components/form-components/Card"
-import { formatDateTimeFromBasis } from "@date-time"
-import { EditEventFormLocationView, useEditEventFormLocation } from "./Location"
-import { TiFFormScrollableLayoutView } from "@components/form-components/ScrollableFormLayout"
-import { TiFFooterView } from "@components/Footer"
-import {
-  EditEventFormValues,
-  defaultEditFormValues
-} from "@event/EditFormValues"
-import { featureContext } from "@lib/FeatureContext"
 
 export const EditEventFeature = featureContext({
   submit: submitEventEdit
@@ -73,6 +73,7 @@ export type EditEventProps = {
   hostProfileImageURL?: string
   eventId?: EventID
   onSuccess: (event: ClientSideEvent) => void
+  onMapLongPress: () => void
   onSelectLocationTapped: () => void
   currentDate?: Date
   initialValues?: EditEventFormValues
@@ -114,6 +115,7 @@ export const EditEventView = ({
   eventId,
   currentDate = new Date(),
   onSelectLocationTapped,
+  onMapLongPress,
   onSuccess,
   initialValues,
   style
@@ -130,6 +132,7 @@ export const EditEventView = ({
         hostName={hostName}
         hostProfileImageURL={hostProfileImageURL}
         onSelectLocationTapped={onSelectLocationTapped}
+        onMapLongPress={onMapLongPress}
       />
       <StartDateSectionView />
       <DurationSectionView />
@@ -176,6 +179,7 @@ const TitleSectionView = () => {
 
 type LocationSectionProps = {
   onSelectLocationTapped: () => void
+  onMapLongPress: () => void
   hostName: string
   hostProfileImageURL?: string
 }

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -1,28 +1,27 @@
-import { useAtom } from "jotai"
-import {
-  ViewStyle,
-  StyleProp,
-  View,
-  StyleSheet,
-  ActivityIndicator
-} from "react-native"
-import { editEventFormValueAtoms } from "./FormAtoms"
+import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
+import { ExpandableMapSnippetView } from "@components/MapSnippetView"
+import { TiFFormNavigationLinkView } from "@components/form-components/NavigationLink"
+import { EditEventFormLocation } from "@event/EditFormValues"
+import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
+import { AppStyles } from "@lib/AppColorStyle"
+import { FontScaleFactors } from "@lib/Fonts"
 import {
   DEFAULT_GEOCODE_QUERY_OPTIONS,
   useGeocodeQuery,
   useReverseGeocodeQuery
 } from "@location/Geocoding"
-import React, { useEffect, useRef, useState } from "react"
-import { TiFFormNavigationLinkView } from "@components/form-components/NavigationLink"
-import { AppStyles } from "@lib/AppColorStyle"
-import MapView from "react-native-maps"
-import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
-import { FontScaleFactors } from "@lib/Fonts"
-import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
-import { EditEventFormLocation } from "@event/EditFormValues"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
-import { ExpandableMapSnippetView } from "@components/MapSnippetView"
-import { TiFFormCardView } from "@components/form-components/Card"
+import { useAtom } from "jotai"
+import React, { useEffect, useRef, useState } from "react"
+import {
+  ActivityIndicator,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle
+} from "react-native"
+import MapView from "react-native-maps"
+import { editEventFormValueAtoms } from "./FormAtoms"
 
 export const useEditEventFormLocation = () => {
   const [location, setLocation] = useAtom(editEventFormValueAtoms.location)
@@ -55,6 +54,7 @@ export type EditEventFormLocationProps = {
   hostProfileImageURL?: string
   location?: EditEventFormLocation
   onSelectLocationTapped: () => void
+  onMapLongPress: () => void
   style?: StyleProp<ViewStyle>
 }
 
@@ -63,6 +63,7 @@ export const EditEventFormLocationView = ({
   hostProfileImageURL,
   location,
   onSelectLocationTapped,
+  onMapLongPress,
   style
 }: EditEventFormLocationProps) => (
   <View style={style}>
@@ -82,6 +83,7 @@ export const EditEventFormLocationView = ({
         hostProfileImageURL={hostProfileImageURL}
         location={location}
         onSelectLocationTapped={onSelectLocationTapped}
+        onMapLongPress={onMapLongPress}
       />
     )}
   </View>
@@ -92,13 +94,15 @@ type LocationProps = {
   hostProfileImageURL?: string
   location: EditEventFormLocation
   onSelectLocationTapped: () => void
+  onMapLongPress: () => void
 }
 
 const LocationView = ({
   hostName,
   hostProfileImageURL,
   location,
-  onSelectLocationTapped
+  onSelectLocationTapped,
+  onMapLongPress
 }: LocationProps) => {
   const mapRef = useRef<MapView>(null)
   useEffect(() => {
@@ -127,7 +131,10 @@ const LocationView = ({
               }
             ]
           }}
-          expandedMapProps={{ showsUserLocation: true }}
+          expandedMapProps={{
+            onLongPress: onMapLongPress,
+            showsUserLocation: true
+          }}
           marker={
             <AvatarMapMarkerView
               name={hostName}

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -1,7 +1,8 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { ExpandableMapSnippetView } from "@components/MapSnippetView"
+import { Caption, Footnote } from "@components/Text"
+import { Ionicon } from "@components/common/Icons"
 import { TiFFormNavigationLinkView } from "@components/form-components/NavigationLink"
-import { TiFFormRowItemView } from "@components/form-components/RowItem"
 import { EditEventFormLocation } from "@event/EditFormValues"
 import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
 import { AppStyles } from "@lib/AppColorStyle"
@@ -144,44 +145,76 @@ const LocationView = ({
           }
           overlay={(isExpanding) => {
             return (
-              <View style={styles.overlayContainer}>
+              <View style={{ rowGap: 16 }}>
                 {isExpanding && (
-                  <TiFFormRowItemView
-                    style={styles.locationMapNavigationLink}
-                    title={
-                      "Tap and hold anywhere on the map to select a new location."
-                    }
-                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                  />
+                  <View
+                    style={[
+                      styles.overlayContainer,
+                      {
+                        padding: 16,
+                        flex: 1,
+                        alignItems: "center",
+                        columnGap: 16,
+                        flexDirection: "row"
+                      }
+                    ]}
+                  >
+                    <Ionicon
+                      name="pin-sharp"
+                      size={24}
+                      style={{ marginLeft: 8 }}
+                      color="black"
+                    />
+                    <Footnote style={{ flex: 1 }}>
+                      {
+                        "Tap and hold anywhere on the map to select a new location."
+                      }
+                    </Footnote>
+                  </View>
                 )}
                 {!location.placemark ? (
-                  <TiFFormNavigationLinkView
-                    iconName="location"
-                    iconBackgroundColor={AppStyles.primary}
-                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                    style={styles.locationMapNavigationLink}
-                    title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
-                    onTapped={() => {
-                      setIsExpanded(false)
-                      onSelectLocationTapped()
-                    }}
-                  />
+                  <View style={styles.overlayContainer}>
+                    <Caption style={{ paddingHorizontal: 16, paddingTop: 16 }}>
+                      {"Current Location"}
+                    </Caption>
+                    <TiFFormNavigationLinkView
+                      iconName="location"
+                      iconBackgroundColor={AppStyles.primary}
+                      maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                      style={styles.locationMapNavigationLink}
+                      title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
+                      onTapped={() => {
+                        setIsExpanded(false)
+                        onSelectLocationTapped()
+                      }}
+                    />
+                  </View>
                 ) : (
-                  <TiFFormNavigationLinkView
-                    iconName="location"
-                    iconBackgroundColor={AppStyles.primary}
-                    style={styles.locationMapNavigationLink}
-                    title={location.placemark.name ?? "Unknown Location"}
-                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                    description={
-                      placemarkToFormattedAddress(location.placemark) ??
-                      "Unknown Address"
-                    }
-                    onTapped={() => {
-                      setIsExpanded(false)
-                      onSelectLocationTapped()
-                    }}
-                  />
+                  <View style={styles.overlayContainer}>
+                    <Caption
+                      style={{
+                        paddingHorizontal: 16,
+                        paddingTop: 16
+                      }}
+                    >
+                      {"Current Location"}
+                    </Caption>
+                    <TiFFormNavigationLinkView
+                      iconName="location"
+                      iconBackgroundColor={AppStyles.primary}
+                      style={styles.locationMapNavigationLink}
+                      title={location.placemark.name ?? "Unknown Location"}
+                      maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                      description={
+                        placemarkToFormattedAddress(location.placemark) ??
+                        "Unknown Address"
+                      }
+                      onTapped={() => {
+                        setIsExpanded(false)
+                        onSelectLocationTapped()
+                      }}
+                    />
+                  </View>
                 )}
               </View>
             )

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -145,27 +145,16 @@ const LocationView = ({
           }
           overlay={(isExpanding) => {
             return (
-              <View style={{ rowGap: 16 }}>
+              <View style={styles.container}>
                 {isExpanding && (
-                  <View
-                    style={[
-                      styles.overlayContainer,
-                      {
-                        padding: 16,
-                        flex: 1,
-                        alignItems: "center",
-                        columnGap: 16,
-                        flexDirection: "row"
-                      }
-                    ]}
-                  >
+                  <View style={styles.instructionContainer}>
                     <Ionicon
                       name="pin-sharp"
                       size={24}
-                      style={{ marginLeft: 8 }}
+                      style={styles.instructionIcon}
                       color="black"
                     />
-                    <Footnote style={{ flex: 1 }}>
+                    <Footnote style={styles.instructionText}>
                       {
                         "Tap and hold anywhere on the map to select a new location."
                       }
@@ -174,7 +163,7 @@ const LocationView = ({
                 )}
                 {!location.placemark ? (
                   <View style={styles.overlayContainer}>
-                    <Caption style={{ paddingHorizontal: 16, paddingTop: 16 }}>
+                    <Caption style={styles.currentLocation}>
                       {"Current Location"}
                     </Caption>
                     <TiFFormNavigationLinkView
@@ -191,12 +180,7 @@ const LocationView = ({
                   </View>
                 ) : (
                   <View style={styles.overlayContainer}>
-                    <Caption
-                      style={{
-                        paddingHorizontal: 16,
-                        paddingTop: 16
-                      }}
-                    >
+                    <Caption style={styles.currentLocation}>
                       {"Current Location"}
                     </Caption>
                     <TiFFormNavigationLinkView
@@ -236,6 +220,29 @@ const mapRegion = (coordinate: LocationCoordinate2D) => ({
 })
 
 const styles = StyleSheet.create({
+  container: {
+    rowGap: 16
+  },
+  currentLocation: {
+    paddingHorizontal: 16,
+    paddingTop: 16
+  },
+  instructionContainer: {
+    borderRadius: 12,
+    backgroundColor: "white",
+    overflow: "hidden",
+    padding: 16,
+    flex: 1,
+    alignItems: "center",
+    columnGap: 16,
+    flexDirection: "row"
+  },
+  instructionIcon: {
+    marginLeft: 8
+  },
+  instructionText: {
+    flex: 1
+  },
   locationNavigationLink: {
     width: "100%",
     borderStyle: "dashed",

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -1,6 +1,7 @@
 import { AvatarMapMarkerView } from "@components/AvatarMapMarker"
 import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { TiFFormNavigationLinkView } from "@components/form-components/NavigationLink"
+import { TiFFormRowItemView } from "@components/form-components/RowItem"
 import { EditEventFormLocation } from "@event/EditFormValues"
 import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
 import { AppStyles } from "@lib/AppColorStyle"
@@ -20,7 +21,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import MapView from "react-native-maps"
+import MapView, { LongPressEvent } from "react-native-maps"
 import { editEventFormValueAtoms } from "./FormAtoms"
 
 export const useEditEventFormLocation = () => {
@@ -54,7 +55,7 @@ export type EditEventFormLocationProps = {
   hostProfileImageURL?: string
   location?: EditEventFormLocation
   onSelectLocationTapped: () => void
-  onMapLongPress: () => void
+  onMapLongPress: (event: LongPressEvent) => void
   style?: StyleProp<ViewStyle>
 }
 
@@ -94,7 +95,7 @@ type LocationProps = {
   hostProfileImageURL?: string
   location: EditEventFormLocation
   onSelectLocationTapped: () => void
-  onMapLongPress: () => void
+  onMapLongPress: (event: LongPressEvent) => void
 }
 
 const LocationView = ({
@@ -141,39 +142,50 @@ const LocationView = ({
               imageURL={hostProfileImageURL}
             />
           }
-          overlay={
-            <View style={styles.overlayContainer}>
-              {!location.placemark ? (
-                <TiFFormNavigationLinkView
-                  iconName="location"
-                  iconBackgroundColor={AppStyles.primary}
-                  maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                  style={styles.locationMapNavigationLink}
-                  title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
-                  onTapped={() => {
-                    setIsExpanded(false)
-                    onSelectLocationTapped()
-                  }}
-                />
-              ) : (
-                <TiFFormNavigationLinkView
-                  iconName="location"
-                  iconBackgroundColor={AppStyles.primary}
-                  style={styles.locationMapNavigationLink}
-                  title={location.placemark.name ?? "Unknown Location"}
-                  maximumFontScaleFactor={FontScaleFactors.xxxLarge}
-                  description={
-                    placemarkToFormattedAddress(location.placemark) ??
-                    "Unknown Address"
-                  }
-                  onTapped={() => {
-                    setIsExpanded(false)
-                    onSelectLocationTapped()
-                  }}
-                />
-              )}
-            </View>
-          }
+          overlay={(isExpanding) => {
+            return (
+              <View style={styles.overlayContainer}>
+                {isExpanding && (
+                  <TiFFormRowItemView
+                    style={styles.locationMapNavigationLink}
+                    title={
+                      "Tap and hold onto a point in the map to select a new location."
+                    }
+                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                  />
+                )}
+                {!location.placemark ? (
+                  <TiFFormNavigationLinkView
+                    iconName="location"
+                    iconBackgroundColor={AppStyles.primary}
+                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                    style={styles.locationMapNavigationLink}
+                    title={`${location.coordinate.latitude}, ${location.coordinate.longitude}`}
+                    onTapped={() => {
+                      setIsExpanded(false)
+                      onSelectLocationTapped()
+                    }}
+                  />
+                ) : (
+                  <TiFFormNavigationLinkView
+                    iconName="location"
+                    iconBackgroundColor={AppStyles.primary}
+                    style={styles.locationMapNavigationLink}
+                    title={location.placemark.name ?? "Unknown Location"}
+                    maximumFontScaleFactor={FontScaleFactors.xxxLarge}
+                    description={
+                      placemarkToFormattedAddress(location.placemark) ??
+                      "Unknown Address"
+                    }
+                    onTapped={() => {
+                      setIsExpanded(false)
+                      onSelectLocationTapped()
+                    }}
+                  />
+                )}
+              </View>
+            )
+          }}
         />
       ) : (
         <View style={[styles.mapDimensions, styles.loadingMap]}>

--- a/edit-event-boundary/Location.tsx
+++ b/edit-event-boundary/Location.tsx
@@ -149,7 +149,7 @@ const LocationView = ({
                   <TiFFormRowItemView
                     style={styles.locationMapNavigationLink}
                     title={
-                      "Tap and hold onto a point in the map to select a new location."
+                      "Tap and hold anywhere on the map to select a new location."
                     }
                     maximumFontScaleFactor={FontScaleFactors.xxxLarge}
                   />

--- a/event-details-boundary/TravelEstimates.tsx
+++ b/event-details-boundary/TravelEstimates.tsx
@@ -3,16 +3,13 @@ import { ExpandableMapSnippetView } from "@components/MapSnippetView"
 import { useCoreNavigation } from "@components/Navigation"
 import {
   BodyText,
-  BoldFootnote,
   Caption,
   CaptionTitle,
   Footnote,
   Headline
 } from "@components/Text"
 import { Ionicon, RoundedIonicon } from "@components/common/Icons"
-import { TiFFormLabelView } from "@components/form-components/Label"
 import { TiFFormNamedIconRowView } from "@components/form-components/NamedIconRow"
-import { TiFFormRowItemView } from "@components/form-components/RowItem"
 import { ClientSideEvent } from "@event/ClientSideEvent"
 import { openEventLocationInMaps } from "@event/LocationIdentifier"
 import { placemarkToFormattedAddress } from "@lib/AddressFormatting"
@@ -46,7 +43,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated"
+import Animated, { FadeIn } from "react-native-reanimated"
 
 export const EventTravelEstimatesFeature = featureContext({
   eventTravelEstimates


### PR DESCRIPTION
- Adds a long press trigger on the expanded map, in the edit event screen, alongside a prompt, in order to allow for moving the location after it has been selected.

![Screenshot_20250307_212730_FitnessApp.jpg](https://github.com/user-attachments/assets/95692609-0ecf-4449-bdfa-9bb1680aebb3)

## Tickets

https://trello.com/c/53QoPMF8