### PR TITLE
Refactor TiF Bottom Sheet

### DIFF
--- a/components/BottomSheetMenu.tsx
+++ b/components/BottomSheetMenu.tsx
@@ -1,0 +1,49 @@
+import { useMutation } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+
+export type TiFBottomSheetMenuContent = {
+  title: string
+  description: string
+  ctaText: string
+  ctaAction: () => Promise<void>
+}
+
+export type TiFBottomSheetMenu = {
+  contents: TiFBottomSheetMenuContent[]
+  onFinished?: () => void
+}
+
+export const useBottomSheetMenu = () => {
+  const [index, setIndex] = useState(0)
+  const [menu, setMenu] = useState<TiFBottomSheetMenu | undefined>()
+  const ctaMutation = useMutation({
+    mutationFn: async (menu: TiFBottomSheetMenu) => {
+      if (index >= menu.contents.length) return
+      await menu.contents[index].ctaAction()
+    },
+    onSettled: () => setIndex((index) => index + 1)
+  })
+
+  useEffect(() => {
+    if (!menu) return
+    if (index >= menu.contents.length) {
+      menu.onFinished?.()
+    }
+  }, [index, menu])
+
+  return {
+    present: (menu: TiFBottomSheetMenu) => {
+      setMenu(menu)
+      setIndex(0)
+    },
+    content: menu
+      ? {
+          ...menu.contents[index],
+          ctaAction: async () => await ctaMutation.mutateAsync(menu)
+        }
+      : undefined,
+    dismissed: () => setIndex((index) => index + 1)
+  }
+}
+
+export type TiFBottomSheetMenuState = ReturnType<typeof useBottomSheetMenu>

--- a/event/JoinEvent.test.tsx
+++ b/event/JoinEvent.test.tsx
@@ -16,10 +16,13 @@ import { resetTestSQLiteBeforeEach, testSQLite } from "@test-helpers/SQLite"
 import { act, renderHook, waitFor } from "@testing-library/react-native"
 import { TiFAPI, TiFEndpointResponse } from "TiFShared/api"
 import { mockTiFServer } from "TiFShared/test-helpers/mockAPIServer"
