### PR TITLE
Fix Modal Presentation

### DIFF
--- a/.storybook/.ondevice/storybook.requires.ts
+++ b/.storybook/.ondevice/storybook.requires.ts
@@ -13,12 +13,12 @@ const normalizedStories = [
     directory: "./.storybook/components",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
     // @ts-ignore
     req: require.context(
       "../components",
       true,
-      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
 ];

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -110,29 +110,27 @@ export const TiFBottomSheet = <Item = boolean,>({
       : children
   )
   return (
-    <Container>
-      <BottomSheetModal
-        ref={bottomSheetRef}
-        enablePanDownToClose={canSwipeToDismiss}
-        enableContentPanningGesture={enableContentPanningGesture}
-        handleStyle={bottomSheetHandleStyle}
-        animatedIndex={animatedIndex}
-        handleComponent={HandleView}
-        onDismiss={onDismiss}
-        containerComponent={
-          // NB: iOS needs a FullWindowOverlay in order to have the sheet appear above the native
-          // stack navigator when presented in a modal.
-          overlay === "above-screen" && Platform.OS === "ios"
-            ? FullWindowOverlay
-            : undefined
-        }
-        backdropComponent={shouldIncludeBackdrop ? TiFBackdropView : null}
-        style={style}
-        {...sizeProp}
-      >
-        <Container>{renderedChildren}</Container>
-      </BottomSheetModal>
-    </Container>
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      enablePanDownToClose={canSwipeToDismiss}
+      enableContentPanningGesture={enableContentPanningGesture}
+      handleStyle={bottomSheetHandleStyle}
+      animatedIndex={animatedIndex}
+      handleComponent={HandleView}
+      onDismiss={onDismiss}
+      containerComponent={
+        // NB: iOS needs a FullWindowOverlay in order to have the sheet appear above the native
+        // stack navigator when presented in a modal.
+        overlay === "above-screen" && Platform.OS === "ios"
+          ? FullWindowOverlay
+          : undefined
+      }
+      backdropComponent={shouldIncludeBackdrop ? TiFBackdropView : null}
+      style={style}
+      {...sizeProp}
+    >
+      {renderedChildren}
+    </BottomSheetModal>
   )
 }
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -36,8 +36,7 @@ export type UseNavigationReturn = Omit<
 /**
  * Returns the main navigator in the current navigation context in the app.
  *
- * Use this instead hook of `useNavigation`, as this hook will ensure to dismiss any bottom sheet
- * modals when navigating.
+ * Use this instead hook of `useNavigation` for better type safety.
  */
 export const useTiFNavigation = (): UseNavigationReturn => {
   return useNavigation<UseNavigationReturn>()

--- a/core-root/HomeLiveEvents.tsx
+++ b/core-root/HomeLiveEvents.tsx
@@ -1,9 +1,4 @@
 import { TiFBottomSheet } from "@components/BottomSheet"
-import {
-  NavigatorContext,
-  NavigatorProvider,
-  useTiFNavigation
-} from "@components/Navigation"
 import { useScreenBottomPadding } from "@components/Padding"
 import { Title } from "@components/Text"
 import { IoniconCloseButton } from "@components/common/Icons"
@@ -15,7 +10,6 @@ import {
   BottomSheetHandle,
   BottomSheetHandleProps
 } from "@gorhom/bottom-sheet"
-import { UserID } from "TiFShared/domain-models/User"
 import dayjs from "dayjs"
 import { useCallback, useState } from "react"
 import { ViewStyle, StyleProp, View, StyleSheet } from "react-native"
@@ -40,14 +34,13 @@ export const useHomeLiveEvents = () => {
 }
 
 export type HomeLiveEventsProps = {
-  id: UserID
   style?: StyleProp<ViewStyle>
 }
 
 const SNAP_POINTS = ["50%", "85%"]
 
-export const HomeLiveEventsView = ({ id, style }: HomeLiveEventsProps) => {
-  const state = useHomeLiveEvents(id)
+export const HomeLiveEventsView = ({ style }: HomeLiveEventsProps) => {
+  const state = useHomeLiveEvents()
   const inset = useScreenBottomPadding({
     safeAreaScreens: 48,
     nonSafeAreaScreens: 0

--- a/explore-events-boundary/BottomSheet.tsx
+++ b/explore-events-boundary/BottomSheet.tsx
@@ -14,7 +14,7 @@ import {
   View,
   ViewStyle
 } from "react-native"
-import { TiFBottomSheet } from "@components/BottomSheet"
+import { TiFBottomSheet, TiFBottomSheetProvider } from "@components/BottomSheet"
 
 export type ExploreEventsBottomSheetProps = {
   events: ClientSideEvent[]
@@ -34,38 +34,40 @@ export const ExploreEventsBottomSheet = ({
   EmptyEventsComponent,
   style
 }: ExploreEventsBottomSheetProps) => (
-  <TiFBottomSheet
-    isTerminallyPresented
-    overlay="on-screen"
-    sizing={{ snapPoints: SNAP_POINTS }}
-    initialSnapPointIndex={1}
-    HandleView={useCallback(
-      (props: BottomSheetHandleProps) => (
-        <View style={styles.handle}>
-          <BottomSheetHandle {...props} />
-          <HeaderComponent />
-        </View>
-      ),
-      [HeaderComponent]
-    )}
-    canSwipeToDismiss={false}
-    shouldIncludeBackdrop={false}
-    style={style}
-  >
-    <BottomSheetFlatList
-      data={events}
-      keyExtractor={(event) => event.id.toString()}
-      renderItem={({ item }: ListRenderItemInfo<ClientSideEvent>) => (
-        <EventCard event={item} style={styles.event} />
+  <TiFBottomSheetProvider>
+    <TiFBottomSheet
+      isTerminallyPresented
+      overlay="on-screen"
+      sizing={{ snapPoints: SNAP_POINTS }}
+      initialSnapPointIndex={1}
+      HandleView={useCallback(
+        (props: BottomSheetHandleProps) => (
+          <View style={styles.handle}>
+            <BottomSheetHandle {...props} />
+            <HeaderComponent />
+          </View>
+        ),
+        [HeaderComponent]
       )}
-      ListEmptyComponent={EmptyEventsComponent}
-      ItemSeparatorComponent={() => <View style={styles.separator} />}
-      contentContainerStyle={{
-        paddingBottom: Platform.OS === "ios" ? 16 : 104
-      }}
-      contentInset={{ bottom: 104 }}
-    />
-  </TiFBottomSheet>
+      canSwipeToDismiss={false}
+      shouldIncludeBackdrop={false}
+      style={style}
+    >
+      <BottomSheetFlatList
+        data={events}
+        keyExtractor={(event) => event.id.toString()}
+        renderItem={({ item }: ListRenderItemInfo<ClientSideEvent>) => (
+          <EventCard event={item} style={styles.event} />
+        )}
+        ListEmptyComponent={EmptyEventsComponent}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        contentContainerStyle={{
+          paddingBottom: Platform.OS === "ios" ? 16 : 104
+        }}
+        contentInset={{ bottom: 104 }}
+      />
+    </TiFBottomSheet>
+  </TiFBottomSheetProvider>
 )
 
 const styles = StyleSheet.create({

--- a/explore-events-boundary/ExploreEvents.tsx
+++ b/explore-events-boundary/ExploreEvents.tsx
@@ -133,9 +133,7 @@ const useUserRegion = (
   const permissionQuery = useRequestForegroundLocationPermissions(options)
   const locationQuery = useUserCoordinatesQuery(
     { accuracy: LocationAccuracy.Balanced },
-    {
-      enabled: permissionQuery.data !== undefined
-    }
+    { enabled: permissionQuery.data !== undefined }
   )
   if (permissionQuery.isFetching || locationQuery.isFetching) {
     return "pending"

--- a/location/UserLocation.tsx
+++ b/location/UserLocation.tsx
@@ -26,7 +26,7 @@ export const useUserCoordinatesQuery = (
 ) => {
   const { getCurrentLocation } = useUserLocationFunctions()
   return useQuery({
-    queryKey: ["user-coordinates", { preview: true }],
+    queryKey: ["user-coordinates", locationOptions],
     queryFn: async () => await getCurrentLocation(locationOptions),
     ...options
   })


### PR DESCRIPTION
As seen in #475, the bottom sheet modal would present with a particularly weird gap at the bottom of the screen. This gap was caused by the placements of `TiFBottomSheetModalProvider` within `TiFBottomSheet`. The main reason for the placements of `TiFBottomSheetModalProvider` was to ensure that a sheet marked with the `isTerminallyPresented` prop would not be dismissed when `dismissAll` was called by `useBottomSheetModal` (ie. It wouldn't be dismissed by the automatic modal dismissal mechanism in `useTiFNavigation`).

To preserve the automatic modal dismissal, we can leverage `useFocusEffect` inside `TiFBottomSheet` instead. When the focus effect cleanup handler is ran, we can dismiss the sheet.

## Tickets

https://trello.com/c/3oBkrCgD