### PR TITLE
Use Coordinate Instead of Placemark

### DIFF
--- a/.storybook/.ondevice/storybook.requires.ts
+++ b/.storybook/.ondevice/storybook.requires.ts
@@ -13,12 +13,12 @@ const normalizedStories = [
     directory: "./.storybook/components",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
+      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
     // @ts-ignore
     req: require.context(
       "../components",
       true,
-      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
+      /^\.(?:(?:^|[\\/]|(?:(?:(?!(?:^|[\\/])\.).)*?)[\\/])(?!\.)(?=.)[^\\/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
 ];

--- a/edit-event-boundary/FormAtoms.test.ts
+++ b/edit-event-boundary/FormAtoms.test.ts
@@ -1,11 +1,11 @@
+import { faker } from "@faker-js/faker"
+import { mockLocationCoordinate2D, mockPlacemark } from "@location/MockData"
 import { createStore } from "jotai"
 import {
   _DEFAULT_FORM_VALUES,
   editEventFormValueAtoms,
   eventEditAtom
 } from "./FormAtoms"
-import { mockLocationCoordinate2D, mockPlacemark } from "@location/MockData"
-import { faker } from "@faker-js/faker"
 
 describe("EventFormValues tests", () => {
   test("Default Values should not be submittable", () => {
@@ -45,19 +45,20 @@ describe("EventFormValues tests", () => {
     })
   })
 
-  it("should prefer the placemark to the coordinate when validating form values", () => {
+  it("should prefer the coordinate to the placemark when validating form values", () => {
     const store = createStore()
     const title = faker.lorem.words()
-    const placemark = mockPlacemark()
+    const coordinate = mockLocationCoordinate2D()
+
     store.set(editEventFormValueAtoms.title, title)
     store.set(editEventFormValueAtoms.location, {
-      coordinate: mockLocationCoordinate2D(),
-      placemark
+      coordinate,
+      placemark: mockPlacemark()
     })
     expect(store.get(eventEditAtom)).toEqual({
       ..._DEFAULT_FORM_VALUES,
       title,
-      location: { type: "placemark", value: placemark }
+      location: { type: "coordinate", value: coordinate }
     })
   })
 })

--- a/edit-event-boundary/FormAtoms.ts
+++ b/edit-event-boundary/FormAtoms.ts
@@ -50,8 +50,8 @@ export const eventEditAtom = atom<EventEdit | undefined>((get) => {
   const result = EventEditSchema.safeParse({
     ...formValues,
     location: {
-      type: formValues.location?.placemark ? "placemark" : "coordinate",
-      value: formValues.location?.placemark ?? formValues.location?.coordinate
+      type: formValues.location?.coordinate ? "coordinate" : "placemark",
+      value: formValues.location?.coordinate ?? formValues.location?.placemark
     }
   })
   return result.success ? result.data : undefined

--- a/edit-event-boundary/Submit.test.tsx
+++ b/edit-event-boundary/Submit.test.tsx
@@ -1,33 +1,36 @@
+import { EventMocks } from "@event-details-boundary/MockData"
+import { renderUseLoadEventDetails } from "@event-details-boundary/TestHelpers"
+import {
+  EditEventFormValues,
+  defaultEditFormValues
+} from "@event/EditFormValues"
+import {
+  LocationCoordinatesMocks,
+  mockLocationCoordinate2D
+} from "@location/MockData"
+import { SettingsProvider } from "@settings-storage/Hooks"
 import { PersistentSettingsStores } from "@settings-storage/PersistentStores"
 import { SQLiteUserSettingsStorage } from "@settings-storage/UserSettings"
-import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
-import { editEventFormValuesAtom } from "./FormAtoms"
-import {
-  TEST_EDIT_EVENT_FORM_STORE,
-  renderUseHydrateEditEvent
-} from "./TestHelpers"
-import { act, renderHook, waitFor } from "@testing-library/react-native"
-import { ALERTS, submitEventEdit, useEditEventFormSubmission } from "./Submit"
-import { SettingsProvider } from "@settings-storage/Hooks"
-import { Provider } from "jotai"
-import { LocationCoordinatesMocks, mockPlacemark } from "@location/MockData"
 import { captureAlerts } from "@test-helpers/Alerts"
+import { TestInternetConnectionStatus } from "@test-helpers/InternetConnectionStatus"
+import { neverPromise } from "@test-helpers/Promise"
 import {
   TestQueryClientProvider,
   createTestQueryClient
 } from "@test-helpers/ReactQuery"
-import { EventEdit, EventID } from "TiFShared/domain-models/Event"
-import { EventMocks } from "@event-details-boundary/MockData"
-import { renderUseLoadEventDetails } from "@event-details-boundary/TestHelpers"
-import { TestInternetConnectionStatus } from "@test-helpers/InternetConnectionStatus"
-import { neverPromise } from "@test-helpers/Promise"
-import { mockTiFEndpoint } from "TiFShared/test-helpers/mockAPIServer"
+import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
 import { fakeTimers } from "@test-helpers/Timers"
+import { act, renderHook, waitFor } from "@testing-library/react-native"
+import { Provider } from "jotai"
 import { TiFAPI } from "TiFShared/api"
+import { EventEdit, EventID } from "TiFShared/domain-models/Event"
+import { mockTiFEndpoint } from "TiFShared/test-helpers/mockAPIServer"
+import { editEventFormValuesAtom } from "./FormAtoms"
+import { ALERTS, submitEventEdit, useEditEventFormSubmission } from "./Submit"
 import {
-  defaultEditFormValues,
-  EditEventFormValues
-} from "@event/EditFormValues"
+  TEST_EDIT_EVENT_FORM_STORE,
+  renderUseHydrateEditEvent
+} from "./TestHelpers"
 
 describe("EditEventSubmit tests", () => {
   describe("SubmitEventEdit tests", () => {
@@ -120,7 +123,10 @@ describe("EditEventSubmit tests", () => {
     const TEST_VALUES = {
       ...defaultEditFormValues(),
       title: "Blob",
-      location: { placemark: mockPlacemark(), coordinate: undefined }
+      location: {
+        placemark: undefined,
+        coordinate: mockLocationCoordinate2D()
+      }
     }
 
     it("should not be able to submit the initial event", () => {
@@ -139,7 +145,7 @@ describe("EditEventSubmit tests", () => {
     it("should submit a changed valid event", async () => {
       submit.mockResolvedValueOnce({
         status: "success",
-        event: EventMocks.PickupBasketball
+        event: EventMocks.NoPlacemarkInfo
       })
       renderUseHydrateEditEvent(TEST_VALUES, settings)
       const { result } = renderUseEditEventSubmission(10)
@@ -149,11 +155,11 @@ describe("EditEventSubmit tests", () => {
       await waitFor(() => {
         expect(submit).toHaveBeenCalledWith(10, {
           ...newValues,
-          location: { type: "placemark", value: newValues.location.placemark }
+          location: { type: "coordinate", value: newValues.location.coordinate }
         })
       })
       await waitFor(() => {
-        expect(onSuccess).toHaveBeenCalledWith(EventMocks.PickupBasketball)
+        expect(onSuccess).toHaveBeenCalledWith(EventMocks.NoPlacemarkInfo)
       })
       expect(submit).toHaveBeenCalledTimes(1)
       expect(onSuccess).toHaveBeenCalledTimes(1)

--- a/edit-event-boundary/Submit.tsx
+++ b/edit-event-boundary/Submit.tsx
@@ -118,7 +118,6 @@ const submitFormAtom = (
   return atom((get) => {
     const isDirty = get(isEditEventFormDirtyAtom)
     const eventEdit = get(eventEditAtom)
-    console.log(eventEdit)
     if (!isDirty || !eventEdit) return undefined
     return async () => await submit(eventId, eventEdit)
   })

--- a/edit-event-boundary/Submit.tsx
+++ b/edit-event-boundary/Submit.tsx
@@ -118,6 +118,7 @@ const submitFormAtom = (
   return atom((get) => {
     const isDirty = get(isEditEventFormDirtyAtom)
     const eventEdit = get(eventEditAtom)
+    console.log(eventEdit)
     if (!isDirty || !eventEdit) return undefined
     return async () => await submit(eventId, eventEdit)
   })


### PR DESCRIPTION
- Change order of eventEditAtom, in order to prioritize the coordinate over the placemark

- Done in order to start the debugging process for the 10-miles-difference bug

## Tickets

https://trello.com/c/jSEPfdQ5