+import { Provider } from "jotai"
 import {
   JOIN_EVENT_ERROR_ALERTS,
+  JOIN_EVENT_PERMISSION_BANNERS,
   JoinEventRequest,
   JoinEventResult,
+  UseJoinEvent,
   joinEvent,
   saveRecentLocationJoinEventHandler,
   useJoinEvent
@@ -52,16 +55,12 @@ describe("JoinEvent tests", () => {
 
     const NON_REQUESTABLE_PERMISSIONS = [
       {
-        kind: "notifications",
         canRequestPermission: false,
-        requestPermission: jest.fn().mockResolvedValueOnce(true),
-        bannerContents: TEST_BANNER_CONTENTS
+        bannerContents: JOIN_EVENT_PERMISSION_BANNERS.notifications
       },
       {
-        kind: "backgroundLocation",
         canRequestPermission: false,
-        requestPermission: jest.fn().mockResolvedValueOnce(true),
-        bannerContents: TEST_BANNER_CONTENTS
+        bannerContents: JOIN_EVENT_PERMISSION_BANNERS.backgroundLocation
       }
     ] as const
 
@@ -92,26 +91,24 @@ describe("JoinEvent tests", () => {
       await waitFor(() => expect(result.current.stage).toEqual("pending"))
       await act(async () => resolveJoin?.("success"))
       await waitFor(() => {
-        expect(result.current).toMatchObject({
-          stage: "permission",
-          permissionKind: "notifications"
-        })
+        expectPermissionBanner("notifications", result)
       })
       expect(env.joinEvent).toHaveBeenCalledWith({
         ...TEST_EVENT,
         hasArrived: true
       })
 
-      await act(async () => (result.current as any).requestButtonTapped())
+      await act(async () =>
+        (result.current as any).bannerContents.content.ctaAction()
+      )
       await waitFor(() => {
-        expect(result.current).toMatchObject({
-          stage: "permission",
-          permissionKind: "backgroundLocation"
-        })
+        expectPermissionBanner("backgroundLocation", result)
       })
 
       expect(env.onSuccess).not.toHaveBeenCalled()
-      await act(async () => (result.current as any).requestButtonTapped())
+      await act(async () =>
+        (result.current as any).bannerContents.content.ctaAction()
+      )
       await waitFor(() =>
         expect(result.current).toMatchObject({ stage: "idle" })
       )
@@ -130,10 +127,7 @@ describe("JoinEvent tests", () => {
 
       await act(async () => (result.current as any).joinButtonTapped())
       await waitFor(() => {
-        expect(result.current).toMatchObject({
-          stage: "permission",
-          permissionKind: "backgroundLocation"
-        })
+        expectPermissionBanner("backgroundLocation", result)
       })
     })
 
@@ -153,7 +147,7 @@ describe("JoinEvent tests", () => {
     })
 
     test("join event flow, can join multiple times", async () => {
-      env.loadPermissions.mockResolvedValueOnce(NON_REQUESTABLE_PERMISSIONS)
+      env.loadPermissions.mockResolvedValue(NON_REQUESTABLE_PERMISSIONS)
       env.joinEvent.mockResolvedValue("success")
       const { result } = renderUseJoinEvent()
 
@@ -178,24 +172,19 @@ describe("JoinEvent tests", () => {
 
       await act(async () => (result.current as any).joinButtonTapped())
       await waitFor(() => {
-        expect(result.current).toMatchObject({
-          stage: "permission",
-          permissionKind: "notifications"
-        })
+        expectPermissionBanner("notifications", result)
       })
 
-      await act(async () => (result.current as any).dismissButtonTapped())
-      expect(result.current).toMatchObject({
-        stage: "permission",
-        permissionKind: "backgroundLocation"
-      })
+      await act(async () => (result.current as any).bannerContents.dismissed())
 
-      await act(async () => (result.current as any).dismissButtonTapped())
+      expectPermissionBanner("backgroundLocation", result)
+
+      await act(async () => (result.current as any).bannerContents.dismissed())
       expect(result.current).toMatchObject({ stage: "idle" })
     })
 
     test("join event flow, error alerts", async () => {
-      env.loadPermissions.mockResolvedValueOnce([])
+      env.loadPermissions.mockResolvedValue([])
       const { result } = renderUseJoinEvent()
 
       env.joinEvent.mockResolvedValueOnce("event-has-ended")
@@ -269,12 +258,28 @@ describe("JoinEvent tests", () => {
       return renderSuccessfulUseLoadEventDetails(TEST_EVENT, queryClient)
     }
 
+    const expectPermissionBanner = (
+      banner: keyof typeof JOIN_EVENT_PERMISSION_BANNERS,
+      result: { current: UseJoinEvent }
+    ) => {
+      expect(result.current).toMatchObject({
+        stage: "permission",
+        bannerContents: {
+          content: {
+            title: JOIN_EVENT_PERMISSION_BANNERS[banner].title
+          }
+        }
+      })
+    }
+
     const renderUseJoinEvent = () => {
       return renderHook(() => useJoinEvent(TEST_EVENT, env), {
         wrapper: ({ children }: any) => (
-          <TestQueryClientProvider client={queryClient}>
-            {children}
-          </TestQueryClientProvider>
+          <Provider>
+            <TestQueryClientProvider client={queryClient}>
+              {children}
+            </TestQueryClientProvider>
+          </Provider>
         )
       })
     }

--- a/event/JoinEvent.tsx
+++ b/event/JoinEvent.tsx
@@ -3,17 +3,14 @@ import {
   EventRegionMonitor,
   useHasArrivedAtRegion
 } from "@arrival-tracking/region-monitoring"
-import { TiFBottomSheet } from "@components/BottomSheet"
 import { PrimaryButton } from "@components/Buttons"
-import { IoniconCloseButton } from "@components/common/Icons"
-import { BodyText, Title } from "@components/Text"
 import { ClientSideEvent } from "@event/ClientSideEvent"
 import { updateEventDetailsQueryEvent } from "@event/DetailsQuery"
 import {
   RecentLocationsStorage,
   recentLocationsStorage
 } from "@location/Recents"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   getBackgroundPermissionsAsync as getBackgroundLocationPermissions,
   requestBackgroundPermissionsAsync as requestBackgroundLocationPermissions
@@ -22,15 +19,18 @@ import {
   getPermissionsAsync as getNotificationPermissions,
   requestPermissionsAsync as requestNotificationPermissions
 } from "expo-notifications"
-import React, { useEffect, useState } from "react"
-import { StyleProp, StyleSheet, TextProps, View, ViewStyle } from "react-native"
+import React from "react"
+import { StyleProp, StyleSheet, TextProps, ViewStyle } from "react-native"
 
-import { useSafeAreaInsets } from "react-native-safe-area-context"
+import {
+  TiFBottomSheetMenuContent,
+  TiFBottomSheetMenuState,
+  useBottomSheetMenu
+} from "@components/BottomSheetMenu"
+import { AlertsObject, presentAlert } from "@lib/Alerts"
 import { TiFAPI } from "TiFShared/api"
 import { EventLocation } from "TiFShared/domain-models/Event"
 import { EventLocationIdentifier } from "./LocationIdentifier"
-import { AlertsObject, presentAlert } from "@lib/Alerts"
-import { BottomSheetView } from "@gorhom/bottom-sheet"
 
 export const JOIN_EVENT_ERROR_ALERTS = {
   "event-has-ended": {
@@ -55,49 +55,42 @@ export const JOIN_EVENT_ERROR_ALERTS = {
   }
 } satisfies AlertsObject
 
+export const JOIN_EVENT_PERMISSION_BANNERS = {
+  notifications: {
+    title: "Don’t miss out on the fun!",
+    description:
+      "Enable notifications to stay informed on all the exciting events happening around you.",
+    ctaText: "Turn on Notifications",
+    ctaAction: async () => {
+      await requestNotificationPermissions()
+    }
+  },
+  backgroundLocation: {
+    title: "Don’t get left behind!",
+    description:
+      "Enable Location Sharing to inform others of your location in the event.",
+    ctaText: "Turn on Location Sharing",
+    ctaAction: async () => {
+      await requestBackgroundLocationPermissions()
+    }
+  }
+} satisfies Record<string, TiFBottomSheetMenuContent>
+
 export const loadJoinEventPermissions = async () => [
   {
-    kind: "notifications",
     canRequestPermission: (await getNotificationPermissions()).canAskAgain,
-    requestPermission: async () => {
-      await requestNotificationPermissions()
-    },
-    bannerContents: {
-      title: "Don’t miss out on the fun!",
-      description:
-        "Enable notifications to stay informed on all the exciting events happening around you.",
-      ctaText: "Turn on Notifications"
-    }
+    bannerContents: JOIN_EVENT_PERMISSION_BANNERS.notifications
   } as const,
   {
-    kind: "backgroundLocation",
     canRequestPermission: (await getBackgroundLocationPermissions())
       .canAskAgain,
-    requestPermission: async () => {
-      await requestBackgroundLocationPermissions()
-    },
-    bannerContents: {
-      title: "Don’t get left behind!",
-      description:
-        "Enable Location Sharing to inform others of your location in the event.",
-      ctaText: "Turn on Location Sharing"
-    }
+    bannerContents: JOIN_EVENT_PERMISSION_BANNERS.backgroundLocation
   } as const
 ]
 
-export type JoinEventPermissionKind = "notifications" | "backgroundLocation"
-
-export type JoinEventPermissionBannerContents = {
-  title: string
-  description: string
-  ctaText: string
-}
-
 export type JoinEventPermission = {
-  kind: JoinEventPermissionKind
-  bannerContents: JoinEventPermissionBannerContents
+  bannerContents: TiFBottomSheetMenuContent
   canRequestPermission: boolean
-  requestPermission: () => Promise<void>
 }
 
 /**
@@ -193,10 +186,7 @@ export type UseJoinEventEnvironment = {
 }
 
 export type UseJoinEventPermission = {
-  permissionKind: JoinEventPermissionKind
-  bannerContents: JoinEventPermissionBannerContents
-  requestButtonTapped: () => void
-  dismissButtonTapped: () => void
+  bannerContents: TiFBottomSheetMenuState
 }
 
 export type UseJoinEvent =
@@ -226,14 +216,27 @@ export const useJoinEvent = (
   { loadPermissions, joinEvent, monitor, onSuccess }: UseJoinEventEnvironment
 ): UseJoinEvent => {
   const hasArrived = useHasArrivedAtRegion(event.location, monitor)
-  const currentPermission = useCurrentJoinEventPermission(loadPermissions)
   const queryClient = useQueryClient()
+  const menuState = useBottomSheetMenu()
   const joinEventMutation = useMutation({
-    mutationFn: async () => await joinEvent({ ...event, hasArrived }),
-    onSuccess: (status) => {
+    mutationFn: async () => {
+      const status = await joinEvent({ ...event, hasArrived })
+      const permissions = (await loadPermissions())
+        .filter((p) => p.canRequestPermission)
+        .map((p) => p.bannerContents)
+      return { status, permissions }
+    },
+    onSuccess: ({ status, permissions }) => {
       if (status !== "success") {
         presentAlert(JOIN_EVENT_ERROR_ALERTS[status])
       } else {
+        menuState.present({
+          contents: permissions,
+          onFinished: () => {
+            onSuccess()
+            joinEventMutation.reset()
+          }
+        })
         updateEventDetailsQueryEvent(queryClient, event.id, (e) => ({
           ...e,
           userAttendeeStatus: "attending"
@@ -243,53 +246,16 @@ export const useJoinEvent = (
     onError: () => presentAlert(JOIN_EVENT_ERROR_ALERTS.generic)
   })
   const hasJoined =
-    joinEventMutation.isSuccess && joinEventMutation.data === "success"
-  const isSuccess = hasJoined && currentPermission === "done"
-  const reset = joinEventMutation.reset
+    joinEventMutation.isSuccess && joinEventMutation.data.status === "success"
 
-  useEffect(() => {
-    if (!isSuccess) return
-    onSuccess()
-    reset()
-  }, [isSuccess, onSuccess, reset])
+  const isDone = hasJoined && !menuState.content
 
-  if (hasJoined && typeof currentPermission === "object") {
-    return { stage: "permission", ...currentPermission }
-  } else if (
-    joinEventMutation.isPending ||
-    (hasJoined && currentPermission === "pending")
-  ) {
+  if (hasJoined && menuState.content) {
+    return { stage: "permission", bannerContents: menuState }
+  } else if (joinEventMutation.isPending || (hasJoined && !isDone)) {
     return { stage: "pending" }
   } else {
     return { stage: "idle", joinButtonTapped: joinEventMutation.mutate }
-  }
-}
-
-const useCurrentJoinEventPermission = (
-  loadPermissions: () => Promise<JoinEventPermission[]>
-) => {
-  const [permissionIndex, setPermissionIndex] = useState(0)
-  const { data: availablePermissions } = useQuery({
-    queryKey: ["join-event-permissions"],
-    queryFn: loadPermissions,
-    select: (permissions) => permissions.filter((p) => p.canRequestPermission)
-  })
-  const permissionRequestMutation = useMutation({
-    mutationFn: async (availablePermissions: JoinEventPermission[]) => {
-      if (permissionIndex >= availablePermissions.length) return
-      await availablePermissions[permissionIndex].requestPermission()
-    },
-    onSuccess: () => setPermissionIndex((index) => index + 1)
-  })
-  if (!availablePermissions) return "pending"
-  if (permissionIndex >= availablePermissions.length) return "done"
-  return {
-    permissionKind: availablePermissions[permissionIndex].kind,
-    bannerContents: availablePermissions[permissionIndex].bannerContents,
-    requestButtonTapped: () => {
-      permissionRequestMutation.mutate(availablePermissions)
-    },
-    dismissButtonTapped: () => setPermissionIndex((index) => index + 1)
   }
 }
 
@@ -322,68 +288,6 @@ export const JoinEventButton = ({
     </Text>
   </PrimaryButton>
 )
-
-export type JoinEventPermissionsSheetProps = {
-  state: UseJoinEvent
-  style?: StyleProp<ViewStyle>
-}
-
-export const JoinEventPermissionsSheetView = ({
-  state,
-  style
-}: JoinEventPermissionsSheetProps) => (
-  <TiFBottomSheet
-    item={state.stage === "permission" ? state : undefined}
-    sizing="content-size"
-    handleStyle={styles.sheetHandle}
-    canSwipeToDismiss={false}
-    onDismiss={() => {
-      if (state.stage !== "permission") return
-      state.dismissButtonTapped()
-    }}
-    style={style}
-  >
-    {(state) => (
-      <BottomSheetView>
-        <JoinEventPermissionBanner {...state} />
-      </BottomSheetView>
-    )}
-  </TiFBottomSheet>
-)
-
-type JoinEventPermissionBannerProps = UseJoinEventPermission & {
-  style?: StyleProp<ViewStyle>
-}
-
-const JoinEventPermissionBanner = ({
-  bannerContents: { title, ctaText, description },
-  requestButtonTapped,
-  dismissButtonTapped,
-  style
-}: JoinEventPermissionBannerProps) => {
-  const { bottom } = useSafeAreaInsets()
-  const paddingForNonSafeAreaScreens = bottom === 0 ? 24 : 0
-  return (
-    <View
-      style={[
-        style,
-        styles.container,
-        { marginBottom: bottom + 24 + paddingForNonSafeAreaScreens }
-      ]}
-    >
-      <View style={styles.topRow}>
-        <View style={styles.topRowSpacer} />
-        <IoniconCloseButton onPress={dismissButtonTapped} />
-      </View>
-      <Title style={styles.titleText}>{title}</Title>
-      <BodyText style={styles.bodyText}>{description}</BodyText>
-      <View style={styles.placeholderIllustration} />
-      <PrimaryButton onPress={requestButtonTapped} style={styles.ctaButton}>
-        {ctaText}
-      </PrimaryButton>
-    </View>
-  )
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/event/UserAttendance.tsx
+++ b/event/UserAttendance.tsx
@@ -1,17 +1,16 @@
+import { TrueRegionMonitor } from "@arrival-tracking/region-monitoring/MockRegionMonitors"
+import { BoldFootnote, Headline } from "@components/Text"
+import { featureContext } from "@lib/FeatureContext"
+import { isAttendingEvent } from "TiFShared/domain-models/Event"
 import { StyleProp, ViewStyle } from "react-native"
+import { ClientSideEvent } from "./ClientSideEvent"
 import {
   JoinEventButton,
-  JoinEventPermissionsSheetView,
   joinEvent,
   loadJoinEventPermissions,
   useJoinEvent
 } from "./JoinEvent"
 import { LeaveEventButton, leaveEvent, useLeaveEvent } from "./LeaveEvent"
-import { isAttendingEvent } from "TiFShared/domain-models/Event"
-import { TrueRegionMonitor } from "@arrival-tracking/region-monitoring/MockRegionMonitors"
-import { ClientSideEvent } from "./ClientSideEvent"
-import { BoldFootnote, Headline } from "@components/Text"
-import { featureContext } from "@lib/FeatureContext"
 
 export const EventUserAttendanceFeature = featureContext({
   // TODO: - Default region monitor.
@@ -74,7 +73,6 @@ export const EventUserAttendanceButton = ({
           style={style}
         />
       )}
-      <JoinEventPermissionsSheetView state={joinState} />
     </>
   )
 }


### PR DESCRIPTION
Problem/Purpose
- In our current solution, we utilize a separate menu modal for each component. Our goal here is to create a generic menu modal that loads it's respective user permissions.   

Proposed Solution
- To achieve that goal, we created a brand new file "BottomSheetMenu.tsx" that handles the menu content per each unique bottom sheet. Utilized a permission banner const "JOIN_EVENT_PERMISSION_BANNERS" that stores the content and callbacks for each individual banner. 

Implementation Steps
- At first, our ticket felt scoped to decouple the Join Button from the user's current permissions. These permissions were expected to be stored in the global state as jotai atoms. Then once the requirements were clarified then we had an understanding on how to proceed with the ticket. 

Results
- Will followup with deliverables after the followup PR that adds back the UI portion.

Warnings
- The UI portion is not handled in this PR. That will be done in a followup ticket in the next Sprint. Once we migrate to Expo 53, then we will handle the next step in the refactor of this feature.

Other Changes
- We removed the UI for the current bottom sheet in event details. That will be handled in a future ticket.

Follow Ups
- Need to add back the UI for the bottom sheet in a followup PR.

## Tickets
https://trello.com/c/q8uCb4by