### PR TITLE
Fix Explore Refetch on Navigate (iOS)

### DIFF
--- a/explore-events-boundary/ExploreEvents.tsx
+++ b/explore-events-boundary/ExploreEvents.tsx
@@ -133,9 +133,7 @@ const useUserRegion = (
   const permissionQuery = useRequestForegroundLocationPermissions(options)
   const locationQuery = useUserCoordinatesQuery(
     { accuracy: LocationAccuracy.Balanced },
-    {
-      enabled: permissionQuery.data !== undefined
-    }
+    { enabled: permissionQuery.data !== undefined }
   )
   if (permissionQuery.isFetching || locationQuery.isFetching) {
     return "pending"

--- a/location/UserLocation.tsx
+++ b/location/UserLocation.tsx
@@ -26,7 +26,7 @@ export const useUserCoordinatesQuery = (
 ) => {
   const { getCurrentLocation } = useUserLocationFunctions()
   return useQuery({
-    queryKey: ["user-coordinates", { preview: true }],
+    queryKey: ["user-coordinates", locationOptions],
     queryFn: async () => await getCurrentLocation(locationOptions),
     ...options
   })


### PR DESCRIPTION
On iOS, the explore screen was subtly refetching in the background whenever navigating to the event details. This would cause weird behavior on the explore screen, such as not maintaining the current scroll position when the user navigates back.

The problem was `useUserCoordinatesQuery`. In particular, the previous query key was as static `["user-coordinates", { preview: true }]` (I have no idea where the `{ preview: true }` came from...), which means that different instances of `useUserCoordinatesQuery` that used different location accuracies would trample on each other. This is exactly what happened in this case.

The explore screen uses an accuracy of `Balanced`, but the travel estimates on the details screen use an accuracy of `BestForNavigation`. Therefore, when navigating to the details, the user's location would be updated due to the accuracy change, and therefore the location update would trigger a refetch of the explore screen. This behavior was iOS exclusive, because travel estimates are not supported on Android.

The fix was to put the location options into the query key for `useUserCoordinatesQuery `.

TASK_UNTRACKED